### PR TITLE
feat: checkbox and radio button builders

### DIFF
--- a/.changeset/ninety-lemons-sell.md
+++ b/.changeset/ninety-lemons-sell.md
@@ -1,0 +1,6 @@
+---
+'seedcord': minor
+---
+
+- Add `checkbox`, `checkbox_group`, `checkbox_group_option`, `radio_group`, and `radio_group_option` builders to the public API.
+- **BREAKING**: Rename `ActionRowComponentType` to `RowType` for consistency with `BuilderType`

--- a/packages/seedcord/src/interfaces/Components.ts
+++ b/packages/seedcord/src/interfaces/Components.ts
@@ -2,6 +2,9 @@ import {
     ActionRowBuilder,
     ButtonBuilder,
     ChannelSelectMenuBuilder,
+    CheckboxBuilder,
+    CheckboxGroupBuilder,
+    CheckboxGroupOptionBuilder,
     ContainerBuilder,
     ContextMenuCommandBuilder,
     EmbedBuilder,
@@ -12,6 +15,8 @@ import {
     MediaGalleryBuilder,
     MentionableSelectMenuBuilder,
     ModalBuilder,
+    RadioGroupBuilder,
+    RadioGroupOptionBuilder,
     RoleSelectMenuBuilder,
     SectionBuilder,
     SeparatorBuilder,
@@ -31,7 +36,7 @@ import { getBotColor } from '@miscellaneous/botColorHolder';
 import type { Join, NonEmptyTuple } from 'type-fest';
 
 /**
- * Available Discord.js builder classes for use with BuilderComponent
+ * Available Discord.js builder classes for use with BuilderComponent for commands, embeds, modals, etc.
  *
  * @internal
  */
@@ -50,6 +55,11 @@ export const BuilderTypes = {
     label: LabelBuilder,
     text_input: TextInputBuilder,
     file_upload: FileUploadBuilder,
+    checkbox: CheckboxBuilder,
+    checkbox_group: CheckboxGroupBuilder,
+    checkbox_group_option: CheckboxGroupOptionBuilder,
+    radio_group: RadioGroupBuilder,
+    radio_group_option: RadioGroupOptionBuilder,
 
     // Action Row Components
     button: ButtonBuilder,
@@ -70,7 +80,7 @@ export const BuilderTypes = {
 };
 
 /**
- * Available Discord.js action row classes for use with RowComponent
+ * Available Discord.js action row classes for use with RowComponent for Select Menus and Buttons
  *
  * @internal
  */

--- a/packages/seedcord/src/interfaces/Components.ts
+++ b/packages/seedcord/src/interfaces/Components.ts
@@ -113,12 +113,12 @@ export type InstantiatedBuilder<BuilderKey extends BuilderType> = InstanceType<(
 /**
  * Available Discord.js action row types for use with RowComponent
  */
-export type ActionRowComponentType = keyof typeof RowTypes;
+export type RowType = keyof typeof RowTypes;
 
 /**
  * @internal
  */
-export type InstantiatedActionRow<RowKey extends ActionRowComponentType> = InstanceType<(typeof RowTypes)[RowKey]>;
+export type InstantiatedActionRow<RowKey extends RowType> = InstanceType<(typeof RowTypes)[RowKey]>;
 
 /**
  * Base class for Discord component wrappers
@@ -144,7 +144,7 @@ export abstract class BaseComponent<TComponent> {
      * Please do not use for further configuration, use `this.instance` for that.
      * @example new SomeComponent().component
      */
-    public abstract get component(): InstantiatedBuilder<BuilderType> | InstantiatedActionRow<ActionRowComponentType>;
+    public abstract get component(): InstantiatedBuilder<BuilderType> | InstantiatedActionRow<RowType>;
 
     /**
      * Gets the component instance for configuration
@@ -240,9 +240,7 @@ export abstract class BuilderComponent<BuilderKey extends BuilderType> extends B
  *
  * @typeParam RowKey - The Discord.js action row type being wrapped
  */
-export abstract class RowComponent<RowKey extends ActionRowComponentType> extends BaseComponent<
-    InstantiatedActionRow<RowKey>
-> {
+export abstract class RowComponent<RowKey extends RowType> extends BaseComponent<InstantiatedActionRow<RowKey>> {
     protected constructor(public readonly type: RowKey) {
         const ComponentClass = RowTypes[type] as unknown;
         super(ComponentClass as new () => InstantiatedActionRow<RowKey>);

--- a/packages/seedcord/src/interfaces/index.ts
+++ b/packages/seedcord/src/interfaces/index.ts
@@ -1,10 +1,4 @@
-export {
-    BuilderComponent,
-    CustomError,
-    RowComponent,
-    type ActionRowComponentType,
-    type BuilderType
-} from './Components';
+export { BuilderComponent, CustomError, RowComponent, type RowType, type BuilderType } from './Components';
 export {
     AutocompleteHandler,
     EventHandler,


### PR DESCRIPTION
Adds `checkbox`, `checkbox_group`, `checkbox_group_option`, `radio_group`, and `radio_group_option` builders to the public API.

**BREAKING** (minor, pre-1.0): renames `ActionRowComponentType` to `RowType` for consistency with `BuilderType`.

Changeset: `seedcord` minor. Rebased on `next`; lint / tc / test green locally.