### PR TITLE
feat: command line interface for scaffolding projects

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -87,6 +87,7 @@
     "MD033": false,
     "MD013": false,
     "MD041": false,
-    "MD024": false
+    "MD024": false,
+    "MD030": false
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A Discord bot framework built on top of Discord.js",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@10.12.0",
+  "packageManager": "pnpm@10.15.0",
   "scripts": {
     "build": "turbo build",
     "dev": "turbo dev",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@changesets/cli": "^2.29.6",
+    "@clack/prompts": "^0.11.0",
     "@commitlint/cli": "^19.8.1",
     "@commitlint/config-conventional": "^19.8.1",
     "@swc/core": "^1.13.3",

--- a/packages/cli/LICENSE
+++ b/packages/cli/LICENSE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1.  Definitions.
+
+    "License" shall mean the terms and conditions for use, reproduction,
+    and distribution as defined by Sections 1 through 9 of this document.
+
+    "Licensor" shall mean the copyright owner or entity authorized by
+    the copyright owner that is granting the License.
+
+    "Legal Entity" shall mean the union of the acting entity and all
+    other entities that control, are controlled by, or are under common
+    control with that entity. For the purposes of this definition,
+    "control" means (i) the power, direct or indirect, to cause the
+    direction or management of such entity, whether by contract or
+    otherwise, or (ii) ownership of fifty percent (50%) or more of the
+    outstanding shares, or (iii) beneficial ownership of such entity.
+
+    "You" (or "Your") shall mean an individual or Legal Entity
+    exercising permissions granted by this License.
+
+    "Source" form shall mean the preferred form for making modifications,
+    including but not limited to software source code, documentation
+    source, and configuration files.
+
+    "Object" form shall mean any form resulting from mechanical
+    transformation or translation of a Source form, including but
+    not limited to compiled object code, generated documentation,
+    and conversions to other media types.
+
+    "Work" shall mean the work of authorship, whether in Source or
+    Object form, made available under the License, as indicated by a
+    copyright notice that is included in or attached to the work
+    (an example is provided in the Appendix below).
+
+    "Derivative Works" shall mean any work, whether in Source or Object
+    form, that is based on (or derived from) the Work and for which the
+    editorial revisions, annotations, elaborations, or other modifications
+    represent, as a whole, an original work of authorship. For the purposes
+    of this License, Derivative Works shall not include works that remain
+    separable from, or merely link (or bind by name) to the interfaces of,
+    the Work and Derivative Works thereof.
+
+    "Contribution" shall mean any work of authorship, including
+    the original version of the Work and any modifications or additions
+    to that Work or Derivative Works thereof, that is intentionally
+    submitted to Licensor for inclusion in the Work by the copyright owner
+    or by an individual or Legal Entity authorized to submit on behalf of
+    the copyright owner. For the purposes of this definition, "submitted"
+    means any form of electronic, verbal, or written communication sent
+    to the Licensor or its representatives, including but not limited to
+    communication on electronic mailing lists, source code control systems,
+    and issue tracking systems that are managed by, or on behalf of, the
+    Licensor for the purpose of discussing and improving the Work, but
+    excluding communication that is conspicuously marked or otherwise
+    designated in writing by the copyright owner as "Not a Contribution."
+
+    "Contributor" shall mean Licensor and any individual or Legal Entity
+    on behalf of whom a Contribution has been received by Licensor and
+    subsequently incorporated within the Work.
+
+2.  Grant of Copyright License. Subject to the terms and conditions of
+    this License, each Contributor hereby grants to You a perpetual,
+    worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+    copyright license to reproduce, prepare Derivative Works of,
+    publicly display, publicly perform, sublicense, and distribute the
+    Work and such Derivative Works in Source or Object form.
+
+3.  Grant of Patent License. Subject to the terms and conditions of
+    this License, each Contributor hereby grants to You a perpetual,
+    worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+    (except as stated in this section) patent license to make, have made,
+    use, offer to sell, sell, import, and otherwise transfer the Work,
+    where such license applies only to those patent claims licensable
+    by such Contributor that are necessarily infringed by their
+    Contribution(s) alone or by combination of their Contribution(s)
+    with the Work to which such Contribution(s) was submitted. If You
+    institute patent litigation against any entity (including a
+    cross-claim or counterclaim in a lawsuit) alleging that the Work
+    or a Contribution incorporated within the Work constitutes direct
+    or contributory patent infringement, then any patent licenses
+    granted to You under this License for that Work shall terminate
+    as of the date such litigation is filed.
+
+4.  Redistribution. You may reproduce and distribute copies of the
+    Work or Derivative Works thereof in any medium, with or without
+    modifications, and in Source or Object form, provided that You
+    meet the following conditions:
+
+    (a) You must give any other recipients of the Work or
+    Derivative Works a copy of this License; and
+
+    (b) You must cause any modified files to carry prominent notices
+    stating that You changed the files; and
+
+    (c) You must retain, in the Source form of any Derivative Works
+    that You distribute, all copyright, patent, trademark, and
+    attribution notices from the Source form of the Work,
+    excluding those notices that do not pertain to any part of
+    the Derivative Works; and
+
+    (d) If the Work includes a "NOTICE" text file as part of its
+    distribution, then any Derivative Works that You distribute must
+    include a readable copy of the attribution notices contained
+    within such NOTICE file, excluding those notices that do not
+    pertain to any part of the Derivative Works, in at least one
+    of the following places: within a NOTICE text file distributed
+    as part of the Derivative Works; within the Source form or
+    documentation, if provided along with the Derivative Works; or,
+    within a display generated by the Derivative Works, if and
+    wherever such third-party notices normally appear. The contents
+    of the NOTICE file are for informational purposes only and
+    do not modify the License. You may add Your own attribution
+    notices within Derivative Works that You distribute, alongside
+    or as an addendum to the NOTICE text from the Work, provided
+    that such additional attribution notices cannot be construed
+    as modifying the License.
+
+    You may add Your own copyright statement to Your modifications and
+    may provide additional or different license terms and conditions
+    for use, reproduction, or distribution of Your modifications, or
+    for any such Derivative Works as a whole, provided Your use,
+    reproduction, and distribution of the Work otherwise complies with
+    the conditions stated in this License.
+
+5.  Submission of Contributions. Unless You explicitly state otherwise,
+    any Contribution intentionally submitted for inclusion in the Work
+    by You to the Licensor shall be under the terms and conditions of
+    this License, without any additional terms or conditions.
+    Notwithstanding the above, nothing herein shall supersede or modify
+    the terms of any separate license agreement you may have executed
+    with Licensor regarding such Contributions.
+
+6.  Trademarks. This License does not grant permission to use the trade
+    names, trademarks, service marks, or product names of the Licensor,
+    except as required for reasonable and customary use in describing the
+    origin of the Work and reproducing the content of the NOTICE file.
+
+7.  Disclaimer of Warranty. Unless required by applicable law or
+    agreed to in writing, Licensor provides the Work (and each
+    Contributor provides its Contributions) on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+    implied, including, without limitation, any warranties or conditions
+    of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+    PARTICULAR PURPOSE. You are solely responsible for determining the
+    appropriateness of using or redistributing the Work and assume any
+    risks associated with Your exercise of permissions under this License.
+
+8.  Limitation of Liability. In no event and under no legal theory,
+    whether in tort (including negligence), contract, or otherwise,
+    unless required by applicable law (such as deliberate and grossly
+    negligent acts) or agreed to in writing, shall any Contributor be
+    liable to You for damages, including any direct, indirect, special,
+    incidental, or consequential damages of any character arising as a
+    result of this License or out of the use or inability to use the
+    Work (including but not limited to damages for loss of goodwill,
+    work stoppage, computer failure or malfunction, or any and all
+    other commercial damages or losses), even if such Contributor
+    has been advised of the possibility of such damages.
+
+9.  Accepting Warranty or Additional Liability. While redistributing
+    the Work or Derivative Works thereof, You may choose to offer,
+    and charge a fee for, acceptance of support, warranty, indemnity,
+    or other liability obligations and/or rights consistent with this
+    License. However, in accepting such obligations, You may act only
+    on Your own behalf and on Your sole responsibility, not on behalf
+    of any other Contributor, and only if You agree to indemnify,
+    defend, and hold each Contributor harmless for any liability
+    incurred by, or claims asserted against, such Contributor by reason
+    of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+Copyright 2025 Dhruv Jain (materwelonDhruv)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/cli/eslint.config.mjs
+++ b/packages/cli/eslint.config.mjs
@@ -1,0 +1,5 @@
+import createConfig from '@seedcord/eslint-config';
+
+export default createConfig({
+  tsconfigRootDir: import.meta.dirname
+});

--- a/packages/cli/eslint.config.mts
+++ b/packages/cli/eslint.config.mts
@@ -1,0 +1,7 @@
+// @ts-check
+
+import createConfig from '@seedcord/eslint-config';
+
+export default createConfig({
+  tsconfigRootDir: import.meta.dirname
+})

--- a/packages/cli/eslint.config.mts
+++ b/packages/cli/eslint.config.mts
@@ -1,7 +1,0 @@
-// @ts-check
-
-import createConfig from '@seedcord/eslint-config';
-
-export default createConfig({
-  tsconfigRootDir: import.meta.dirname
-})

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@seedcord/cli",
   "type": "module",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "private": true,
   "description": "CLI for seedcord",
   "repository": {
@@ -11,7 +11,7 @@
   },
   "files": [],
   "scripts": {
-    "dev": "tsx src/index.ts --conditions=development",
+    "dev": "tsx src/index.ts",
     "build": "tsup",
     "clean": "rm -rf dist",
     "lint": "eslint 'src/**/*.{ts,tsx}' --cache",
@@ -19,23 +19,22 @@
     "fmt": "prettier --write 'src/**/*.{ts,tsx,json,md}' --cache",
     "fmt:check": "prettier --check 'src/**/*.{ts,tsx,json,md}' --cache",
     "tc": "tsc --noEmit",
-    "test": "NODE_OPTIONS=--conditions=development vitest run",
-    "test:watch": "NODE_OPTIONS=--conditions=development vitest dev",
-    "coverage": "NODE_OPTIONS=--conditions=development vitest run --coverage"
+    "test": "vitest run",
+    "test:watch": "vitest dev",
+    "coverage": "vitest run --coverage"
   },
   "peerDependencies": {
-    "typescript": "^5.9.2"
+    "typescript": "catalog:peer"
   },
   "dependencies": {
     "@clack/prompts": "^0.11.0",
-    "chalk": "^5.5.0",
+    "chalk": "catalog:deps",
     "lodash.merge": "^4.6.2"
   },
   "devDependencies": {
     "@seedcord/eslint-config": "workspace:^",
     "@seedcord/tsconfig": "workspace:^",
     "@seedcord/tsup-config": "workspace:^",
-    "@types/lodash.merge": "^4.6.9",
-    "tsx": "^4.20.4"
+    "@types/lodash.merge": "^4.6.9"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@seedcord/cli",
+  "type": "module",
+  "version": "0.1.0",
+  "private": true,
+  "description": "CLI fro seedcord",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/materwelondhruv/seedcord.git",
+    "directory": "packages/cli"
+  },
+  "exports": {
+    ".": {
+      "development": "./src/index.ts",
+      "default": "./dist/index.mjs"
+    }
+  },
+  "files": [],
+  "scripts": {
+    "dev": "tsx src/index.ts --conditions=development",
+    "start:watch": "tsx src/start-watch.ts",
+    "build": "tsup",
+    "clean": "rm -rf dist",
+    "lint": "#eslint --config eslint.config.mts 'src/**/*.{ts,tsx}' --cache",
+    "lint:fix": "eslint --config eslint.config.mts 'src/**/*.{ts,tsx}' --fix --cache",
+    "fmt": "prettier --write 'src/**/*.{ts,tsx,json,md}' --cache",
+    "fmt:check": "prettier --check 'src/**/*.{ts,tsx,json,md}' --cache",
+    "tc": "tsc --noEmit",
+    "test": "NODE_OPTIONS=--conditions=development vitest run",
+    "test:watch": "NODE_OPTIONS=--conditions=development vitest dev",
+    "coverage": "NODE_OPTIONS=--conditions=development vitest run --coverage"
+  },
+  "dependencies": {
+    "@clack/prompts": "^0.11.0",
+    "@eslint/js": "^9.33.0",
+    "chalk": "^5.5.0",
+    "eslint": "^9.33.0",
+    "lodash.merge": "^4.6.2",
+    "typescript-eslint": "^8.39.1"
+  },
+  "devDependencies": {
+    "@seedcord/eslint-config": "workspace:^",
+    "@seedcord/tsconfig": "workspace:^",
+    "@seedcord/tsup-config": "workspace:^",
+    "@types/lodash.merge": "^4.6.9",
+    "tsx": "^4.20.4"
+  }
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,7 +28,9 @@
   },
   "dependencies": {
     "@clack/prompts": "^0.11.0",
+    "@commander-js/extra-typings": "^14.0.0",
     "chalk": "catalog:deps",
+    "commander": "^14.0.0",
     "lodash.merge": "^4.6.2"
   },
   "devDependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,32 +3,28 @@
   "type": "module",
   "version": "0.1.0",
   "private": true,
-  "description": "CLI fro seedcord",
+  "description": "CLI for seedcord",
   "repository": {
     "type": "git",
     "url": "https://github.com/materwelondhruv/seedcord.git",
     "directory": "packages/cli"
   },
-  "exports": {
-    ".": {
-      "development": "./src/index.ts",
-      "default": "./dist/index.mjs"
-    }
-  },
   "files": [],
   "scripts": {
     "dev": "tsx src/index.ts --conditions=development",
-    "start:watch": "tsx src/start-watch.ts",
     "build": "tsup",
     "clean": "rm -rf dist",
-    "lint": "#eslint --config eslint.config.mts 'src/**/*.{ts,tsx}' --cache",
-    "lint:fix": "eslint --config eslint.config.mts 'src/**/*.{ts,tsx}' --fix --cache",
+    "lint": "eslint 'src/**/*.{ts,tsx}' --cache",
+    "lint:fix": "eslint 'src/**/*.{ts,tsx}' --fix --cache",
     "fmt": "prettier --write 'src/**/*.{ts,tsx,json,md}' --cache",
     "fmt:check": "prettier --check 'src/**/*.{ts,tsx,json,md}' --cache",
     "tc": "tsc --noEmit",
     "test": "NODE_OPTIONS=--conditions=development vitest run",
     "test:watch": "NODE_OPTIONS=--conditions=development vitest dev",
     "coverage": "NODE_OPTIONS=--conditions=development vitest run --coverage"
+  },
+  "peerDependencies": {
+    "typescript": "^5.9.2"
   },
   "dependencies": {
     "@clack/prompts": "^0.11.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,11 +28,8 @@
   },
   "dependencies": {
     "@clack/prompts": "^0.11.0",
-    "@eslint/js": "^9.33.0",
     "chalk": "^5.5.0",
-    "eslint": "^9.33.0",
-    "lodash.merge": "^4.6.2",
-    "typescript-eslint": "^8.39.1"
+    "lodash.merge": "^4.6.2"
   },
   "devDependencies": {
     "@seedcord/eslint-config": "workspace:^",

--- a/packages/cli/src/create.ts
+++ b/packages/cli/src/create.ts
@@ -1,0 +1,37 @@
+import { resolve } from 'path';
+
+import { createFile } from './utils';
+
+// TODO: move components to their files
+const components: Record<string, string> = {
+  mock: `@RegisterCommand('global')
+export class TemplateCommand extends BuilderComponent<'command'> {
+  constructor() {
+    super('command');
+
+    this.instance
+      .setName('template')
+      .setDescription('Template command')
+  }
+}\n`
+};
+
+export const availableComponents: string[] = [];
+const minNameLength = 3;
+
+for (const component in components) {
+  if (Object.hasOwn(components, component)) availableComponents.push(component);
+}
+
+export async function createComponent(path: string, name: string, template: string): Promise<void> {
+  if (!components[template])
+    throw new Error(`unable to find template: available templates are ${availableComponents.join(', ')}`);
+  if (name.length < minNameLength) throw new Error(`component name is lower than ${minNameLength} characters`);
+  const commandName = name.toLowerCase();
+  // TODO: do not hardcode casing replacement, maybe create a command for that
+  const commandTemplate = components[template]
+    .replaceAll('template', commandName)
+    // maybe there is a function for pascal case
+    .replaceAll('Template', commandName[0]?.toUpperCase() + commandName.slice(1));
+  await createFile(resolve(path, `${name}.ts`), commandTemplate);
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -152,8 +152,7 @@ async function spawnProcess(command: string, args: string[], options: SpawnSyncO
     commandProcess.on('error', (err) => reject(err));
     commandProcess.on('close', (code) => {
       if (code === 0) resolve();
-      // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
-      else reject(commandProcess.stdout);
+      else reject(new Error(`${command} exited with ${code} code, output: ${commandProcess.stdout?.read()}`));
     });
   });
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -152,6 +152,7 @@ async function spawnProcess(command: string, args: string[], options: SpawnSyncO
     commandProcess.on('error', (err) => reject(err));
     commandProcess.on('close', (code) => {
       if (code === 0) resolve();
+      // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
       else reject(commandProcess.stdout);
     });
   });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,6 @@
 import { spawn } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
-import { copyFile, mkdir, readdir, rename, stat, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { copyFile, mkdir, readdir, readFile, rename, stat, writeFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { setTimeout } from 'node:timers/promises';
 import { fileURLToPath } from 'node:url';
@@ -115,7 +115,7 @@ function fetchPackageManager(): string | undefined {
 async function extractTools(root: string, tools: string[], spinner: Spinner): Promise<void> {
   spinner.start(`Adding additional tools`);
   const packagePath = resolve(root, './package.json');
-  let packageJson = JSON.parse(readFileSync(packagePath, 'utf-8')) as Record<string, unknown>;
+  let packageJson = JSON.parse(await readFile(packagePath, 'utf-8')) as Record<string, unknown>;
   for (const tool of tools) {
     packageJson = installTool(tool, packageJson);
   }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,3 @@
-import * as p from '@clack/prompts';
-import { Chalk } from 'chalk';
 import { spawnSync } from 'node:child_process';
 import {
   copyFileSync,
@@ -13,13 +11,66 @@ import {
 } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+
+import * as p from '@clack/prompts';
+import { Chalk } from 'chalk';
 import merge from 'lodash.merge';
 
+interface Spinner {
+  start: (msg?: string) => void;
+  stop: (msg?: string, code?: number) => void;
+  message: (msg?: string) => void;
+}
+
 const colors = new Chalk();
+const packageManager = fetchPackageManager() ?? 'npm';
 
-async function init() {
-  const packageManager = fetchPackageManager() || 'npm';
+const prompts: p.PromptGroup<{
+  path: string | symbol;
+  tools: string[] | symbol;
+  install: boolean | symbol;
+}> = {
+  path: () =>
+    p.text({
+      message: 'Where should we create your project?',
+      placeholder: 'seedcord-project',
+      validate: (value) => {
+        if (!value) return 'Please enter a path.';
+        // TODO: add prompt for overwriting directory
+        if (existsSync(value)) return 'folder already exists';
+        return undefined;
+      }
+    }),
+  tools: () =>
+    p.multiselect({
+      message: 'Select additional tools.',
+      initialValues: ['prettier'],
+      required: false,
+      options: [
+        // TODO: add more tools
+        { value: 'prettier', label: 'Prettier', hint: 'recommended' }
+      ]
+    }),
+  install: () =>
+    p.confirm({
+      message: `Install dependencies with ${packageManager}?`,
+      initialValue: false
+    })
+};
 
+const additionalTools: Record<string, Record<string, unknown>> = {
+  prettier: {
+    scripts: {
+      fmt: "prettier --write 'src/**/*.{ts,tsx,json,md}' --cache",
+      'fmt:check': "prettier --check 'src/**/*.{ts,tsx,json,md}' --cache"
+    },
+    devDependencies: {
+      prettier: '^3.6.2'
+    }
+  }
+};
+
+async function init(): Promise<void> {
   p.updateSettings({
     aliases: {
       w: 'up',
@@ -31,86 +82,21 @@ async function init() {
 
   p.intro(`${colors.bgCyan(colors.black(' seedcord wizard '))}`);
 
-  const additionalTools: Record<string, Record<string, unknown>> = {
-    prettier: {
-      scripts: {
-        fmt: "prettier --write 'src/**/*.{ts,tsx,json,md}' --cache",
-        'fmt:check': "prettier --check 'src/**/*.{ts,tsx,json,md}' --cache"
-      },
-      devDependencies: {
-        prettier: '^3.6.2'
-      }
+  const project = await p.group(prompts, {
+    onCancel: () => {
+      p.cancel('Operation cancelled.');
+      process.exit(0);
     }
-  };
-
-  const project = await p.group(
-    {
-      path: () =>
-        p.text({
-          message: 'Where should we create your project?',
-          placeholder: 'seedcord-project',
-          validate: (value) => {
-            if (!value) return 'Please enter a path.';
-            // TODO: add prompt for overwriting directory
-            if (existsSync(value)) return 'folder already exists';
-            return undefined;
-          }
-        }),
-      tools: () =>
-        p.multiselect({
-          message: 'Select additional tools.',
-          initialValues: ['prettier'],
-          required: false,
-          options: [
-            // TODO: add more tools
-            { value: 'prettier', label: 'Prettier', hint: 'recommended' }
-          ]
-        }),
-      install: () =>
-        p.confirm({
-          message: `Install dependencies with ${packageManager}?`,
-          initialValue: false
-        })
-    },
-    {
-      onCancel: () => {
-        p.cancel('Operation cancelled.');
-        process.exit(0);
-      }
-    }
-  );
+  });
   const root = join(process.cwd(), formatDir(project.path));
   const templateDir = resolve(fileURLToPath(import.meta.url), '../../template');
 
-  mkdirSync(root, { recursive: true });
-  copyDir(templateDir, root);
-  renameSync(`${root}/_gitignore`, `${root}/.gitignore`);
+  extractBaseTemplate(templateDir, root);
 
-  const tools = project.tools as (keyof typeof additionalTools)[];
-  if (project.tools) {
-    // TODO: actually make spinner work, it requires things to be async
-    const s = p.spinner();
-    s.start(`Adding additional tools`);
-    const packagePath = resolve(root, './package.json');
-    let packageJson = JSON.parse(readFileSync(packagePath, 'utf-8')) as Record<string, unknown>;
-    for (const tool of tools) {
-      const toolObject = additionalTools[tool];
-      if (!toolObject) throw new Error('unable to find tool ' + tool);
-      console.log(toolObject);
-      packageJson = merge<Record<string, unknown>, Record<string, unknown>>(packageJson, toolObject);
-    }
-    writeFileSync(packagePath, `${JSON.stringify(packageJson, null, 2)}\n`, 'utf-8');
-    s.stop();
-  }
+  const tools = project.tools;
 
-  if (project.install) {
-    const s = p.spinner();
-    s.start(`Installing via ${packageManager}`);
-    const packageProcess = spawnSync(`${packageManager}`, ['install'], {
-      cwd: root
-    });
-    s.stop(`Installed via ${packageManager} ${packageProcess.output}`);
-  }
+  if (tools.length > 0) extractTools(root, tools, p.spinner());
+  if (project.install) installPackages(root, packageManager, p.spinner());
 
   const nextSteps =
     `cd ${project.path}\n` +
@@ -122,7 +108,7 @@ async function init() {
   p.outro(`Problems? ${colors.underline(colors.cyan('https://github.com/materwelondhruv/seedcord/issues'))}`);
 }
 
-function formatDir(path: string) {
+function formatDir(path: string): string {
   return path.trim().replace(/\/+$/g, '');
 }
 
@@ -131,14 +117,42 @@ function fetchPackageManager(): string | undefined {
   return agent?.split(' ')[0]?.split('/')[0];
 }
 
-function copyDir(src: string, to: string) {
+function extractTools(root: string, tools: string[], spinner: Spinner): void {
+  // TODO: actually make spinner work, it requires things to be async
+  spinner.start(`Adding additional tools`);
+  const packagePath = resolve(root, './package.json');
+  let packageJson = JSON.parse(readFileSync(packagePath, 'utf-8')) as Record<string, unknown>;
+  for (const tool of tools) {
+    const toolObject = additionalTools[tool];
+    if (!toolObject) throw new Error(`unable to find tool ${tool}`);
+    packageJson = merge<Record<string, unknown>, Record<string, unknown>>(packageJson, toolObject);
+  }
+  writeFileSync(packagePath, `${JSON.stringify(packageJson, null, 2)}\n`, 'utf-8');
+  spinner.stop();
+}
+
+function extractBaseTemplate(base: string, to: string): void {
+  mkdirSync(to, { recursive: true });
+  copyDir(base, to);
+  renameSync(`${to}/_gitignore`, `${to}/.gitignore`);
+}
+
+function installPackages(root: string, packageManager: string, spinner: Spinner): void {
+  spinner.start(`Installing via ${packageManager}`);
+  spawnSync(`${packageManager}`, ['install'], {
+    cwd: root
+  });
+  spinner.stop(`Installed via ${packageManager}`);
+}
+
+function copyDir(src: string, to: string): void {
   mkdirSync(to, { recursive: true });
   for (const file of readdirSync(src)) {
     copy(resolve(src, file), resolve(to, file));
   }
 }
 
-function copy(src: string, to: string) {
+function copy(src: string, to: string): void {
   const isDir = statSync(src).isDirectory();
   if (isDir) {
     copyDir(src, to);
@@ -147,4 +161,4 @@ function copy(src: string, to: string) {
   }
 }
 
-init().catch(console.error);
+void init();

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,7 +1,8 @@
+import * as p from '@clack/prompts';
 import { program } from '@commander-js/extra-typings';
 
 import { availableComponents, createComponent } from './create';
-import { scaffoldProject } from './scaffold';
+import { scaffoldQuestions, scaffoldProject } from './scaffold';
 import { colors } from './utils';
 
 program
@@ -13,9 +14,21 @@ program
 program
   .command('scaffold')
   .description('scaffold a seedcord project')
-  // TODO: add cli options
-  .action(async () => {
-    await scaffoldProject();
+  .option('-t --tools [TOOLS]', "tools to install, separated by comma, example: 'scaffold -t prettier'", "prettier")
+  .option('-i --install [BOOLEAN]', 'install deps automatically', undefined)
+  .option('-p --path [PATH]', 'path to install', '')
+  .addHelpText('after', 'when not specifying options, interactive questions will be asked')
+  .action(async (args) => {
+    if (args.path) {
+      await scaffoldProject(
+        {
+          path: args.path.toString(),
+          projectTools: args.tools.toString().split(','),
+          installDeps: Boolean(args.install)
+        },
+        p
+      );
+    } else await scaffoldQuestions();
   });
 
 program

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,5 @@
 import * as p from '@clack/prompts';
-import { program } from '@commander-js/extra-typings';
+import { program } from 'commander';
 
 import { availableComponents, createComponent } from './create';
 import { scaffoldQuestions, scaffoldProject } from './scaffold';
@@ -14,7 +14,7 @@ program
 program
   .command('scaffold')
   .description('scaffold a seedcord project')
-  .option('-t --tools [TOOLS]', "tools to install, separated by comma, example: 'scaffold -t prettier'", "prettier")
+  .option('-t --tools [TOOLS]', "tools to install, separated by comma, example: 'scaffold -t prettier'", 'prettier')
   .option('-i --install [BOOLEAN]', 'install deps automatically', undefined)
   .option('-p --path [PATH]', 'path to install', '')
   .addHelpText('after', 'when not specifying options, interactive questions will be asked')

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,150 @@
+import * as p from '@clack/prompts';
+import { Chalk } from 'chalk';
+import { spawnSync } from 'node:child_process';
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  writeFileSync
+} from 'node:fs';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import merge from 'lodash.merge';
+
+const colors = new Chalk();
+
+async function init() {
+  const packageManager = fetchPackageManager() || 'npm';
+
+  p.updateSettings({
+    aliases: {
+      w: 'up',
+      s: 'down',
+      a: 'left',
+      d: 'right'
+    }
+  });
+
+  p.intro(`${colors.bgCyan(colors.black(' seedcord wizard '))}`);
+
+  const additionalTools: Record<string, Record<string, unknown>> = {
+    prettier: {
+      scripts: {
+        fmt: "prettier --write 'src/**/*.{ts,tsx,json,md}' --cache",
+        'fmt:check': "prettier --check 'src/**/*.{ts,tsx,json,md}' --cache"
+      },
+      devDependencies: {
+        prettier: '^3.6.2'
+      }
+    }
+  };
+
+  const project = await p.group(
+    {
+      path: () =>
+        p.text({
+          message: 'Where should we create your project?',
+          placeholder: 'seedcord-project',
+          validate: (value) => {
+            if (!value) return 'Please enter a path.';
+            // TODO: add prompt for overwriting directory
+            if (existsSync(value)) return 'folder already exists';
+            return undefined;
+          }
+        }),
+      tools: () =>
+        p.multiselect({
+          message: 'Select additional tools.',
+          initialValues: ['prettier'],
+          required: false,
+          options: [
+            // TODO: add more tools
+            { value: 'prettier', label: 'Prettier', hint: 'recommended' }
+          ]
+        }),
+      install: () =>
+        p.confirm({
+          message: `Install dependencies with ${packageManager}?`,
+          initialValue: false
+        })
+    },
+    {
+      onCancel: () => {
+        p.cancel('Operation cancelled.');
+        process.exit(0);
+      }
+    }
+  );
+  const root = join(process.cwd(), formatDir(project.path));
+  const templateDir = resolve(fileURLToPath(import.meta.url), '../../template');
+
+  mkdirSync(root, { recursive: true });
+  copyDir(templateDir, root);
+  renameSync(`${root}/_gitignore`, `${root}/.gitignore`);
+
+  const tools = project.tools as (keyof typeof additionalTools)[];
+  if (project.tools) {
+    // TODO: actually make spinner work, it requires things to be async
+    const s = p.spinner();
+    s.start(`Adding additional tools`);
+    const packagePath = resolve(root, './package.json');
+    let packageJson = JSON.parse(readFileSync(packagePath, 'utf-8')) as Record<string, unknown>;
+    for (const tool of tools) {
+      const toolObject = additionalTools[tool];
+      if (!toolObject) throw new Error('unable to find tool ' + tool);
+      console.log(toolObject);
+      packageJson = merge<Record<string, unknown>, Record<string, unknown>>(packageJson, toolObject);
+    }
+    writeFileSync(packagePath, `${JSON.stringify(packageJson, null, 2)}\n`, 'utf-8');
+    s.stop();
+  }
+
+  if (project.install) {
+    const s = p.spinner();
+    s.start(`Installing via ${packageManager}`);
+    const packageProcess = spawnSync(`${packageManager}`, ['install'], {
+      cwd: root
+    });
+    s.stop(`Installed via ${packageManager} ${packageProcess.output}`);
+  }
+
+  const nextSteps =
+    `cd ${project.path}\n` +
+    `${project.install ? '' : `${packageManager} install\n`}` +
+    `fill .env.example and rename it to .env\n` +
+    `${packageManager} dev`;
+
+  p.note(nextSteps, 'Next steps.');
+  p.outro(`Problems? ${colors.underline(colors.cyan('https://github.com/materwelondhruv/seedcord/issues'))}`);
+}
+
+function formatDir(path: string) {
+  return path.trim().replace(/\/+$/g, '');
+}
+
+function fetchPackageManager(): string | undefined {
+  const agent = process.env.npm_config_user_agent;
+  return agent?.split(' ')[0]?.split('/')[0];
+}
+
+function copyDir(src: string, to: string) {
+  mkdirSync(to, { recursive: true });
+  for (const file of readdirSync(src)) {
+    copy(resolve(src, file), resolve(to, file));
+  }
+}
+
+function copy(src: string, to: string) {
+  const isDir = statSync(src).isDirectory();
+  if (isDir) {
+    copyDir(src, to);
+  } else {
+    copyFileSync(src, to);
+  }
+}
+
+init().catch(console.error);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,176 +1,34 @@
-import { spawn } from 'node:child_process';
-import { existsSync } from 'node:fs';
-import { copyFile, mkdir, readdir, readFile, rename, stat, writeFile } from 'node:fs/promises';
-import { join, resolve } from 'node:path';
-import { setTimeout } from 'node:timers/promises';
-import { fileURLToPath } from 'node:url';
+import { program } from '@commander-js/extra-typings';
 
-import * as p from '@clack/prompts';
-import { Chalk } from 'chalk';
-import merge from 'lodash.merge';
+import { availableComponents, createComponent } from './create';
+import { scaffoldProject } from './scaffold';
+import { colors } from './utils';
 
-import type { SpawnSyncOptions } from 'node:child_process';
+program
+  .name('@seedcord/cli')
+  .description('cli for scaffolding seedcord projects and adding components (coming soon)')
+  // TODO: maybe get version from package.json or remove it fully
+  .version('0.0.0');
 
-interface Spinner {
-  start: (msg?: string) => void;
-  stop: (msg?: string, code?: number) => void;
-  message: (msg?: string) => void;
-}
-
-const colors = new Chalk();
-const packageManager = fetchPackageManager() ?? 'npm';
-
-const prompts: p.PromptGroup<{
-  path: string | symbol;
-  tools: string[] | symbol;
-  install: boolean | symbol;
-}> = {
-  path: () =>
-    p.text({
-      message: 'Where should we create your project?',
-      placeholder: 'seedcord-project',
-      validate: (value) => {
-        if (!value) return 'Please enter a path.';
-        // TODO: add prompt for overwriting directory
-        if (existsSync(value)) return 'folder already exists';
-        return undefined;
-      }
-    }),
-  tools: () =>
-    p.multiselect({
-      message: 'Select additional tools.',
-      initialValues: ['prettier'],
-      required: false,
-      options: [
-        // TODO: add more tools
-        { value: 'prettier', label: 'Prettier', hint: 'recommended' }
-      ]
-    }),
-  install: () =>
-    p.confirm({
-      message: `Install dependencies with ${packageManager}?`,
-      initialValue: false
-    })
-};
-
-const additionalTools: Record<string, Record<string, unknown>> = {
-  prettier: {
-    scripts: {
-      fmt: "prettier --write 'src/**/*.{ts,tsx,json,md}' --cache",
-      'fmt:check': "prettier --check 'src/**/*.{ts,tsx,json,md}' --cache"
-    },
-    devDependencies: {
-      prettier: '^3.6.2'
-    }
-  }
-};
-
-async function init(): Promise<void> {
-  p.updateSettings({
-    aliases: {
-      w: 'up',
-      s: 'down',
-      a: 'left',
-      d: 'right'
-    }
+program
+  .command('scaffold')
+  .description('scaffold a seedcord project')
+  // TODO: add cli options
+  .action(async () => {
+    await scaffoldProject();
   });
 
-  p.intro(`${colors.bgCyan(colors.black(' seedcord wizard '))}`);
-
-  const project = await p.group(prompts, {
-    onCancel: () => {
-      p.cancel('Operation cancelled.');
-      process.exit(0);
-    }
+program
+  .command('create')
+  .description('create a template component')
+  .argument('<path>', 'path for copying template component to')
+  .addHelpText('after', `\nAvailable templates: ${colors.cyan(availableComponents.join(', '))}`)
+  // TODO: create both handler and component
+  .argument('[name]', 'name of created component', 'newCommand')
+  .option('-t --template <TYPE>', 'select template', 'mock')
+  .action(async (path, name, args) => {
+    const template = args.template;
+    await createComponent(path, name, template);
   });
-  const root = join(process.cwd(), formatDir(project.path));
-  const templateDir = resolve(fileURLToPath(import.meta.url), '../../template');
 
-  await extractBaseTemplate(templateDir, root, p.spinner());
-
-  const tools = project.tools;
-
-  if (tools.length > 0) await extractTools(root, tools, p.spinner());
-  if (project.install) await installPackages(root, packageManager, p.spinner());
-
-  const nextSteps =
-    `cd ${project.path}\n` +
-    `${project.install ? '' : `${packageManager} install\n`}` +
-    `fill .env.example and rename it to .env\n` +
-    `${packageManager} dev`;
-
-  p.note(nextSteps, 'Next steps.');
-  p.outro(`Problems? ${colors.underline(colors.cyan('https://github.com/materwelondhruv/seedcord/issues'))}`);
-}
-
-function formatDir(path: string): string {
-  return path.trim().replace(/\/+$/g, '');
-}
-
-function fetchPackageManager(): string | undefined {
-  const agent = process.env.npm_config_user_agent;
-  return agent?.split(' ')[0]?.split('/')[0];
-}
-
-async function extractTools(root: string, tools: string[], spinner: Spinner): Promise<void> {
-  spinner.start(`Adding additional tools`);
-  const packagePath = resolve(root, './package.json');
-  let packageJson = JSON.parse(await readFile(packagePath, 'utf-8')) as Record<string, unknown>;
-  for (const tool of tools) {
-    packageJson = installTool(tool, packageJson);
-  }
-  await writeFile(packagePath, `${JSON.stringify(packageJson, null, 2)}\n`, 'utf-8');
-  spinner.stop('Added tools');
-}
-
-async function extractBaseTemplate(base: string, to: string, spinner: Spinner): Promise<void> {
-  spinner.start('extracting base files');
-  await mkdir(to, { recursive: true });
-  await copyDir(base, to);
-  await rename(`${to}/_gitignore`, `${to}/.gitignore`);
-  spinner.stop('extracted base files');
-}
-
-async function installPackages(root: string, packageManager: string, spinner: Spinner): Promise<void> {
-  spinner.start(`Installing via ${packageManager}`);
-  await setTimeout(1000);
-  await spawnProcess(`${packageManager}`, ['install'], {
-    cwd: root
-  });
-  spinner.stop(`Installed via ${packageManager}`);
-}
-
-function installTool(tool: string, packageJson: Record<string, unknown>): Record<string, unknown> {
-  const toolObject = additionalTools[tool];
-  if (!toolObject) throw new Error(`unable to find tool ${tool}`);
-  return merge<Record<string, unknown>, Record<string, unknown>>(packageJson, toolObject);
-}
-
-async function spawnProcess(command: string, args: string[], options: SpawnSyncOptions): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const commandProcess = spawn(command, args, options);
-    commandProcess.on('error', (err) => reject(err));
-    commandProcess.on('close', (code) => {
-      if (code === 0) resolve();
-      else reject(new Error(`${command} exited with ${code} code, output: ${commandProcess.stdout?.read()}`));
-    });
-  });
-}
-
-async function copyDir(src: string, to: string): Promise<void> {
-  await mkdir(to, { recursive: true });
-  for (const file of await readdir(src)) {
-    await copy(resolve(src, file), resolve(to, file));
-  }
-}
-
-async function copy(src: string, to: string): Promise<void> {
-  const isDir = (await stat(src)).isDirectory();
-  if (isDir) {
-    await copyDir(src, to);
-  } else {
-    await copyFile(src, to);
-  }
-}
-
-void init();
+program.parse();

--- a/packages/cli/src/scaffold.ts
+++ b/packages/cli/src/scaffold.ts
@@ -94,7 +94,6 @@ export async function scaffoldProject(
   project: { path: string; projectTools: string[]; installDeps: boolean },
   clack: typeof p
 ): Promise<void> {
-  console.log(project.path + " " + project.installDeps + " " + project.projectTools)
   const root = join(process.cwd(), formatDir(project.path));
   const templateDir = resolve(fileURLToPath(import.meta.url), '../../template');
 

--- a/packages/cli/src/scaffold.ts
+++ b/packages/cli/src/scaffold.ts
@@ -1,0 +1,140 @@
+import { existsSync } from 'node:fs';
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { setTimeout } from 'node:timers/promises';
+import { fileURLToPath } from 'node:url';
+
+import * as p from '@clack/prompts';
+import merge from 'lodash.merge';
+
+import { formatDir, copyDir, spawnProcess, colors } from './utils';
+
+interface Spinner {
+  start: (msg?: string) => void;
+  stop: (msg?: string, code?: number) => void;
+  message: (msg?: string) => void;
+}
+
+const packageManager = fetchPackageManager() ?? 'npm';
+
+const prompts: p.PromptGroup<{
+  path: string | symbol;
+  tools: string[] | symbol;
+  install: boolean | symbol;
+}> = {
+  path: () =>
+    p.text({
+      message: 'Where should we create your project?',
+      placeholder: 'seedcord-project',
+      validate: (value) => {
+        if (!value) return 'Please enter a path.';
+        // TODO: add prompt for overwriting directory
+        if (existsSync(value)) return 'folder already exists';
+        return undefined;
+      }
+    }),
+  tools: () =>
+    p.multiselect({
+      message: 'Select additional tools.',
+      initialValues: ['prettier'],
+      required: false,
+      options: [
+        // TODO: add more tools
+        { value: 'prettier', label: 'Prettier', hint: 'recommended' }
+      ]
+    }),
+  install: () =>
+    p.confirm({
+      message: `Install dependencies with ${packageManager}?`,
+      initialValue: false
+    })
+};
+
+const additionalTools: Record<string, Record<string, unknown>> = {
+  prettier: {
+    scripts: {
+      fmt: "prettier --write 'src/**/*.{ts,tsx,json,md}' --cache",
+      'fmt:check': "prettier --check 'src/**/*.{ts,tsx,json,md}' --cache"
+    },
+    devDependencies: {
+      prettier: '^3.6.2'
+    }
+  }
+};
+
+export async function scaffoldProject(): Promise<void> {
+  p.updateSettings({
+    aliases: {
+      w: 'up',
+      s: 'down',
+      a: 'left',
+      d: 'right'
+    }
+  });
+
+  p.intro(`${colors.bgCyan(colors.black(' seedcord wizard '))}`);
+
+  const project = await p.group(prompts, {
+    onCancel: () => {
+      p.cancel('Operation cancelled.');
+      process.exit(0);
+    }
+  });
+  const root = join(process.cwd(), formatDir(project.path));
+  const templateDir = resolve(fileURLToPath(import.meta.url), '../../template');
+
+  await extractBaseTemplate(templateDir, root, p.spinner());
+
+  const tools = project.tools;
+
+  if (tools.length > 0) await extractTools(root, tools, p.spinner());
+  if (project.install) await installPackages(root, packageManager, p.spinner());
+
+  const nextSteps =
+    `cd ${project.path}\n` +
+    `${project.install ? '' : `${packageManager} install\n`}` +
+    `fill .env.example and rename it to .env\n` +
+    `${packageManager} dev`;
+
+  p.note(nextSteps, 'Next steps.');
+  p.outro(`Problems? ${colors.underline(colors.cyan('https://github.com/materwelondhruv/seedcord/issues'))}`);
+}
+
+function fetchPackageManager(): string | undefined {
+  const agent = process.env.npm_config_user_agent;
+  return agent?.split(' ')[0]?.split('/')[0];
+}
+
+async function extractTools(root: string, tools: string[], spinner: Spinner): Promise<void> {
+  spinner.start(`Adding additional tools`);
+  const packagePath = resolve(root, './package.json');
+  let packageJson = JSON.parse(await readFile(packagePath, 'utf-8')) as Record<string, unknown>;
+  for (const tool of tools) {
+    packageJson = installTool(tool, packageJson);
+  }
+  await writeFile(packagePath, `${JSON.stringify(packageJson, null, 2)}\n`, 'utf-8');
+  spinner.stop('Added tools');
+}
+
+async function extractBaseTemplate(base: string, to: string, spinner: Spinner): Promise<void> {
+  spinner.start('extracting base files');
+  await mkdir(to, { recursive: true });
+  await copyDir(base, to);
+  await rename(`${to}/_gitignore`, `${to}/.gitignore`);
+  spinner.stop('extracted base files');
+}
+
+async function installPackages(root: string, packageManager: string, spinner: Spinner): Promise<void> {
+  spinner.start(`Installing via ${packageManager}`);
+  await setTimeout(1000);
+  await spawnProcess(`${packageManager}`, ['install'], {
+    cwd: root
+  });
+  spinner.stop(`Installed via ${packageManager}`);
+}
+
+function installTool(tool: string, packageJson: Record<string, unknown>): Record<string, unknown> {
+  const toolObject = additionalTools[tool];
+  if (!toolObject) throw new Error(`unable to find tool ${tool}`);
+  return merge<Record<string, unknown>, Record<string, unknown>>(packageJson, toolObject);
+}

--- a/packages/cli/src/scaffold.ts
+++ b/packages/cli/src/scaffold.ts
@@ -99,6 +99,7 @@ export async function scaffoldProject(
 
   await extractBaseTemplate(templateDir, root, clack.spinner());
 
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const tools = project.projectTools || [];
 
   if (tools.length > 0) await extractTools(root, tools, clack.spinner());

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -1,0 +1,44 @@
+import { spawn } from 'node:child_process';
+import { copyFile, mkdir, readdir, stat, writeFile } from 'node:fs/promises';
+import { resolve } from 'path';
+
+import { Chalk } from 'chalk';
+
+import type { SpawnSyncOptions } from 'node:child_process';
+
+export const colors = new Chalk();
+
+export function formatDir(path: string): string {
+  return path.trim().replace(/\/+$/g, '');
+}
+
+export async function spawnProcess(command: string, args: string[], options: SpawnSyncOptions): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const commandProcess = spawn(command, args, options);
+    commandProcess.on('error', (err) => reject(err));
+    commandProcess.on('close', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`${command} exited with ${code} code, output: ${commandProcess.stdout?.read()}`));
+    });
+  });
+}
+
+export async function copyDir(src: string, to: string): Promise<void> {
+  await mkdir(to, { recursive: true });
+  for (const file of await readdir(src)) {
+    await copy(resolve(src, file), resolve(to, file));
+  }
+}
+
+export async function copy(src: string, to: string): Promise<void> {
+  const isDir = (await stat(src)).isDirectory();
+  if (isDir) {
+    await copyDir(src, to);
+  } else {
+    await copyFile(src, to);
+  }
+}
+
+export async function createFile(location: string, content: string): Promise<void> {
+  await writeFile(location, content);
+}

--- a/packages/cli/template/.env.example
+++ b/packages/cli/template/.env.example
@@ -1,0 +1,1 @@
+DISCORD_BOT_TOKEN="insert your token here"

--- a/packages/cli/template/_gitignore
+++ b/packages/cli/template/_gitignore
@@ -1,0 +1,2 @@
+node_modules/
+logs/

--- a/packages/cli/template/bot.ts
+++ b/packages/cli/template/bot.ts
@@ -1,0 +1,35 @@
+import { GatewayIntentBits } from 'discord.js';
+import { resolve } from 'node:path';
+import { Seedcord } from 'seedcord';
+
+async function main() {
+  const seed = new Seedcord({
+    bot: {
+      clientOptions: {
+        intents: [
+          GatewayIntentBits.MessageContent,
+          GatewayIntentBits.GuildMessages,
+          GatewayIntentBits.Guilds,
+          GatewayIntentBits.GuildMembers,
+          GatewayIntentBits.GuildWebhooks,
+        ],
+      },
+      interactions: {
+        path: resolve(import.meta.dirname, './handlers'),
+      },
+      commands: {
+        path: resolve(import.meta.dirname, './commands'),
+      },
+      events: {
+        path: resolve(import.meta.dirname, './events'),
+      },
+    },
+    hooks: {
+      path: resolve(import.meta.dirname, './hooks'),
+    },
+  });
+
+  await seed.start();
+}
+
+main();

--- a/packages/cli/template/commands/Throw.ts
+++ b/packages/cli/template/commands/Throw.ts
@@ -1,0 +1,26 @@
+import { BuilderComponent, RegisterCommand } from 'seedcord';
+
+@RegisterCommand('global')
+export class ThrowCommand extends BuilderComponent<'command'> {
+  constructor() {
+    super('command');
+
+    this.instance
+      .setName('throw')
+      .setDescription('Throws a test error')
+      .addStringOption((option) =>
+        option
+          .setName('error')
+          .setDescription('The error to throw')
+          .setRequired(true)
+          .setAutocomplete(true)
+      )
+      .addStringOption((option) =>
+        option
+          .setName('message')
+          .setDescription('The error message')
+          .setRequired(true)
+          .setAutocomplete(true)
+      );
+  }
+}

--- a/packages/cli/template/handlers/Throw.ts
+++ b/packages/cli/template/handlers/Throw.ts
@@ -1,0 +1,44 @@
+import type { ChatInputCommandInteraction } from 'discord.js';
+import {
+  AutocompleteHandler,
+  AutocompleteRoute,
+  Catchable,
+  InteractionHandler,
+  SlashRoute,
+} from 'seedcord';
+
+@SlashRoute('throw')
+export class Throw extends InteractionHandler<ChatInputCommandInteraction> {
+  @Catchable()
+  execute(): Promise<void> {
+    throw new Error('This is a test error');
+  }
+}
+
+@AutocompleteRoute('throw', ['error', 'message'])
+export class ThrowAutocomplete extends AutocompleteHandler {
+  async execute(): Promise<void> {
+    const options: { name: string; value: string }[] = [
+      { name: 'Error 1', value: 'error1' },
+      { name: 'Error 2', value: 'error2' },
+      { name: 'Error 3', value: 'error3' },
+      { name: 'Error 4', value: 'error4' },
+      { name: 'Error 5', value: 'error5' },
+      { name: 'Error 6', value: 'error6' },
+      { name: 'Message 1', value: 'message1' },
+      { name: 'Message 2', value: 'message2' },
+      { name: 'Message 3', value: 'message3' },
+      { name: 'Message 4', value: 'message4' },
+      { name: 'Message 5', value: 'message5' },
+      { name: 'Message 6', value: 'message6' },
+    ];
+
+    const focused = this.focused.value;
+
+    const filtered = options.filter((option) =>
+      option.value.startsWith(focused)
+    );
+
+    await this.event.respond(filtered);
+  }
+}

--- a/packages/cli/template/package.json
+++ b/packages/cli/template/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "seed",
+  "version": "1.0.0",
+  "description": "",
+  "private": "true",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "dev": "tsx bot.ts"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "packageManager": "pnpm@10.11.0",
+  "devDependencies": {
+    "tsx": "^4.20.4",
+    "typescript": "^5.9.2"
+  },
+  "dependencies": {
+    "@types/node": "^24.2.1",
+    "discord.js": "^14.21.0",
+    "seedcord": "0.1.0-alpha.1"
+  }
+}

--- a/packages/cli/template/tsconfig.json
+++ b/packages/cli/template/tsconfig.json
@@ -1,0 +1,46 @@
+{
+  // Visit https://aka.ms/tsconfig to read more about this file
+  "compilerOptions": {
+    // File Layout
+    // "rootDir": "./src",
+    "outDir": "./dist",
+
+    // Environment Settings
+    // See also https://aka.ms/tsconfig/module
+    "module": "nodenext",
+    "target": "esnext",
+    "types": [],
+    // For nodejs:
+    // "lib": ["esnext"],
+    // "types": ["node"],
+    // and npm install -D @types/node
+
+    // Other Outputs
+    "sourceMap": true,
+    "declaration": true,
+    "declarationMap": true,
+
+    // Stricter Typechecking Options
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+
+    // Style Options
+    // "noImplicitReturns": true,
+    // "noImplicitOverride": true,
+    // "noUnusedLocals": true,
+    // "noUnusedParameters": true,
+    // "noFallthroughCasesInSwitch": true,
+    // "noPropertyAccessFromIndexSignature": true,
+
+    // Recommended Options
+    "strict": true,
+    "jsx": "react-jsx",
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "skipLibCheck": true,
+
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
+  }
+}

--- a/packages/cli/tests/basic.test.ts
+++ b/packages/cli/tests/basic.test.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from 'vitest';
+
+describe('CLI Package', () => {
+  it('should pass basic test', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -2,9 +2,11 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "../tsconfig/node.json",
   "compilerOptions": {
-    "rootDir": "./",
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "rootDir": ".",
+    "allowJs": true,
+    "checkJs": false
   },
-  "include": ["src/**/*.ts", "tests/**/*.ts", "tsup.config.ts"],
+  "include": ["*.ts", "*.mjs", "**/*.mjs", "tsup.config.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -3,7 +3,11 @@
   "extends": "../tsconfig/node.json",
   "compilerOptions": {
     "rootDir": "./",
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "baseUrl": ".",
+    "paths": {
+      "commander": ["./node_modules/@commander-js/extra-typings"]
+    }
   },
   "include": ["src/**/*.ts", "tests/**/*.ts", "tsup.config.ts"],
   "exclude": ["node_modules", "dist"]

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -2,11 +2,9 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "../tsconfig/node.json",
   "compilerOptions": {
-    "outDir": "./dist",
-    "rootDir": ".",
-    "allowJs": true,
-    "checkJs": false
+    "rootDir": "./",
+    "outDir": "./dist"
   },
-  "include": ["*.ts", "*.mjs", "**/*.mjs", "tsup.config.ts"],
+  "include": ["src/**/*.ts", "tests/**/*.ts", "tsup.config.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../tsconfig/node.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": ".",
+    "allowJs": true,
+    "checkJs": false
+  },
+  "include": ["*.ts", "*.mjs", "**/*.mjs", "tsup.config.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -1,5 +1,3 @@
 import { createTsupConfig } from '@seedcord/tsup-config';
 
-export default createTsupConfig({
-  format: ['esm']
-});
+export default createTsupConfig();

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -1,0 +1,5 @@
+import { createTsupConfig } from '@seedcord/tsup-config';
+
+export default createTsupConfig({
+  format: ['esm']
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,7 +95,7 @@ importers:
         version: 0.11.0
       chalk:
         specifier: ^5.5.0
-        version: 5.5.0
+        version: 5.6.0
       lodash.merge:
         specifier: ^4.6.2
         version: 4.6.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,9 +93,15 @@ importers:
       '@clack/prompts':
         specifier: ^0.11.0
         version: 0.11.0
+      '@commander-js/extra-typings':
+        specifier: ^14.0.0
+        version: 14.0.0(commander@14.0.0)
       chalk:
         specifier: catalog:deps
         version: 5.6.0
+      commander:
+        specifier: ^14.0.0
+        version: 14.0.0
       lodash.merge:
         specifier: ^4.6.2
         version: 4.6.2
@@ -477,6 +483,11 @@ packages:
   '@colors/colors@1.6.0':
     resolution: {integrity: sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==}
     engines: {node: '>=0.1.90'}
+
+  '@commander-js/extra-typings@14.0.0':
+    resolution: {integrity: sha512-hIn0ncNaJRLkZrxBIp5AsW/eXEHNKYQBh0aPdoUqNgD+Io3NIykQqpKFyKcuasZhicGaEZJX/JBSIkZ4e5x8Dg==}
+    peerDependencies:
+      commander: ~14.0.0
 
   '@commitlint/cli@19.8.1':
     resolution: {integrity: sha512-LXUdNIkspyxrlV6VDHWBmCZRtkEVRpBKxi2Gtw3J54cGWhLCTouVD/Q6ZSaSvd2YaDObWK8mDjrz3TIKtaQMAA==}
@@ -1527,6 +1538,10 @@ packages:
 
   colorspace@1.1.4:
     resolution: {integrity: sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==}
+
+  commander@14.0.0:
+    resolution: {integrity: sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==}
+    engines: {node: '>=20'}
 
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -3559,6 +3574,10 @@ snapshots:
 
   '@colors/colors@1.6.0': {}
 
+  '@commander-js/extra-typings@14.0.0(commander@14.0.0)':
+    dependencies:
+      commander: 14.0.0
+
   '@commitlint/cli@19.8.1(@types/node@24.3.0)(typescript@5.9.2)':
     dependencies:
       '@commitlint/format': 19.8.1
@@ -4600,6 +4619,8 @@ snapshots:
     dependencies:
       color: 3.2.1
       text-hex: 1.0.0
+
+  commander@14.0.0: {}
 
   commander@4.1.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,9 +39,6 @@ importers:
       '@clack/prompts':
         specifier: ^0.11.0
         version: 0.11.0
-      '@clack/prompts':
-        specifier: ^0.11.0
-        version: 0.11.0
       '@commitlint/cli':
         specifier: ^19.8.1
         version: 19.8.1(@types/node@24.3.0)(typescript@5.9.2)
@@ -91,32 +88,29 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@24.3.0)(jiti@2.5.1)(tsx@4.20.5)
 
-  packages/clis:
+  packages/cli:
     dependencies:
-      '@seedcord/plugins':
-        specifier: workspace:*
-        version: link:../plugins
-      '@seedcord/types':
-        specifier: workspace:^
-        version: link:../types
-      discord.js:
-        specifier: ^14.21.0
-        version: 14.21.0
-      envapt:
-        specifier: ^2.2.9
-        version: 2.2.9
-      mongoose:
-        specifier: ^8.17.1
-        version: 8.17.1
-      reflect-metadata:
-        specifier: ^0.2.2
-        version: 0.2.2
-      seedcord:
-        specifier: workspace:^
-        version: link:../seedcord
+      '@clack/prompts':
+        specifier: ^0.11.0
+        version: 0.11.0
+      '@eslint/js':
+        specifier: ^9.33.0
+        version: 9.33.0
+      chalk:
+        specifier: ^5.5.0
+        version: 5.5.0
+      eslint:
+        specifier: ^9.33.0
+        version: 9.33.0(jiti@2.5.1)
+      lodash.merge:
+        specifier: ^4.6.2
+        version: 4.6.2
       typescript:
         specifier: ^5.9.2
         version: 5.9.2
+      typescript-eslint:
+        specifier: ^8.39.1
+        version: 8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2)
     devDependencies:
       '@seedcord/eslint-config':
         specifier: workspace:^
@@ -127,6 +121,12 @@ importers:
       '@seedcord/tsup-config':
         specifier: workspace:^
         version: link:../tsup-config
+      '@types/lodash.merge':
+        specifier: ^4.6.9
+        version: 4.6.9
+      tsx:
+        specifier: ^4.20.4
+        version: 4.20.4
 
   packages/eslint-config:
     dependencies:
@@ -216,46 +216,6 @@ importers:
       '@seedcord/tsup-config':
         specifier: workspace:^
         version: link:../tsup-config
-
-  packages/mocktest:
-    dependencies:
-      '@clack/prompts':
-        specifier: ^0.11.0
-        version: 0.11.0
-      '@eslint/js':
-        specifier: ^9.33.0
-        version: 9.33.0
-      chalk:
-        specifier: ^5.5.0
-        version: 5.5.0
-      eslint:
-        specifier: ^9.33.0
-        version: 9.33.0(jiti@2.5.1)
-      lodash.merge:
-        specifier: ^4.6.2
-        version: 4.6.2
-      typescript:
-        specifier: ^5.9.2
-        version: 5.9.2
-      typescript-eslint:
-        specifier: ^8.39.1
-        version: 8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2)
-    devDependencies:
-      '@seedcord/eslint-config':
-        specifier: workspace:^
-        version: link:../eslint-config
-      '@seedcord/tsconfig':
-        specifier: workspace:^
-        version: link:../tsconfig
-      '@seedcord/tsup-config':
-        specifier: workspace:^
-        version: link:../tsup-config
-      '@types/lodash.merge':
-        specifier: ^4.6.9
-        version: 4.6.9
-      tsx:
-        specifier: ^4.20.4
-        version: 4.20.4
 
   packages/plugins:
     dependencies:
@@ -519,12 +479,6 @@ packages:
 
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
-
-  '@clack/core@0.5.0':
-    resolution: {integrity: sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==}
-
-  '@clack/prompts@0.11.0':
-    resolution: {integrity: sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw==}
 
   '@clack/core@0.5.0':
     resolution: {integrity: sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==}
@@ -2944,9 +2898,6 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
-  sisteransi@1.0.5:
-    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
-
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -3606,17 +3557,6 @@ snapshots:
       fs-extra: 7.0.1
       human-id: 4.1.1
       prettier: 2.8.8
-
-  '@clack/core@0.5.0':
-    dependencies:
-      picocolors: 1.1.1
-      sisteransi: 1.0.5
-
-  '@clack/prompts@0.11.0':
-    dependencies:
-      '@clack/core': 0.5.0
-      picocolors: 1.1.1
-      sisteransi: 1.0.5
 
   '@clack/core@0.5.0':
     dependencies:
@@ -6126,8 +6066,6 @@ snapshots:
   simple-update-notifier@2.0.0:
     dependencies:
       semver: 7.7.2
-
-  sisteransi@1.0.5: {}
 
   sisteransi@1.0.5: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       '@clack/prompts':
         specifier: ^0.11.0
         version: 0.11.0
+      '@clack/prompts':
+        specifier: ^0.11.0
+        version: 0.11.0
       '@commitlint/cli':
         specifier: ^19.8.1
         version: 19.8.1(@types/node@24.3.0)(typescript@5.9.2)
@@ -88,26 +91,32 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@24.3.0)(jiti@2.5.1)(tsx@4.20.5)
 
-  packages/cli:
+  packages/clis:
     dependencies:
-      '@clack/prompts':
-        specifier: ^0.11.0
-        version: 0.11.0
-      '@eslint/js':
-        specifier: ^9.33.0
-        version: 9.33.0
-      chalk:
-        specifier: ^5.5.0
-        version: 5.5.0
-      eslint:
-        specifier: ^9.33.0
-        version: 9.33.0(jiti@2.5.1)
-      lodash.merge:
-        specifier: ^4.6.2
-        version: 4.6.2
-      typescript-eslint:
-        specifier: ^8.39.1
-        version: 8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2)
+      '@seedcord/plugins':
+        specifier: workspace:*
+        version: link:../plugins
+      '@seedcord/types':
+        specifier: workspace:^
+        version: link:../types
+      discord.js:
+        specifier: ^14.21.0
+        version: 14.21.0
+      envapt:
+        specifier: ^2.2.9
+        version: 2.2.9
+      mongoose:
+        specifier: ^8.17.1
+        version: 8.17.1
+      reflect-metadata:
+        specifier: ^0.2.2
+        version: 0.2.2
+      seedcord:
+        specifier: workspace:^
+        version: link:../seedcord
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.2
     devDependencies:
       '@seedcord/eslint-config':
         specifier: workspace:^
@@ -118,12 +127,6 @@ importers:
       '@seedcord/tsup-config':
         specifier: workspace:^
         version: link:../tsup-config
-      '@types/lodash.merge':
-        specifier: ^4.6.9
-        version: 4.6.9
-      tsx:
-        specifier: ^4.20.4
-        version: 4.20.4
 
   packages/eslint-config:
     dependencies:
@@ -213,6 +216,46 @@ importers:
       '@seedcord/tsup-config':
         specifier: workspace:^
         version: link:../tsup-config
+
+  packages/mocktest:
+    dependencies:
+      '@clack/prompts':
+        specifier: ^0.11.0
+        version: 0.11.0
+      '@eslint/js':
+        specifier: ^9.33.0
+        version: 9.33.0
+      chalk:
+        specifier: ^5.5.0
+        version: 5.5.0
+      eslint:
+        specifier: ^9.33.0
+        version: 9.33.0(jiti@2.5.1)
+      lodash.merge:
+        specifier: ^4.6.2
+        version: 4.6.2
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.2
+      typescript-eslint:
+        specifier: ^8.39.1
+        version: 8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2)
+    devDependencies:
+      '@seedcord/eslint-config':
+        specifier: workspace:^
+        version: link:../eslint-config
+      '@seedcord/tsconfig':
+        specifier: workspace:^
+        version: link:../tsconfig
+      '@seedcord/tsup-config':
+        specifier: workspace:^
+        version: link:../tsup-config
+      '@types/lodash.merge':
+        specifier: ^4.6.9
+        version: 4.6.9
+      tsx:
+        specifier: ^4.20.4
+        version: 4.20.4
 
   packages/plugins:
     dependencies:
@@ -476,6 +519,12 @@ packages:
 
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
+
+  '@clack/core@0.5.0':
+    resolution: {integrity: sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==}
+
+  '@clack/prompts@0.11.0':
+    resolution: {integrity: sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw==}
 
   '@clack/core@0.5.0':
     resolution: {integrity: sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==}
@@ -2895,6 +2944,9 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -3554,6 +3606,17 @@ snapshots:
       fs-extra: 7.0.1
       human-id: 4.1.1
       prettier: 2.8.8
+
+  '@clack/core@0.5.0':
+    dependencies:
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
+
+  '@clack/prompts@0.11.0':
+    dependencies:
+      '@clack/core': 0.5.0
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
 
   '@clack/core@0.5.0':
     dependencies:
@@ -6063,6 +6126,8 @@ snapshots:
   simple-update-notifier@2.0.0:
     dependencies:
       semver: 7.7.2
+
+  sisteransi@1.0.5: {}
 
   sisteransi@1.0.5: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,9 +108,6 @@ importers:
       typescript:
         specifier: catalog:peer
         version: 5.9.2
-      typescript-eslint:
-        specifier: ^8.39.1
-        version: 8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2)
     devDependencies:
       '@seedcord/eslint-config':
         specifier: workspace:^

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,13 +94,13 @@ importers:
         specifier: ^0.11.0
         version: 0.11.0
       chalk:
-        specifier: ^5.5.0
+        specifier: catalog:deps
         version: 5.6.0
       lodash.merge:
         specifier: ^4.6.2
         version: 4.6.2
       typescript:
-        specifier: ^5.9.2
+        specifier: catalog:peer
         version: 5.9.2
     devDependencies:
       '@seedcord/eslint-config':
@@ -115,9 +115,6 @@ importers:
       '@types/lodash.merge':
         specifier: ^4.6.9
         version: 4.6.9
-      tsx:
-        specifier: ^4.20.4
-        version: 4.20.4
 
   packages/eslint-config:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,9 +39,6 @@ importers:
       '@clack/prompts':
         specifier: ^0.11.0
         version: 0.11.0
-      '@clack/prompts':
-        specifier: ^0.11.0
-        version: 0.11.0
       '@commitlint/cli':
         specifier: ^19.8.1
         version: 19.8.1(@types/node@24.3.0)(typescript@5.9.2)
@@ -91,7 +88,7 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@24.3.0)(jiti@2.5.1)(tsx@4.20.5)
 
-  packages/clis:
+  packages/cli:
     dependencies:
       '@clack/prompts':
         specifier: ^0.11.0
@@ -111,6 +108,9 @@ importers:
       typescript:
         specifier: catalog:peer
         version: 5.9.2
+      typescript-eslint:
+        specifier: ^8.39.1
+        version: 8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2)
     devDependencies:
       '@seedcord/eslint-config':
         specifier: workspace:^
@@ -213,46 +213,6 @@ importers:
       '@seedcord/tsup-config':
         specifier: workspace:^
         version: link:../tsup-config
-
-  packages/mocktest:
-    dependencies:
-      '@clack/prompts':
-        specifier: ^0.11.0
-        version: 0.11.0
-      '@eslint/js':
-        specifier: ^9.33.0
-        version: 9.33.0
-      chalk:
-        specifier: ^5.5.0
-        version: 5.5.0
-      eslint:
-        specifier: ^9.33.0
-        version: 9.33.0(jiti@2.5.1)
-      lodash.merge:
-        specifier: ^4.6.2
-        version: 4.6.2
-      typescript:
-        specifier: ^5.9.2
-        version: 5.9.2
-      typescript-eslint:
-        specifier: ^8.39.1
-        version: 8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2)
-    devDependencies:
-      '@seedcord/eslint-config':
-        specifier: workspace:^
-        version: link:../eslint-config
-      '@seedcord/tsconfig':
-        specifier: workspace:^
-        version: link:../tsconfig
-      '@seedcord/tsup-config':
-        specifier: workspace:^
-        version: link:../tsup-config
-      '@types/lodash.merge':
-        specifier: ^4.6.9
-        version: 4.6.9
-      tsx:
-        specifier: ^4.20.4
-        version: 4.20.4
 
   packages/plugins:
     dependencies:
@@ -516,12 +476,6 @@ packages:
 
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
-
-  '@clack/core@0.5.0':
-    resolution: {integrity: sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==}
-
-  '@clack/prompts@0.11.0':
-    resolution: {integrity: sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw==}
 
   '@clack/core@0.5.0':
     resolution: {integrity: sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==}
@@ -2950,9 +2904,6 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
-  sisteransi@1.0.5:
-    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
-
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -3612,17 +3563,6 @@ snapshots:
       fs-extra: 7.0.1
       human-id: 4.1.1
       prettier: 2.8.8
-
-  '@clack/core@0.5.0':
-    dependencies:
-      picocolors: 1.1.1
-      sisteransi: 1.0.5
-
-  '@clack/prompts@0.11.0':
-    dependencies:
-      '@clack/core': 0.5.0
-      picocolors: 1.1.1
-      sisteransi: 1.0.5
 
   '@clack/core@0.5.0':
     dependencies:
@@ -6138,8 +6078,6 @@ snapshots:
   simple-update-notifier@2.0.0:
     dependencies:
       semver: 7.7.2
-
-  sisteransi@1.0.5: {}
 
   sisteransi@1.0.5: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       '@clack/prompts':
         specifier: ^0.11.0
         version: 0.11.0
+      '@clack/prompts':
+        specifier: ^0.11.0
+        version: 0.11.0
       '@commitlint/cli':
         specifier: ^19.8.1
         version: 19.8.1(@types/node@24.3.0)(typescript@5.9.2)
@@ -88,7 +91,7 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@24.3.0)(jiti@2.5.1)(tsx@4.20.5)
 
-  packages/cli:
+  packages/clis:
     dependencies:
       '@clack/prompts':
         specifier: ^0.11.0
@@ -210,6 +213,46 @@ importers:
       '@seedcord/tsup-config':
         specifier: workspace:^
         version: link:../tsup-config
+
+  packages/mocktest:
+    dependencies:
+      '@clack/prompts':
+        specifier: ^0.11.0
+        version: 0.11.0
+      '@eslint/js':
+        specifier: ^9.33.0
+        version: 9.33.0
+      chalk:
+        specifier: ^5.5.0
+        version: 5.5.0
+      eslint:
+        specifier: ^9.33.0
+        version: 9.33.0(jiti@2.5.1)
+      lodash.merge:
+        specifier: ^4.6.2
+        version: 4.6.2
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.2
+      typescript-eslint:
+        specifier: ^8.39.1
+        version: 8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2)
+    devDependencies:
+      '@seedcord/eslint-config':
+        specifier: workspace:^
+        version: link:../eslint-config
+      '@seedcord/tsconfig':
+        specifier: workspace:^
+        version: link:../tsconfig
+      '@seedcord/tsup-config':
+        specifier: workspace:^
+        version: link:../tsup-config
+      '@types/lodash.merge':
+        specifier: ^4.6.9
+        version: 4.6.9
+      tsx:
+        specifier: ^4.20.4
+        version: 4.20.4
 
   packages/plugins:
     dependencies:
@@ -473,6 +516,12 @@ packages:
 
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
+
+  '@clack/core@0.5.0':
+    resolution: {integrity: sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==}
+
+  '@clack/prompts@0.11.0':
+    resolution: {integrity: sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw==}
 
   '@clack/core@0.5.0':
     resolution: {integrity: sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==}
@@ -2901,6 +2950,9 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -3560,6 +3612,17 @@ snapshots:
       fs-extra: 7.0.1
       human-id: 4.1.1
       prettier: 2.8.8
+
+  '@clack/core@0.5.0':
+    dependencies:
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
+
+  '@clack/prompts@0.11.0':
+    dependencies:
+      '@clack/core': 0.5.0
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
 
   '@clack/core@0.5.0':
     dependencies:
@@ -6075,6 +6138,8 @@ snapshots:
   simple-update-notifier@2.0.0:
     dependencies:
       semver: 7.7.2
+
+  sisteransi@1.0.5: {}
 
   sisteransi@1.0.5: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,24 +93,15 @@ importers:
       '@clack/prompts':
         specifier: ^0.11.0
         version: 0.11.0
-      '@eslint/js':
-        specifier: ^9.33.0
-        version: 9.33.0
       chalk:
         specifier: ^5.5.0
         version: 5.5.0
-      eslint:
-        specifier: ^9.33.0
-        version: 9.33.0(jiti@2.5.1)
       lodash.merge:
         specifier: ^4.6.2
         version: 4.6.2
       typescript:
         specifier: ^5.9.2
         version: 5.9.2
-      typescript-eslint:
-        specifier: ^8.39.1
-        version: 8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2)
     devDependencies:
       '@seedcord/eslint-config':
         specifier: workspace:^

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       '@changesets/cli':
         specifier: ^2.29.6
         version: 2.29.6(@types/node@24.3.0)
+      '@clack/prompts':
+        specifier: ^0.11.0
+        version: 0.11.0
       '@commitlint/cli':
         specifier: ^19.8.1
         version: 19.8.1(@types/node@24.3.0)(typescript@5.9.2)
@@ -84,6 +87,43 @@ importers:
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@24.3.0)(jiti@2.5.1)(tsx@4.20.5)
+
+  packages/cli:
+    dependencies:
+      '@clack/prompts':
+        specifier: ^0.11.0
+        version: 0.11.0
+      '@eslint/js':
+        specifier: ^9.33.0
+        version: 9.33.0
+      chalk:
+        specifier: ^5.5.0
+        version: 5.5.0
+      eslint:
+        specifier: ^9.33.0
+        version: 9.33.0(jiti@2.5.1)
+      lodash.merge:
+        specifier: ^4.6.2
+        version: 4.6.2
+      typescript-eslint:
+        specifier: ^8.39.1
+        version: 8.39.1(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2)
+    devDependencies:
+      '@seedcord/eslint-config':
+        specifier: workspace:^
+        version: link:../eslint-config
+      '@seedcord/tsconfig':
+        specifier: workspace:^
+        version: link:../tsconfig
+      '@seedcord/tsup-config':
+        specifier: workspace:^
+        version: link:../tsup-config
+      '@types/lodash.merge':
+        specifier: ^4.6.9
+        version: 4.6.9
+      tsx:
+        specifier: ^4.20.4
+        version: 4.20.4
 
   packages/eslint-config:
     dependencies:
@@ -436,6 +476,12 @@ packages:
 
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
+
+  '@clack/core@0.5.0':
+    resolution: {integrity: sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow==}
+
+  '@clack/prompts@0.11.0':
+    resolution: {integrity: sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw==}
 
   '@colors/colors@1.6.0':
     resolution: {integrity: sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==}
@@ -2846,6 +2892,9 @@ packages:
     resolution: {integrity: sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==}
     engines: {node: '>=10'}
 
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -3505,6 +3554,17 @@ snapshots:
       fs-extra: 7.0.1
       human-id: 4.1.1
       prettier: 2.8.8
+
+  '@clack/core@0.5.0':
+    dependencies:
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
+
+  '@clack/prompts@0.11.0':
+    dependencies:
+      '@clack/core': 0.5.0
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
 
   '@colors/colors@1.6.0': {}
 
@@ -6003,6 +6063,8 @@ snapshots:
   simple-update-notifier@2.0.0:
     dependencies:
       semver: 7.7.2
+
+  sisteransi@1.0.5: {}
 
   slash@3.0.0: {}
 


### PR DESCRIPTION
This pr adds cli package, currently only having create feature, similarly as `vite create` and allows to choose a custom directory, add prettier and install packages (optional)
To try it, use `dev` task of package with your tooling, like `pnpm dev`, `npm start dev` or `deno task dev`