### PR TITLE
feat: pagination, deferred-reply fix, `SelectMenuHandler` rename

### DIFF
--- a/.changeset/pagination.md
+++ b/.changeset/pagination.md
@@ -1,0 +1,7 @@
+---
+'@seedcord/kit': minor
+'seedcord': minor
+'@seedcord/errors': patch
+---
+
+Add pagination. `Paginator` renders paged Components V2 replies with first/prev/next/last controls, backed by `ArraySource` for an in-memory list or `CursorSource` for one-page-at-a-time fetches. Each control encodes its target page, so clicks keep working after a restart. The pure `paginate()` math and the `PageView` shape ship from `@seedcord/kit` for headless use.

--- a/.changeset/rename-select-menu-handler.md
+++ b/.changeset/rename-select-menu-handler.md
@@ -1,0 +1,5 @@
+---
+'seedcord': minor
+---
+
+Rename the `SelectHandler` base class to `SelectMenuHandler`, matching `SelectMenuRoute` and `SelectMenuKind`. Select-menu handlers should now extend `SelectMenuHandler`.

--- a/mock/src/commands/DeferNotice.ts
+++ b/mock/src/commands/DeferNotice.ts
@@ -1,0 +1,12 @@
+import { RegisterCommand, BuilderComponent } from 'seedcord';
+
+@RegisterCommand('global')
+export class DeferNoticeCommand extends BuilderComponent<'command'> {
+    constructor() {
+        super('command');
+
+        this.instance
+            .setName('defernotice')
+            .setDescription('Probe a deferReply followed by a thrown Notice, to watch the reply path.');
+    }
+}

--- a/mock/src/commands/Feed.ts
+++ b/mock/src/commands/Feed.ts
@@ -1,0 +1,12 @@
+import { RegisterCommand, BuilderComponent } from 'seedcord';
+
+@RegisterCommand('global')
+export class FeedCommand extends BuilderComponent<'command'> {
+    constructor() {
+        super('command');
+
+        this.instance
+            .setName('feed')
+            .setDescription('Complex pagination demo: a cursor source with a custom render and styled controls.');
+    }
+}

--- a/mock/src/commands/Leaderboard.ts
+++ b/mock/src/commands/Leaderboard.ts
@@ -1,0 +1,12 @@
+import { RegisterCommand, BuilderComponent } from 'seedcord';
+
+@RegisterCommand('global')
+export class LeaderboardCommand extends BuilderComponent<'command'> {
+    constructor() {
+        super('command');
+
+        this.instance
+            .setName('leaderboard')
+            .setDescription('Headless pagination demo, an embed driven by your own cursor and routing.');
+    }
+}

--- a/mock/src/commands/Roster.ts
+++ b/mock/src/commands/Roster.ts
@@ -1,0 +1,12 @@
+import { RegisterCommand, BuilderComponent } from 'seedcord';
+
+@RegisterCommand('global')
+export class RosterCommand extends BuilderComponent<'command'> {
+    constructor() {
+        super('command');
+
+        this.instance
+            .setName('roster')
+            .setDescription('Simple pagination demo: an array source with the default render.');
+    }
+}

--- a/mock/src/components/bundles/Feed.ts
+++ b/mock/src/components/bundles/Feed.ts
@@ -1,0 +1,32 @@
+import { ActionRowBuilder, ButtonStyle, TextDisplayBuilder } from 'discord.js';
+import { BuilderComponent } from 'seedcord';
+
+import type { ButtonBuilder } from 'discord.js';
+import type { PageView, PaginatorControls } from 'seedcord';
+
+/** One paginated activity event. */
+export interface FeedEvent {
+    id: number;
+    text: string;
+}
+
+/** The complex paginator's styled page, holding the events and the hand-placed controls. */
+export class FeedCard extends BuilderComponent<'container'> {
+    constructor(view: PageView<FeedEvent>, controls: PaginatorControls) {
+        super('container');
+
+        this.instance
+            .addTextDisplayComponents(
+                new TextDisplayBuilder().setContent(
+                    `## Activity feed\n${view.items.map((event) => `- ${event.text}`).join('\n')}`
+                )
+            )
+            .addActionRowComponents(
+                new ActionRowBuilder<ButtonBuilder>().addComponents(
+                    controls.button('prev', { style: ButtonStyle.Primary, emoji: '⬅️' }),
+                    controls.button('indicator'),
+                    controls.button('next', { style: ButtonStyle.Primary, emoji: '➡️' })
+                )
+            );
+    }
+}

--- a/mock/src/components/bundles/Leaderboard.ts
+++ b/mock/src/components/bundles/Leaderboard.ts
@@ -1,0 +1,45 @@
+import { ButtonBuilder, ButtonStyle } from 'discord.js';
+import { BuilderComponent, RowComponent } from 'seedcord';
+
+import type { PageView } from 'seedcord';
+
+/** One leaderboard row. */
+export interface LeaderboardEntry {
+    name: string;
+    score: number;
+}
+
+/** The leaderboard page as an embed (the headless path uses embeds, with no components-v2 flag). */
+export class LeaderboardCard extends BuilderComponent<'embed'> {
+    constructor(view: PageView<LeaderboardEntry>) {
+        super('embed');
+
+        const lines = view.items.map(
+            (entry, offset) => `**${view.page * view.perPage + offset + 1}.** ${entry.name} — ${entry.score}`
+        );
+        this.instance
+            .setTitle('Leaderboard')
+            .setDescription(lines.join('\n'))
+            .setFooter({ text: `Page ${view.page + 1} of ${view.totalPages ?? '?'}` });
+    }
+}
+
+/** Prev/Next for the headless leaderboard, stamped with the caller's own cursor wires. */
+export class LeaderboardControls extends RowComponent<'button'> {
+    constructor(view: PageView<LeaderboardEntry>, prevId: string, nextId: string) {
+        super('button');
+
+        this.instance.addComponents(
+            new ButtonBuilder()
+                .setCustomId(prevId)
+                .setLabel('Prev')
+                .setStyle(ButtonStyle.Secondary)
+                .setDisabled(!view.hasPrev),
+            new ButtonBuilder()
+                .setCustomId(nextId)
+                .setLabel('Next')
+                .setStyle(ButtonStyle.Secondary)
+                .setDisabled(!view.hasNext)
+        );
+    }
+}

--- a/mock/src/handlers/DeferNotice.ts
+++ b/mock/src/handlers/DeferNotice.ts
@@ -1,0 +1,30 @@
+import { MessageFlags, TextDisplayBuilder } from 'discord.js';
+import { Notice, SlashHandler, SlashRoute } from 'seedcord';
+
+import type { ReplyResponse } from 'seedcord';
+
+class ProbeNotice extends Notice {
+    public constructor() {
+        super('defer + notice probe');
+        this.ephemeral = false;
+    }
+
+    public render(): ReplyResponse {
+        return {
+            components: [
+                new TextDisplayBuilder().setContent(
+                    'I am a Notice thrown after deferReply(). Watch whether the thinking message turns into this, or a new message appears and the thinking one is removed.'
+                )
+            ]
+        };
+    }
+}
+
+@SlashRoute('defernotice')
+export class DeferNoticeProbe extends SlashHandler<'defernotice'> {
+    public async execute(): Promise<void> {
+        await this.event.deferReply({ flags: MessageFlags.Ephemeral });
+        // await Promise.resolve();
+        throw new ProbeNotice();
+    }
+}

--- a/mock/src/handlers/Feed.ts
+++ b/mock/src/handlers/Feed.ts
@@ -1,0 +1,35 @@
+import { ButtonRoute, CursorSource, Paginator, SlashHandler, SlashRoute } from 'seedcord';
+
+import { FeedCard } from '../components/bundles/Feed';
+
+import type { FeedEvent } from '../components/bundles/Feed';
+
+const TOTAL_EVENTS = 43;
+
+// a simulated paged feed, so a CursorSource has no cheap total (no last button, indicator "Page X").
+function fetchEvents(page: number, perPage: number): { items: FeedEvent[]; hasNext: boolean } {
+    const start = page * perPage;
+    const count = Math.min(perPage, Math.max(0, TOTAL_EVENTS - start));
+    const items = Array.from({ length: count }, (_, offset) => ({
+        id: start + offset,
+        text: `Activity #${start + offset + 1}`
+    }));
+    return { items, hasNext: start + perPage < TOTAL_EVENTS };
+}
+
+export const Feed = new Paginator({
+    prefix: 'feed',
+    source: new CursorSource((_ctx, page, perPage) => fetchEvents(page, perPage), { perPage: 5 }),
+    render: (view, controls) => [new FeedCard(view, controls).component],
+    ephemeral: true
+});
+
+@ButtonRoute(Feed.cursor)
+export class FeedNav extends Feed.Handler {}
+
+@SlashRoute('feed')
+export class FeedSlash extends SlashHandler<'feed'> {
+    public async execute(): Promise<void> {
+        await Feed.start(this.event);
+    }
+}

--- a/mock/src/handlers/Leaderboard.ts
+++ b/mock/src/handlers/Leaderboard.ts
@@ -1,0 +1,44 @@
+import { ButtonHandler, ButtonRoute, CustomId, paginate, SlashHandler, SlashRoute } from 'seedcord';
+
+import { LeaderboardCard, LeaderboardControls } from '../components/bundles/Leaderboard';
+
+import type { LeaderboardEntry } from '../components/bundles/Leaderboard';
+import type { ActionRowBuilder, ButtonBuilder, EmbedBuilder } from 'discord.js';
+
+const PER_PAGE = 5;
+const PAGE_BOUND = 999;
+const ENTRY_COUNT = 23;
+const SCORE_STEP = 100;
+
+// the caller defines the cursor here. a plain prev/next never collides, so the slot is unnecessary.
+const Board = new CustomId('lb').int('page', 0, PAGE_BOUND);
+
+const SCORES: LeaderboardEntry[] = Array.from({ length: ENTRY_COUNT }, (_, index) => ({
+    name: `Player ${index + 1}`,
+    score: (ENTRY_COUNT - index) * SCORE_STEP
+}));
+
+// a headless render from the kit paginate() math and the caller's own cursor, without the Paginator.
+function renderBoard(page: number): { embeds: EmbedBuilder[]; components: ActionRowBuilder<ButtonBuilder>[] } {
+    const view = paginate(SCORES, page, PER_PAGE);
+    const controls = new LeaderboardControls(
+        view,
+        Board.encode({ page: Math.max(0, view.page - 1) }),
+        Board.encode({ page: view.page + 1 })
+    );
+    return { embeds: [new LeaderboardCard(view).component], components: [controls.component] };
+}
+
+@SlashRoute('leaderboard')
+export class LeaderboardSlash extends SlashHandler<'leaderboard'> {
+    public async execute(): Promise<void> {
+        await this.event.reply(renderBoard(0));
+    }
+}
+
+@ButtonRoute(Board)
+export class LeaderboardNav extends ButtonHandler<[typeof Board]> {
+    public async execute(): Promise<void> {
+        await this.event.update(renderBoard(this.params.page));
+    }
+}

--- a/mock/src/handlers/Roster.ts
+++ b/mock/src/handlers/Roster.ts
@@ -1,0 +1,21 @@
+import { ArraySource, ButtonRoute, Paginator, SlashHandler, SlashRoute } from 'seedcord';
+
+const MEMBERS = Array.from({ length: 37 }, (_, index) => `Member ${index + 1}`);
+
+// the whole list is in memory, so ArraySource has a real total and shows all five controls.
+export const Roster = new Paginator({
+    prefix: 'roster',
+    source: new ArraySource(() => MEMBERS, { perPage: 8 }),
+    renderItem: (name, index) => `**${index + 1}.** ${name}`,
+    ephemeral: true
+});
+
+@ButtonRoute(Roster.cursor)
+export class RosterNav extends Roster.Handler {}
+
+@SlashRoute('roster')
+export class RosterSlash extends SlashHandler<'roster'> {
+    public async execute(): Promise<void> {
+        await Roster.start(this.event);
+    }
+}

--- a/mock/src/seedcord-gen.d.ts
+++ b/mock/src/seedcord-gen.d.ts
@@ -3,6 +3,7 @@
 
 declare module 'seedcord' {
     interface SlashOptionRegistry {
+        defernotice: {};
         feed: {};
         leaderboard: {};
         maintenance: { notify: { kind: 'user'; required: true }; reason: { kind: 'string'; required: false } };

--- a/mock/src/seedcord-gen.d.ts
+++ b/mock/src/seedcord-gen.d.ts
@@ -3,8 +3,17 @@
 
 declare module 'seedcord' {
     interface SlashOptionRegistry {
+        feed: {};
+        leaderboard: {};
         maintenance: { notify: { kind: 'user'; required: true }; reason: { kind: 'string'; required: false } };
-        probe: { query: { kind: 'string'; required: true; autocomplete: true }; count: { kind: 'integer'; required: false; autocomplete: true }; ratio: { kind: 'number'; required: false; autocomplete: true }; category: { kind: 'string'; required: false; choices: ['books', 'films'] }; exact: { kind: 'boolean'; required: false } };
+        probe: {
+            query: { kind: 'string'; required: true; autocomplete: true };
+            count: { kind: 'integer'; required: false; autocomplete: true };
+            ratio: { kind: 'number'; required: false; autocomplete: true };
+            category: { kind: 'string'; required: false; choices: ['books', 'films'] };
+            exact: { kind: 'boolean'; required: false };
+        };
+        roster: {};
         'test/confirmable/v2': {};
         throw: {};
     }

--- a/mock/src/seedcord-gen.d.ts
+++ b/mock/src/seedcord-gen.d.ts
@@ -7,13 +7,7 @@ declare module 'seedcord' {
         feed: {};
         leaderboard: {};
         maintenance: { notify: { kind: 'user'; required: true }; reason: { kind: 'string'; required: false } };
-        probe: {
-            query: { kind: 'string'; required: true; autocomplete: true };
-            count: { kind: 'integer'; required: false; autocomplete: true };
-            ratio: { kind: 'number'; required: false; autocomplete: true };
-            category: { kind: 'string'; required: false; choices: ['books', 'films'] };
-            exact: { kind: 'boolean'; required: false };
-        };
+        probe: { query: { kind: 'string'; required: true; autocomplete: true }; count: { kind: 'integer'; required: false; autocomplete: true }; ratio: { kind: 'number'; required: false; autocomplete: true }; category: { kind: 'string'; required: false; choices: ['books', 'films'] }; exact: { kind: 'boolean'; required: false } };
         roster: {};
         'test/confirmable/v2': {};
         throw: {};

--- a/packages/errors/src/ErrorCodes.ts
+++ b/packages/errors/src/ErrorCodes.ts
@@ -95,6 +95,10 @@ export enum SeedcordErrorCode {
     PaginationInvalidPerPage = 1801,
     /** A control row was assembled with more than the five buttons Discord allows. */
     PaginationTooManyControls = 1802,
+    /** A control row was assembled with no controls. */
+    PaginationEmptyControls = 1803,
+    /** A control row repeats the same control, which would collide the custom_ids. */
+    PaginationDuplicateControls = 1804,
 
     /** Mongo service class is missing the `@RegisterMongoService` decorator. */
     PluginMongoServiceDecoratorMissing = 2101,

--- a/packages/errors/src/ErrorCodes.ts
+++ b/packages/errors/src/ErrorCodes.ts
@@ -91,6 +91,11 @@ export enum SeedcordErrorCode {
     /** A Cooldown gate was given a duration string that is not a well-formed positive duration. */
     GateInvalidCooldownDuration = 1701,
 
+    /** A paginator source was given a perPage that is not a positive integer. */
+    PaginationInvalidPerPage = 1801,
+    /** A control row was assembled with more than the five buttons Discord allows. */
+    PaginationTooManyControls = 1802,
+
     /** Mongo service class is missing the `@RegisterMongoService` decorator. */
     PluginMongoServiceDecoratorMissing = 2101,
     /** Mongo model class is missing the `@RegisterMongoModel` decorator. */

--- a/packages/errors/src/ErrorMessages.ts
+++ b/packages/errors/src/ErrorMessages.ts
@@ -80,6 +80,11 @@ const messages = {
     [SeedcordErrorCode.GateInvalidCooldownDuration]: (input: string) =>
         `Cooldown duration ${JSON.stringify(input)} is not valid. Pass a number of seconds or a duration string like '30m', '24h', or '500ms'.`,
 
+    [SeedcordErrorCode.PaginationInvalidPerPage]: (perPage: number) =>
+        `perPage must be a positive integer, got ${perPage}.`,
+    [SeedcordErrorCode.PaginationTooManyControls]: (count: number) =>
+        `A control row holds at most 5 buttons, got ${count}.`,
+
     [SeedcordErrorCode.PluginMongoServiceDecoratorMissing]: (className: string) =>
         `Missing @RegisterMongoService on ${className}.`,
     [SeedcordErrorCode.PluginMongoModelDecoratorMissing]: (className: string) =>

--- a/packages/errors/src/ErrorMessages.ts
+++ b/packages/errors/src/ErrorMessages.ts
@@ -84,6 +84,9 @@ const messages = {
         `perPage must be a positive integer, got ${perPage}.`,
     [SeedcordErrorCode.PaginationTooManyControls]: (count: number) =>
         `A control row holds at most 5 buttons, got ${count}.`,
+    [SeedcordErrorCode.PaginationEmptyControls]: () => `A control row must hold at least one control.`,
+    [SeedcordErrorCode.PaginationDuplicateControls]: (key: string) =>
+        `A control row cannot repeat the '${key}' control.`,
 
     [SeedcordErrorCode.PluginMongoServiceDecoratorMissing]: (className: string) =>
         `Missing @RegisterMongoService on ${className}.`,

--- a/packages/kit/src/index.ts
+++ b/packages/kit/src/index.ts
@@ -5,7 +5,6 @@ export { Fault } from '@stops/Fault';
 export { Silence } from '@stops/Silence';
 export { CustomId } from '@customId/CustomId';
 export { paginate } from '@pagination/paginate';
-export { pageCursor, type PageCursor } from '@pagination/cursor';
 export { type PageView } from '@pagination/PageView';
 
 /** Package version */

--- a/packages/kit/src/index.ts
+++ b/packages/kit/src/index.ts
@@ -4,6 +4,9 @@ export { Notice } from '@stops/Notice';
 export { Fault } from '@stops/Fault';
 export { Silence } from '@stops/Silence';
 export { CustomId } from '@customId/CustomId';
+export { paginate } from '@pagination/paginate';
+export { pageCursor, type PageCursor } from '@pagination/cursor';
+export { type PageView } from '@pagination/PageView';
 
 /** Package version */
 export const version = process.env.PACKAGE_VERSION ?? '0.0.0';

--- a/packages/kit/src/internal.index.ts
+++ b/packages/kit/src/internal.index.ts
@@ -1,6 +1,7 @@
 export { setBotColor } from '@src/botColorHolder';
 
 export { prefixOf, decodeFor, type AnyCustomId } from '@customId/CustomId';
+export { PAGE_MAX } from '@pagination/cursor';
 export { ComponentDefsKey, type HasComponentDefs } from '@customId/routing';
 export type { DecodedParams } from '@customId/Field';
 

--- a/packages/kit/src/internal.index.ts
+++ b/packages/kit/src/internal.index.ts
@@ -1,7 +1,7 @@
 export { setBotColor } from '@src/botColorHolder';
 
 export { prefixOf, decodeFor, type AnyCustomId } from '@customId/CustomId';
-export { PAGE_MAX } from '@pagination/cursor';
+export { PAGE_MAX, pageCursor, type PageCursor } from '@pagination/cursor';
 export { ComponentDefsKey, type HasComponentDefs } from '@customId/routing';
 export type { DecodedParams } from '@customId/Field';
 

--- a/packages/kit/src/pagination/PageView.ts
+++ b/packages/kit/src/pagination/PageView.ts
@@ -1,0 +1,15 @@
+/**
+ * One rendered page of a paginated list.
+ *
+ * @typeParam Item - The item type.
+ */
+export interface PageView<Item> {
+    items: Item[];
+    /** Zero-based, already clamped into range. */
+    page: number;
+    perPage: number;
+    /** The total page count, or `undefined` for a cursor source that has no cheap total. */
+    totalPages?: number;
+    hasPrev: boolean;
+    hasNext: boolean;
+}

--- a/packages/kit/src/pagination/cursor.ts
+++ b/packages/kit/src/pagination/cursor.ts
@@ -11,23 +11,13 @@ export const PAGE_MAX = 1_000_000;
 // @internal
 export const SLOT_MAX = 4;
 
-/**
- * A page cursor for a paginator. Use `PageCursor<'bans'>` or extract it from `typeof paginator.cursor`.
- *
- * @typeParam Prefix - The route prefix the dispatcher matches.
- */
+/** Page cursor for a paginator. */
 export type PageCursor<Prefix extends string> = CustomId<
     Prefix,
     { page: CustomIdField<number>; slot: CustomIdField<number> }
 >;
 
-/**
- * Build the page cursor for a paginator. The bounded `page` and `slot` fields encode under Discord's
- * 100-char customId cap.
- *
- * @param prefix - The route prefix the dispatcher matches.
- * @returns A {@link PageCursor} for `prefix`.
- */
+/** Build the page cursor for a paginator. */
 export function pageCursor<Prefix extends string>(prefix: Prefix): PageCursor<Prefix> {
     return new CustomId(prefix).int('page', 0, PAGE_MAX).int('slot', 0, SLOT_MAX);
 }

--- a/packages/kit/src/pagination/cursor.ts
+++ b/packages/kit/src/pagination/cursor.ts
@@ -1,0 +1,33 @@
+import { CustomId } from '@customId/CustomId';
+
+import type { CustomIdField } from '@customId/Field';
+
+// Included in the layout hash so it is fixed per prefix. Reducing it marks every active button as StaleCustomId.
+// @internal
+export const PAGE_MAX = 1_000_000;
+
+// Discord rejects a message with duplicate custom_ids, and two controls can target the same page (first and
+// prev both hit 0), so each control uses a distinct slot.
+// @internal
+export const SLOT_MAX = 4;
+
+/**
+ * A page cursor for a paginator. Use `PageCursor<'bans'>` or extract it from `typeof paginator.cursor`.
+ *
+ * @typeParam Prefix - The route prefix the dispatcher matches.
+ */
+export type PageCursor<Prefix extends string> = CustomId<
+    Prefix,
+    { page: CustomIdField<number>; slot: CustomIdField<number> }
+>;
+
+/**
+ * Build the page cursor for a paginator. The bounded `page` and `slot` fields encode under Discord's
+ * 100-char customId cap.
+ *
+ * @param prefix - The route prefix the dispatcher matches.
+ * @returns A {@link PageCursor} for `prefix`.
+ */
+export function pageCursor<Prefix extends string>(prefix: Prefix): PageCursor<Prefix> {
+    return new CustomId(prefix).int('page', 0, PAGE_MAX).int('slot', 0, SLOT_MAX);
+}

--- a/packages/kit/src/pagination/paginate.ts
+++ b/packages/kit/src/pagination/paginate.ts
@@ -1,0 +1,33 @@
+import { SeedcordErrorCode } from '@seedcord/errors';
+import { SeedcordRangeError } from '@seedcord/errors/internal';
+
+import type { PageView } from './PageView';
+
+/**
+ * Pure page math, usable headless. Clamps `page` into range and slices the window.
+ *
+ * @param items - The full list to page over.
+ * @param page - The requested zero-based page, clamped into `[0, totalPages - 1]`.
+ * @param perPage - The page size. Must be a positive integer.
+ * @returns The sliced {@link PageView}, with `totalPages` always known.
+ * @throws SeedcordRangeError when `perPage` is not a positive integer.
+ */
+export function paginate<Item>(items: readonly Item[], page: number, perPage: number): PageView<Item> {
+    if (!Number.isInteger(perPage) || perPage <= 0) {
+        throw new SeedcordRangeError(SeedcordErrorCode.PaginationInvalidPerPage, [perPage]);
+    }
+
+    const totalPages = Math.max(1, Math.ceil(items.length / perPage));
+    // a headless caller can pass a non-integer or out-of-range page.
+    const clamped = Math.min(Math.max(Math.trunc(page), 0), totalPages - 1);
+    const start = clamped * perPage;
+
+    return {
+        items: items.slice(start, start + perPage),
+        page: clamped,
+        perPage,
+        totalPages,
+        hasPrev: clamped > 0,
+        hasNext: clamped < totalPages - 1
+    };
+}

--- a/packages/kit/tests/pagination/cursor.test.ts
+++ b/packages/kit/tests/pagination/cursor.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+
+import { pageCursor } from '@pagination/cursor';
+
+describe('pageCursor', () => {
+    it('round-trips a page and slot through the wire', () => {
+        const cursor = pageCursor('bans');
+        expect(cursor.prefix).toBe('bans');
+        expect(cursor.decode(cursor.encode({ page: 7, slot: 2 }))).toEqual({ page: 7, slot: 2 });
+    });
+
+    it('packs a large page well under the 100-char wire cap', () => {
+        const cursor = pageCursor('logs');
+        expect(cursor.encode({ page: 4096, slot: 0 }).length).toBeLessThan(20);
+    });
+});

--- a/packages/kit/tests/pagination/paginate.test.ts
+++ b/packages/kit/tests/pagination/paginate.test.ts
@@ -1,0 +1,63 @@
+import { SeedcordRangeError } from '@seedcord/errors/internal';
+import { describe, expect, expectTypeOf, it } from 'vitest';
+
+import { paginate } from '@pagination/paginate';
+
+const items = Array.from({ length: 25 }, (_, i) => i);
+
+describe('paginate', () => {
+    it('slices the requested page and reports the bounds', () => {
+        const view = paginate(items, 0, 10);
+        expect(view.items).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+        expect(view.page).toBe(0);
+        expect(view.perPage).toBe(10);
+        expect(view.totalPages).toBe(3);
+        expect(view.hasPrev).toBe(false);
+        expect(view.hasNext).toBe(true);
+    });
+
+    it('reports the last page as having a previous page and no next', () => {
+        const view = paginate(items, 2, 10);
+        expect(view.items).toEqual([20, 21, 22, 23, 24]);
+        expect(view.hasPrev).toBe(true);
+        expect(view.hasNext).toBe(false);
+    });
+
+    it('clamps an above-range page to the last page', () => {
+        const view = paginate(items, 99, 10);
+        expect(view.page).toBe(2);
+        expect(view.items).toEqual([20, 21, 22, 23, 24]);
+    });
+
+    it('clamps a negative page to the first page', () => {
+        const view = paginate(items, -5, 10);
+        expect(view.page).toBe(0);
+        expect(view.items[0]).toBe(0);
+    });
+
+    it('floors a non-integer page before clamping', () => {
+        const view = paginate(items, 1.7, 10);
+        expect(view.page).toBe(1);
+        expect(view.items).toEqual([10, 11, 12, 13, 14, 15, 16, 17, 18, 19]);
+    });
+
+    it('treats an empty list as a single empty page', () => {
+        const view = paginate([], 0, 10);
+        expect(view.items).toEqual([]);
+        expect(view.page).toBe(0);
+        expect(view.totalPages).toBe(1);
+        expect(view.hasPrev).toBe(false);
+        expect(view.hasNext).toBe(false);
+    });
+
+    it('rejects a non-positive or non-integer perPage', () => {
+        expect(() => paginate(items, 0, 0)).toThrow(SeedcordRangeError);
+        expect(() => paginate(items, 0, -1)).toThrow(SeedcordRangeError);
+        expect(() => paginate(items, 0, 2.5)).toThrow(SeedcordRangeError);
+    });
+
+    it('infers the item type from the input', () => {
+        const view = paginate(['a', 'b', 'c'], 0, 2);
+        expectTypeOf(view.items).toEqualTypeOf<string[]>();
+    });
+});

--- a/packages/kit/tsconfig.json
+++ b/packages/kit/tsconfig.json
@@ -8,6 +8,7 @@
             "@src/*": ["./src/*"],
             "@components/*": ["./src/components/*"],
             "@customId/*": ["./src/customId/*"],
+            "@pagination/*": ["./src/pagination/*"],
             "@stops/*": ["./src/stops/*"]
         },
         "types": ["vite/client"]

--- a/packages/kit/vitest.config.ts
+++ b/packages/kit/vitest.config.ts
@@ -14,6 +14,7 @@ export default mergeConfig(
                 '@src': path.resolve(__dirname, './src'),
                 '@components': path.resolve(__dirname, './src/components'),
                 '@customId': path.resolve(__dirname, './src/customId'),
+                '@pagination': path.resolve(__dirname, './src/pagination'),
                 '@stops': path.resolve(__dirname, './src/stops')
             }
         },

--- a/packages/seedcord/src/bot/ReplySender.ts
+++ b/packages/seedcord/src/bot/ReplySender.ts
@@ -56,15 +56,13 @@ export class ReplySender {
         }
 
         if (this.interaction.deferred) {
-            const message = await this.interaction.followUp(this.replyOptions(response, ephemeral));
-            // a component/modal deferUpdate left @original as the live source message, leave it untouched.
-            // a slash deferReply left a throwaway "thinking" placeholder, clear it so the user sees one
-            // message. editReply cannot turn a classic "thinking" defer into ComponentsV2 (Discord rejects
-            // it with 50035), so this follows up and deletes instead.
-            if (!this.interaction.isMessageComponent() && !this.interaction.isModalSubmit()) {
-                await this.clearStaleDefer();
+            // ephemeral is null only after deferUpdate, where @original is the live source message, so follow
+            // up to avoid overwriting it. deferReply set ephemeral to a boolean over a throwaway placeholder,
+            // so editReply upgrades it in place.
+            if (this.interaction.ephemeral === null) {
+                return await this.interaction.followUp(this.replyOptions(response, ephemeral));
             }
-            return message;
+            return await this.interaction.editReply(this.editBody(response));
         }
 
         await this.interaction.reply(this.replyOptions(response, ephemeral));
@@ -88,14 +86,6 @@ export class ReplySender {
             ...(response.allowedMentions && { allowedMentions: response.allowedMentions }),
             ...(response.files && { files: response.files })
         };
-    }
-
-    private async clearStaleDefer(): Promise<void> {
-        try {
-            await this.interaction.deleteReply();
-        } catch (error) {
-            this.logSwallowed('clear stale defer', error);
-        }
     }
 
     private logSwallowed(action: string, error: unknown): void {

--- a/packages/seedcord/src/bot/decorators/Interactions.ts
+++ b/packages/seedcord/src/bot/decorators/Interactions.ts
@@ -312,7 +312,7 @@ export type SelectMenuInteractionFor<
  * @example
  * ```typescript
  * \@SelectMenuRoute(SelectMenuKind.User, AssignId)
- * class AssignSelect extends SelectHandler<SelectMenuKind.User, [typeof AssignId]> {
+ * class AssignSelect extends SelectMenuHandler<SelectMenuKind.User, [typeof AssignId]> {
  *   // handles user select menus minted from AssignId
  * }
  * ```

--- a/packages/seedcord/src/handlers/index.ts
+++ b/packages/seedcord/src/handlers/index.ts
@@ -5,7 +5,7 @@ export {
     InteractionHandler,
     InteractionMiddleware,
     ModalHandler,
-    SelectHandler,
+    SelectMenuHandler,
     SlashHandler
 } from './interaction';
 export { EventHandler, EventMiddleware } from './event';

--- a/packages/seedcord/src/handlers/interaction/InteractionHandler.ts
+++ b/packages/seedcord/src/handlers/interaction/InteractionHandler.ts
@@ -7,7 +7,7 @@ import type { Core } from '@interfaces/Core';
  * Shared base the typed interaction handlers extend.
  *
  * Not a public entry point. You should be using {@link SlashHandler}, {@link ButtonHandler}, {@link ModalHandler},
- * or {@link SelectHandler} instead. This class only carries the repliable-event plumbing those bases share,
+ * or {@link SelectMenuHandler} instead. This class only carries the repliable-event plumbing those bases share,
  * so DO NOT use it directly.
  *
  * @typeParam Repliable - The interaction type this handler processes

--- a/packages/seedcord/src/handlers/interaction/components/ComponentHandler.ts
+++ b/packages/seedcord/src/handlers/interaction/components/ComponentHandler.ts
@@ -25,7 +25,7 @@ type MatchArms<Defs extends readonly AnyCustomId[], Ret> = {
 /**
  * Shared base the customId-routed component handlers extend.
  *
- * Not a public entry point. You should be using {@link ButtonHandler}, {@link SelectHandler}, or
+ * Not a public entry point. You should be using {@link ButtonHandler}, {@link SelectMenuHandler}, or
  * {@link ModalHandler} instead. This class only carries the customId decode and route-matching plumbing
  * those bases share, so DO NOT use it directly.
  *

--- a/packages/seedcord/src/handlers/interaction/components/SelectMenuHandler.ts
+++ b/packages/seedcord/src/handlers/interaction/components/SelectMenuHandler.ts
@@ -18,7 +18,7 @@ import type { CacheType } from 'discord.js';
  * @example
  * ```ts
  * \@SelectMenuRoute(SelectMenuKind.User, AssignId)
- * class AssignSelect extends SelectHandler<SelectMenuKind.User, [typeof AssignId]> {
+ * class AssignSelect extends SelectMenuHandler<SelectMenuKind.User, [typeof AssignId]> {
  *     async execute() {
  *         const { roleId } = this.params;
  *         await this.event.reply(`assigning ${this.event.values.length} member(s) to <@&${roleId}>`);
@@ -26,7 +26,7 @@ import type { CacheType } from 'discord.js';
  * }
  * ```
  */
-export abstract class SelectHandler<
+export abstract class SelectMenuHandler<
     Kind extends SelectMenuKind,
     Defs extends readonly AnyCustomId[],
     Cache extends CacheType = 'cached'

--- a/packages/seedcord/src/handlers/interaction/components/index.ts
+++ b/packages/seedcord/src/handlers/interaction/components/index.ts
@@ -1,3 +1,3 @@
 export { ButtonHandler } from './ButtonHandler';
 export { ModalHandler } from './ModalHandler';
-export { SelectHandler } from './SelectHandler';
+export { SelectMenuHandler } from './SelectMenuHandler';

--- a/packages/seedcord/src/index.ts
+++ b/packages/seedcord/src/index.ts
@@ -28,6 +28,9 @@ export * from '@interfaces/index';
 // Handlers exports
 export * from '@handlers/index';
 
+// Pagination exports
+export * from '@pagination/index';
+
 // Inputs exports
 export type * from '@inputs/index';
 

--- a/packages/seedcord/src/pagination/PageContext.ts
+++ b/packages/seedcord/src/pagination/PageContext.ts
@@ -1,0 +1,17 @@
+import type { Repliables } from '@handlers/BaseHandler';
+import type { Core } from '@interfaces/Core';
+import type { Guild, User } from 'discord.js';
+
+/**
+ * The context passed to a source loader. In a DM `guild` is `null` and `user` is still present.
+ */
+export interface PageContext {
+    /** The interaction that triggered this load (a command or a nav click). */
+    interaction: Repliables;
+    /** The acting user, always present. */
+    user: User;
+    /** The guild, or `null` in a DM. */
+    guild: Guild | null;
+    /** The framework core, passed only when a source requires framework services. */
+    core?: Core;
+}

--- a/packages/seedcord/src/pagination/Paginator.ts
+++ b/packages/seedcord/src/pagination/Paginator.ts
@@ -1,0 +1,94 @@
+import { pageCursor } from '@seedcord/kit';
+
+import { ReplySender } from '@bot/ReplySender';
+import { ButtonHandler } from '@handlers/interaction/components';
+
+import { renderPage } from './render';
+
+import type { PageContext } from './PageContext';
+import type { ItemRender, PageRender } from './render';
+import type { PageSource } from './sources';
+import type { Repliables } from '@handlers/BaseHandler';
+import type { Core } from '@interfaces/Core';
+import type { PageCursor } from '@seedcord/kit';
+import type { ReplyResponse } from '@seedcord/types';
+import type { ButtonInteraction, Message } from 'discord.js';
+
+interface PaginatorConfig<Item, Prefix extends string> {
+    /** The route prefix used to build the page cursor on the nav buttons. */
+    prefix: Prefix;
+    /** Where the page data comes from. */
+    source: PageSource<Item>;
+    /** Render one item, `index` is its absolute position across pages. Ignored when `render` is set. */
+    renderItem?: ItemRender<Item>;
+    /** Take over the whole page tree. Receives the page data and the controls factory. */
+    render?: PageRender<Item>;
+    /** Whether the first page is ephemeral. {@default false} */
+    ephemeral?: boolean;
+}
+
+// `& { execute }` concretizes the abstract execute so the empty `extends Bans.Handler {}` stays concrete
+// (no TS2515) and a concrete Nav assigns with no cast.
+type PaginatorHandlerCtor<Prefix extends string> = new (
+    event: ButtonInteraction<'cached'>,
+    core: Core
+) => ButtonHandler<[PageCursor<Prefix>]> & { execute(): Promise<void> };
+
+function contextOf(interaction: Repliables, core?: Core): PageContext {
+    return { interaction, user: interaction.user, guild: interaction.guild, ...(core && { core }) };
+}
+
+/**
+ * A restart-proof paginator. Each nav button's customId encodes its full target page, so clicks are
+ * idempotent and survive a restart. A persistent `@ButtonRoute` on `Handler` dispatches the clicks.
+ *
+ * @typeParam Item - The item type, inferred from the source.
+ * @typeParam Prefix - The route prefix, inferred from `config.prefix`.
+ *
+ * @example
+ * ```ts
+ * export const Bans = new Paginator({
+ *     prefix: 'bans',
+ *     source: new ArraySource((ctx) => ctx.guild.bans.fetch().then((b) => [...b.values()]), { perPage: 10 }),
+ *     renderItem: (ban) => ban.user.tag
+ * });
+ *
+ * \@ButtonRoute(Bans.cursor)
+ * export class BansNav extends Bans.Handler {}
+ * ```
+ */
+export class Paginator<Item, const Prefix extends string> {
+    /** The page cursor, pass it to your `@ButtonRoute`. */
+    public readonly cursor: PageCursor<Prefix>;
+    /** The nav handler base. Extend it with an empty body and decorate it, `@ButtonRoute(p.cursor)`. */
+    public readonly Handler: PaginatorHandlerCtor<Prefix>;
+
+    private readonly config: PaginatorConfig<Item, Prefix>;
+
+    constructor(config: PaginatorConfig<Item, Prefix>) {
+        this.cursor = pageCursor(config.prefix);
+        this.config = config;
+
+        // an arrow captures the paginator lexically so Nav.execute can reach it without aliasing `this`.
+        const renderPage = (ctx: PageContext, n: number): Promise<ReplyResponse> => this.page(ctx, n);
+        this.Handler = class Nav extends ButtonHandler<[PageCursor<Prefix>]> {
+            async execute(): Promise<void> {
+                await this.event.deferUpdate();
+                const response = await renderPage(contextOf(this.event, this.core), this.params.page);
+                await new ReplySender(this.event).edit(this.event.message, response);
+            }
+        };
+    }
+
+    /** Render page 0 and send it, picking reply or followUp from the interaction's state. */
+    async start(interaction: Repliables, core?: Core): Promise<Message | undefined> {
+        const response = await this.page(contextOf(interaction, core), 0);
+        return new ReplySender(interaction).send(response, this.config.ephemeral ?? false);
+    }
+
+    /** Render a page as a {@link ReplyResponse}. To post it elsewhere, add `flags: MessageFlags.IsComponentsV2`. */
+    async page(ctx: PageContext, n: number): Promise<ReplyResponse> {
+        const view = await this.config.source.page(ctx, n);
+        return renderPage(view, this.cursor, this.config);
+    }
+}

--- a/packages/seedcord/src/pagination/Paginator.ts
+++ b/packages/seedcord/src/pagination/Paginator.ts
@@ -70,11 +70,11 @@ export class Paginator<Item, const Prefix extends string> {
         this.config = config;
 
         // an arrow captures the paginator lexically so Nav.execute can reach it without aliasing `this`.
-        const renderPage = (ctx: PageContext, n: number): Promise<ReplyResponse> => this.page(ctx, n);
+        const loadPage = (ctx: PageContext, n: number): Promise<ReplyResponse> => this.page(ctx, n);
         this.Handler = class Nav extends ButtonHandler<[PageCursor<Prefix>]> {
             async execute(): Promise<void> {
                 await this.event.deferUpdate();
-                const response = await renderPage(contextOf(this.event, this.core), this.params.page);
+                const response = await loadPage(contextOf(this.event, this.core), this.params.page);
                 await new ReplySender(this.event).edit(this.event.message, response);
             }
         };

--- a/packages/seedcord/src/pagination/Paginator.ts
+++ b/packages/seedcord/src/pagination/Paginator.ts
@@ -1,4 +1,4 @@
-import { pageCursor } from '@seedcord/kit';
+import { pageCursor } from '@seedcord/kit/internal';
 
 import { ReplySender } from '@bot/ReplySender';
 import { ButtonHandler } from '@handlers/interaction/components';
@@ -10,7 +10,7 @@ import type { ItemRender, PageRender } from './render';
 import type { PageSource } from './sources';
 import type { Repliables } from '@handlers/BaseHandler';
 import type { Core } from '@interfaces/Core';
-import type { PageCursor } from '@seedcord/kit';
+import type { PageCursor } from '@seedcord/kit/internal';
 import type { ReplyResponse } from '@seedcord/types';
 import type { ButtonInteraction, Message } from 'discord.js';
 

--- a/packages/seedcord/src/pagination/controls.ts
+++ b/packages/seedcord/src/pagination/controls.ts
@@ -1,9 +1,9 @@
 import { SeedcordErrorCode } from '@seedcord/errors';
 import { SeedcordRangeError } from '@seedcord/errors/internal';
-import { PAGE_MAX } from '@seedcord/kit/internal';
+import { PAGE_MAX, type PageCursor } from '@seedcord/kit/internal';
 import { ActionRowBuilder, ButtonBuilder, ButtonStyle } from 'discord.js';
 
-import type { PageCursor, PageView } from '@seedcord/kit';
+import type { PageView } from '@seedcord/kit';
 import type { ComponentEmojiResolvable } from 'discord.js';
 
 /** The five built-in nav controls. */

--- a/packages/seedcord/src/pagination/controls.ts
+++ b/packages/seedcord/src/pagination/controls.ts
@@ -1,5 +1,5 @@
 import { SeedcordErrorCode } from '@seedcord/errors';
-import { SeedcordRangeError } from '@seedcord/errors/internal';
+import { SeedcordRangeError, SeedcordTypeError } from '@seedcord/errors/internal';
 import { PAGE_MAX, type PageCursor } from '@seedcord/kit/internal';
 import { ActionRowBuilder, ButtonBuilder, ButtonStyle } from 'discord.js';
 
@@ -26,7 +26,10 @@ export interface PaginatorControls {
      * state. Call only cosmetic setters on it, a `setCustomId` or `setStyle(Link)` un-routes it.
      */
     button(key: ControlKey, cosmetics?: ControlCosmetics): ButtonBuilder;
-    /** Assemble an action row of the chosen controls, in order. Rejects more than five. */
+    /**
+     * Assemble an action row of the chosen controls, in order. Throws on an empty set, more than five
+     * controls, or a duplicate.
+     */
     row(...keys: ControlKey[]): ActionRowBuilder<ButtonBuilder>;
 }
 
@@ -57,22 +60,7 @@ export class Controls implements PaginatorControls {
     ) {}
 
     button(key: ControlKey, cosmetics?: ControlCosmetics): ButtonBuilder {
-        const { page, totalPages, hasPrev, hasNext } = this.view;
-        const knownTotal = totalPages !== undefined;
-        const target = {
-            first: 0,
-            prev: page - 1,
-            indicator: page,
-            next: page + 1,
-            last: knownTotal ? totalPages - 1 : page
-        }[key];
-        const disabled = {
-            first: !hasPrev,
-            prev: !hasPrev,
-            indicator: true,
-            next: !hasNext,
-            last: !hasNext || !knownTotal
-        }[key];
+        const { target, disabled } = this.navState(key);
 
         // an emoji with no explicit label makes an icon-only button. the indicator always shows its page text.
         const defaultLabel = key === 'indicator' ? this.indicatorText() : DEFAULT_LABEL[key];
@@ -88,9 +76,39 @@ export class Controls implements PaginatorControls {
         return button;
     }
 
+    private navState(key: ControlKey): { target: number; disabled: boolean } {
+        const { page, totalPages, hasPrev, hasNext } = this.view;
+        const knownTotal = totalPages !== undefined;
+        const target = {
+            first: 0,
+            prev: page - 1,
+            indicator: page,
+            next: page + 1,
+            last: knownTotal ? totalPages - 1 : page
+        }[key];
+        // past PAGE_MAX the encoded page would clamp to a wrong one, so next and last are disabled.
+        const disabled = {
+            first: !hasPrev,
+            prev: !hasPrev,
+            indicator: true,
+            next: !hasNext || page + 1 > PAGE_MAX,
+            last: !hasNext || !knownTotal || totalPages - 1 > PAGE_MAX
+        }[key];
+        return { target, disabled };
+    }
+
     row(...keys: ControlKey[]): ActionRowBuilder<ButtonBuilder> {
+        if (keys.length < 1) {
+            throw new SeedcordRangeError(SeedcordErrorCode.PaginationEmptyControls);
+        }
         if (keys.length > MAX_BUTTONS_PER_ROW) {
             throw new SeedcordRangeError(SeedcordErrorCode.PaginationTooManyControls, [keys.length]);
+        }
+        // repeating a control reuses its slot and page, so the custom_ids collide and Discord rejects the message.
+        const seen = new Set<ControlKey>();
+        for (const key of keys) {
+            if (seen.has(key)) throw new SeedcordTypeError(SeedcordErrorCode.PaginationDuplicateControls, [key]);
+            seen.add(key);
         }
         return new ActionRowBuilder<ButtonBuilder>().addComponents(keys.map((key) => this.button(key)));
     }

--- a/packages/seedcord/src/pagination/controls.ts
+++ b/packages/seedcord/src/pagination/controls.ts
@@ -1,0 +1,102 @@
+import { SeedcordErrorCode } from '@seedcord/errors';
+import { SeedcordRangeError } from '@seedcord/errors/internal';
+import { PAGE_MAX } from '@seedcord/kit/internal';
+import { ActionRowBuilder, ButtonBuilder, ButtonStyle } from 'discord.js';
+
+import type { PageCursor, PageView } from '@seedcord/kit';
+import type { ComponentEmojiResolvable } from 'discord.js';
+
+/** The five built-in nav controls. */
+export type ControlKey = 'first' | 'prev' | 'indicator' | 'next' | 'last';
+
+// the button styles with a custom_id. Link and Premium have none, so they would un-route a control.
+type CustomIdStyle = ButtonStyle.Primary | ButtonStyle.Secondary | ButtonStyle.Success | ButtonStyle.Danger;
+
+/** Cosmetic overrides for a control button. `style` excludes Link and Premium, which would un-route it. */
+export interface ControlCosmetics {
+    label?: string;
+    style?: CustomIdStyle;
+    emoji?: ComponentEmojiResolvable;
+}
+
+/** The controls passed to `render`. Each accessor returns a fresh builder stamped with its target page. */
+export interface PaginatorControls {
+    /**
+     * A fresh `ButtonBuilder` for one control, already stamped with its target page and disabled-at-bounds
+     * state. Call only cosmetic setters on it, a `setCustomId` or `setStyle(Link)` un-routes it.
+     */
+    button(key: ControlKey, cosmetics?: ControlCosmetics): ButtonBuilder;
+    /** Assemble an action row of the chosen controls, in order. Rejects more than five. */
+    row(...keys: ControlKey[]): ActionRowBuilder<ButtonBuilder>;
+}
+
+const DEFAULT_LABEL: Record<ControlKey, string> = {
+    first: 'First',
+    prev: 'Prev',
+    indicator: '',
+    next: 'Next',
+    last: 'Last'
+};
+
+// a distinct slot per control keeps two controls with the same target page from sharing an id, within
+// the cursor's SLOT_MAX (0-4).
+const CONTROL_SLOT: Record<ControlKey, number> = {
+    first: 0,
+    prev: 1,
+    indicator: 2,
+    next: 3,
+    last: 4
+};
+
+const MAX_BUTTONS_PER_ROW = 5;
+
+export class Controls implements PaginatorControls {
+    constructor(
+        private readonly cursor: PageCursor<string>,
+        private readonly view: PageView<unknown>
+    ) {}
+
+    button(key: ControlKey, cosmetics?: ControlCosmetics): ButtonBuilder {
+        const { page, totalPages, hasPrev, hasNext } = this.view;
+        const knownTotal = totalPages !== undefined;
+        const target = {
+            first: 0,
+            prev: page - 1,
+            indicator: page,
+            next: page + 1,
+            last: knownTotal ? totalPages - 1 : page
+        }[key];
+        const disabled = {
+            first: !hasPrev,
+            prev: !hasPrev,
+            indicator: true,
+            next: !hasNext,
+            last: !hasNext || !knownTotal
+        }[key];
+
+        // an emoji with no explicit label makes an icon-only button. the indicator always shows its page text.
+        const defaultLabel = key === 'indicator' ? this.indicatorText() : DEFAULT_LABEL[key];
+        const label = cosmetics?.label ?? (key === 'indicator' || !cosmetics?.emoji ? defaultLabel : undefined);
+
+        const button = new ButtonBuilder()
+            // clamp to the cursor's [0, PAGE_MAX] bound, an enormous list could push last/next past it and encode throws.
+            .setCustomId(this.cursor.encode({ page: Math.min(Math.max(0, target), PAGE_MAX), slot: CONTROL_SLOT[key] }))
+            .setStyle(cosmetics?.style ?? ButtonStyle.Secondary)
+            .setDisabled(disabled);
+        if (label !== undefined) button.setLabel(label);
+        if (cosmetics?.emoji) button.setEmoji(cosmetics.emoji);
+        return button;
+    }
+
+    row(...keys: ControlKey[]): ActionRowBuilder<ButtonBuilder> {
+        if (keys.length > MAX_BUTTONS_PER_ROW) {
+            throw new SeedcordRangeError(SeedcordErrorCode.PaginationTooManyControls, [keys.length]);
+        }
+        return new ActionRowBuilder<ButtonBuilder>().addComponents(keys.map((key) => this.button(key)));
+    }
+
+    private indicatorText(): string {
+        const { page, totalPages } = this.view;
+        return totalPages === undefined ? `Page ${page + 1}` : `Page ${page + 1} of ${totalPages}`;
+    }
+}

--- a/packages/seedcord/src/pagination/index.ts
+++ b/packages/seedcord/src/pagination/index.ts
@@ -1,0 +1,7 @@
+export { Paginator } from './Paginator';
+export { ArraySource, CursorSource } from './sources';
+
+export type { PageContext } from './PageContext';
+export type { PageSource } from './sources';
+export type { Renderable, ItemRender, PageRender } from './render';
+export type { PaginatorControls, ControlKey, ControlCosmetics } from './controls';

--- a/packages/seedcord/src/pagination/index.ts
+++ b/packages/seedcord/src/pagination/index.ts
@@ -1,7 +1,4 @@
 export { Paginator } from './Paginator';
 export { ArraySource, CursorSource } from './sources';
 
-export type { PageContext } from './PageContext';
-export type { PageSource } from './sources';
-export type { Renderable, ItemRender, PageRender } from './render';
-export type { PaginatorControls, ControlKey, ControlCosmetics } from './controls';
+export type { PaginatorControls } from './controls';

--- a/packages/seedcord/src/pagination/render.ts
+++ b/packages/seedcord/src/pagination/render.ts
@@ -1,0 +1,69 @@
+import { BuilderComponent } from '@seedcord/kit';
+import { TextDisplayBuilder } from 'discord.js';
+
+import { Controls } from './controls';
+
+import type { ControlKey, PaginatorControls } from './controls';
+import type { PageCursor, PageView } from '@seedcord/kit';
+import type { ReplyResponse, V2Component } from '@seedcord/types';
+import type { ButtonBuilder, ActionRowBuilder } from 'discord.js';
+
+/** What `renderItem` returns for one item, a text line or a section. */
+export type ItemRender<Item> = (item: Item, index: number) => string | BuilderComponent<'section'>;
+
+/** What the V2 reply can be built from. Each arm is normalized into a {@link ReplyResponse}. */
+export type Renderable = string | V2Component[] | ReplyResponse;
+
+/** A full-page render override, handed the page data and the controls factory. */
+export type PageRender<Item> = (view: PageView<Item>, controls: PaginatorControls) => Renderable;
+
+// subclassed because BuilderComponent.instance is protected, so the assembly has to happen inside.
+class PageContainer<Item> extends BuilderComponent<'container'> {
+    constructor(view: PageView<Item>, renderItem: ItemRender<Item>, controlRow: ActionRowBuilder<ButtonBuilder>) {
+        super('container');
+        const base = view.page * view.perPage;
+        let lines: string[] = [];
+        const flush = (): void => {
+            if (lines.length === 0) return;
+            this.instance.addTextDisplayComponents(new TextDisplayBuilder().setContent(lines.join('\n')));
+            lines = [];
+        };
+        view.items.forEach((item, offset) => {
+            const rendered = renderItem(item, base + offset);
+            if (typeof rendered === 'string') {
+                lines.push(rendered);
+                return;
+            }
+            flush();
+            this.instance.addSectionComponents(rendered.component);
+        });
+        flush();
+        this.instance.addActionRowComponents(controlRow);
+    }
+}
+
+function toReplyResponse(renderable: Renderable): ReplyResponse {
+    if (typeof renderable === 'string') return { components: [new TextDisplayBuilder().setContent(renderable)] };
+    if (Array.isArray(renderable)) return { components: renderable };
+    return renderable;
+}
+
+const ARRAY_KEYS: ControlKey[] = ['first', 'prev', 'indicator', 'next', 'last'];
+const CURSOR_KEYS: ControlKey[] = ['prev', 'indicator', 'next'];
+
+/**
+ * Build a page's V2 reply. A `render` override builds the whole tree, otherwise the default container lists
+ * the items and appends the controls (all five for a known total, prev/indicator/next for a cursor source).
+ */
+export function renderPage<Item>(
+    view: PageView<Item>,
+    cursor: PageCursor<string>,
+    config: { renderItem?: ItemRender<Item>; render?: PageRender<Item> }
+): ReplyResponse {
+    const controls = new Controls(cursor, view);
+    if (config.render) return toReplyResponse(config.render(view, controls));
+
+    const renderItem = config.renderItem ?? ((item: Item): string => String(item));
+    const row = controls.row(...(view.totalPages === undefined ? CURSOR_KEYS : ARRAY_KEYS));
+    return { components: [new PageContainer(view, renderItem, row).component] };
+}

--- a/packages/seedcord/src/pagination/render.ts
+++ b/packages/seedcord/src/pagination/render.ts
@@ -4,7 +4,8 @@ import { TextDisplayBuilder } from 'discord.js';
 import { Controls } from './controls';
 
 import type { ControlKey, PaginatorControls } from './controls';
-import type { PageCursor, PageView } from '@seedcord/kit';
+import type { PageView } from '@seedcord/kit';
+import type { PageCursor } from '@seedcord/kit/internal';
 import type { ReplyResponse, V2Component } from '@seedcord/types';
 import type { ButtonBuilder, ActionRowBuilder } from 'discord.js';
 

--- a/packages/seedcord/src/pagination/sources.ts
+++ b/packages/seedcord/src/pagination/sources.ts
@@ -32,6 +32,9 @@ export class ArraySource<Item> implements PageSource<Item> {
         opts?: { perPage?: number }
     ) {
         this.perPage = opts?.perPage ?? DEFAULT_PER_PAGE;
+        if (!Number.isInteger(this.perPage) || this.perPage <= 0) {
+            throw new SeedcordRangeError(SeedcordErrorCode.PaginationInvalidPerPage, [this.perPage]);
+        }
     }
 
     async page(ctx: PageContext, n: number): Promise<PageView<Item>> {

--- a/packages/seedcord/src/pagination/sources.ts
+++ b/packages/seedcord/src/pagination/sources.ts
@@ -1,0 +1,67 @@
+import { paginate } from '@seedcord/kit';
+
+import type { PageContext } from './PageContext';
+import type { PageView } from '@seedcord/kit';
+import type { Promisable } from 'type-fest';
+
+const DEFAULT_PER_PAGE = 10;
+
+/**
+ * The one method a paginator calls on a source, once per click. Implement it to supply a custom source.
+ *
+ * @typeParam Item - The item type the source pages over.
+ */
+export interface PageSource<Item> {
+    page(ctx: PageContext, n: number): Promise<PageView<Item>>;
+}
+
+/**
+ * A source for a bounded list you can load whole. It loads the full list on every click, then slices the
+ * page via {@link paginate}, so the real total is known (a real last button, "Page X of Y"). Cache inside
+ * your loader if the load is expensive.
+ *
+ * @typeParam Item - The item type, inferred from the loader's return.
+ */
+export class ArraySource<Item> implements PageSource<Item> {
+    private readonly perPage: number;
+
+    constructor(
+        private readonly load: (ctx: PageContext) => Promisable<readonly Item[]>,
+        opts?: { perPage?: number }
+    ) {
+        this.perPage = opts?.perPage ?? DEFAULT_PER_PAGE;
+    }
+
+    async page(ctx: PageContext, n: number): Promise<PageView<Item>> {
+        return paginate(await this.load(ctx), n, this.perPage);
+    }
+}
+
+/**
+ * A source for a large or unknown-length set you fetch one page at a time (SQL LIMIT/OFFSET, a paged API).
+ * The fetcher receives the page index and the page size and reports whether a next page exists. A cursor
+ * source has no cheap total, so `totalPages` is undefined, the last button is omitted, and the indicator
+ * reads "Page X".
+ *
+ * @typeParam Item - The item type, inferred from the fetcher's slice.
+ */
+export class CursorSource<Item> implements PageSource<Item> {
+    private readonly perPage: number;
+
+    constructor(
+        private readonly fetch: (
+            ctx: PageContext,
+            page: number,
+            perPage: number
+        ) => Promisable<{ items: readonly Item[]; hasNext: boolean }>,
+        opts?: { perPage?: number }
+    ) {
+        this.perPage = opts?.perPage ?? DEFAULT_PER_PAGE;
+    }
+
+    async page(ctx: PageContext, n: number): Promise<PageView<Item>> {
+        const page = Math.max(0, Math.trunc(n));
+        const { items, hasNext } = await this.fetch(ctx, page, this.perPage);
+        return { items: [...items], page, perPage: this.perPage, hasPrev: page > 0, hasNext };
+    }
+}

--- a/packages/seedcord/src/pagination/sources.ts
+++ b/packages/seedcord/src/pagination/sources.ts
@@ -1,3 +1,5 @@
+import { SeedcordErrorCode } from '@seedcord/errors';
+import { SeedcordRangeError } from '@seedcord/errors/internal';
 import { paginate } from '@seedcord/kit';
 
 import type { PageContext } from './PageContext';
@@ -57,6 +59,9 @@ export class CursorSource<Item> implements PageSource<Item> {
         opts?: { perPage?: number }
     ) {
         this.perPage = opts?.perPage ?? DEFAULT_PER_PAGE;
+        if (!Number.isInteger(this.perPage) || this.perPage <= 0) {
+            throw new SeedcordRangeError(SeedcordErrorCode.PaginationInvalidPerPage, [this.perPage]);
+        }
     }
 
     async page(ctx: PageContext, n: number): Promise<PageView<Item>> {

--- a/packages/seedcord/tests/ReplySender.test.ts
+++ b/packages/seedcord/tests/ReplySender.test.ts
@@ -16,10 +16,9 @@ function mockInteraction() {
         editReply: vi.fn().mockResolvedValue(sentMessage),
         followUp: vi.fn().mockResolvedValue(sentMessage),
         deleteReply: vi.fn().mockResolvedValue(undefined),
-        isMessageComponent: vi.fn().mockReturnValue(false),
-        isModalSubmit: vi.fn().mockReturnValue(false),
         deferred: false,
-        replied: false
+        replied: false,
+        ephemeral: null as boolean | null
     };
 }
 
@@ -58,14 +57,27 @@ describe('ReplySender', () => {
         expect(mock.followUp).not.toHaveBeenCalled();
     });
 
-    it('follows up and clears the stale thinking defer on a deferred slash interaction', async () => {
-        // editReply cannot turn a slash deferReply's "thinking" placeholder into a ComponentsV2 message
-        // (50035), so the sender must follow up fresh and delete the placeholder instead of editing.
+    it('edits the deferReply placeholder into a components-v2 reply', async () => {
+        // deferReply leaves ephemeral a boolean (deferUpdate leaves it null), so editReply upgrades the
+        // throwaway placeholder in place with the V2 flag.
         mock.deferred = true;
+        mock.ephemeral = false;
         await senderFor(mock).send(reply);
-        expect(mock.followUp).toHaveBeenCalledWith(expect.objectContaining({ flags: V2_EPHEMERAL }));
-        expect(mock.deleteReply).toHaveBeenCalledTimes(1);
-        expect(mock.editReply).not.toHaveBeenCalled();
+        expect(mock.editReply).toHaveBeenCalledWith(
+            expect.objectContaining({ components: reply.components, flags: MessageFlags.IsComponentsV2 })
+        );
+        expect(mock.followUp).not.toHaveBeenCalled();
+        expect(mock.deleteReply).not.toHaveBeenCalled();
+    });
+
+    it('keeps the defer ephemerality on a deferReply edit, ignoring the ephemeral argument', async () => {
+        // editReply cannot change ephemerality (Discord fixes it at defer time), so the edit body carries
+        // only the V2 flag and the send() ephemeral argument has no effect on a deferred interaction.
+        mock.deferred = true;
+        mock.ephemeral = true;
+        await senderFor(mock).send(reply, true);
+        const body = mock.editReply.mock.calls[0]?.[0] as { flags: number };
+        expect(body.flags).toBe(MessageFlags.IsComponentsV2);
     });
 
     it('follows up on an already-replied interaction', async () => {
@@ -76,11 +88,11 @@ describe('ReplySender', () => {
         expect(mock.editReply).not.toHaveBeenCalled();
     });
 
-    it('follows up without touching the source message of a deferred component interaction', async () => {
-        // a button/select deferUpdate() leaves @original pointing at the live source message, so editReply
-        // would overwrite it and deleteReply would destroy it.
+    it('follows up on a deferUpdate, leaving the source message untouched', async () => {
+        // deferUpdate leaves ephemeral null and @original pointing at the live source message, so editing
+        // would overwrite it. a fresh follow-up is the non-destructive response.
         mock.deferred = true;
-        mock.isMessageComponent.mockReturnValue(true);
+        mock.ephemeral = null;
 
         await senderFor(mock).send(reply);
 

--- a/packages/seedcord/tests/bot/gates/gated.test.ts
+++ b/packages/seedcord/tests/bot/gates/gated.test.ts
@@ -8,7 +8,7 @@ import { ButtonRoute, ContextMenuRoute, ModalRoute, SelectMenuRoute, SelectMenuK
 import { and, defineGate, or } from '@bot/gates';
 import { EventHandler } from '@handlers/event';
 import { AutocompleteHandler } from '@handlers/interaction/AutocompleteHandler';
-import { ButtonHandler, ModalHandler, SelectHandler } from '@handlers/interaction/components';
+import { ButtonHandler, ModalHandler, SelectMenuHandler } from '@handlers/interaction/components';
 import { ContextMenuHandler } from '@handlers/interaction/ContextMenuHandler';
 import { SlashHandler } from '@handlers/interaction/SlashHandler';
 import { GatedMetadataKey } from '@src/metadataKeys';
@@ -389,7 +389,7 @@ describe('@Gated kind coverage', () => {
     it('accepts a user-select gate on a user-select handler', () => {
         @Gated(UserSelectGate)
         @SelectMenuRoute(SelectMenuKind.User, SelectProbeId)
-        class Handler extends SelectHandler<SelectMenuKind.User, [typeof SelectProbeId]> {
+        class Handler extends SelectMenuHandler<SelectMenuKind.User, [typeof SelectProbeId]> {
             async execute(): Promise<void> {
                 await Promise.resolve();
             }
@@ -452,7 +452,7 @@ describe('@Gated kind coverage', () => {
         // @ts-expect-error the two select kinds do not interchange
         @Gated(UserSelectGate)
         @SelectMenuRoute(SelectMenuKind.String, SelectProbeId)
-        class Handler extends SelectHandler<SelectMenuKind.String, [typeof SelectProbeId]> {
+        class Handler extends SelectMenuHandler<SelectMenuKind.String, [typeof SelectProbeId]> {
             async execute(): Promise<void> {
                 await Promise.resolve();
             }

--- a/packages/seedcord/tests/customId/handlers.test.ts
+++ b/packages/seedcord/tests/customId/handlers.test.ts
@@ -2,7 +2,7 @@ import { CustomId, Notice } from '@seedcord/kit';
 import { describe, expect, it } from 'vitest';
 
 import { ButtonRoute, ModalRoute, SelectMenuRoute, SelectMenuKind } from '@bDecorators/Interactions';
-import { ButtonHandler, ModalHandler, SelectHandler } from '@handlers/interaction/components';
+import { ButtonHandler, ModalHandler, SelectMenuHandler } from '@handlers/interaction/components';
 
 import type { Core } from '@interfaces/Core';
 import type { ButtonInteraction, ModalSubmitInteraction, UserSelectMenuInteraction } from 'discord.js';
@@ -101,7 +101,7 @@ class ConfigModal extends ModalHandler<[typeof Config]> {
 const Assign = new CustomId('assign').snowflake('roleId');
 
 @SelectMenuRoute(SelectMenuKind.User, Assign)
-class AssignSelect extends SelectHandler<SelectMenuKind.User, [typeof Assign]> {
+class AssignSelect extends SelectMenuHandler<SelectMenuKind.User, [typeof Assign]> {
     public summary = '';
     execute(): Promise<void> {
         const { roleId } = this.params;

--- a/packages/seedcord/tests/customId/type-safety.test.ts
+++ b/packages/seedcord/tests/customId/type-safety.test.ts
@@ -2,7 +2,7 @@ import { CustomId } from '@seedcord/kit';
 import { describe, expect, expectTypeOf, it } from 'vitest';
 
 import { ButtonRoute, SelectMenuRoute, SelectMenuKind } from '@bDecorators/Interactions';
-import { ButtonHandler, SelectHandler } from '@handlers/interaction/components';
+import { ButtonHandler, SelectMenuHandler } from '@handlers/interaction/components';
 
 // each @ts-expect-error fails the typecheck if the mistake it guards stops being a compile error.
 
@@ -68,14 +68,14 @@ class MultiParams extends ButtonHandler<[typeof Approve, typeof Deny]> {
 
 // @ts-expect-error a user-select handler cannot be routed as a role select.
 @SelectMenuRoute(SelectMenuKind.Role, Assign)
-class MismatchedSelect extends SelectHandler<SelectMenuKind.User, [typeof Assign]> {
+class MismatchedSelect extends SelectMenuHandler<SelectMenuKind.User, [typeof Assign]> {
     async execute(): Promise<void> {
         await Promise.resolve();
     }
 }
 
 @SelectMenuRoute(SelectMenuKind.User, Assign)
-class GoodSelect extends SelectHandler<SelectMenuKind.User, [typeof Assign]> {
+class GoodSelect extends SelectMenuHandler<SelectMenuKind.User, [typeof Assign]> {
     async execute(): Promise<void> {
         expectTypeOf(this.params).toEqualTypeOf<{ roleId: string }>();
         await Promise.resolve();

--- a/packages/seedcord/tests/interactions/InteractionBoundary.test.ts
+++ b/packages/seedcord/tests/interactions/InteractionBoundary.test.ts
@@ -44,7 +44,8 @@ function mockInteraction() {
         channelId: 'c1',
         id: 'i1',
         deferred: false,
-        replied: false
+        replied: false,
+        ephemeral: null as boolean | null
     };
 }
 
@@ -123,8 +124,9 @@ describe('handleInteractionFault', () => {
         expect(publish).not.toHaveBeenCalled();
     });
 
-    it('follows up, clears the stale defer, and publishes handledException for a reporting denial on a deferred interaction', async () => {
+    it('edits the deferReply placeholder and publishes handledException for a reporting fault on a deferred interaction', async () => {
         mock.deferred = true;
+        mock.ephemeral = false;
 
         await handleInteractionFault(
             new Fault({ cause: new Error('write failed') }),
@@ -132,11 +134,10 @@ describe('handleInteractionFault', () => {
             mockCore(publish)
         );
 
-        // a deferred slash command cannot have its classic "thinking" placeholder turned into a
-        // ComponentsV2 message, so the boundary follows up fresh and deletes the placeholder.
-        expect(mock.followUp).toHaveBeenCalledTimes(1);
-        expect(mock.deleteReply).toHaveBeenCalledTimes(1);
-        expect(mock.editReply).not.toHaveBeenCalled();
+        // editReply upgrades the deferReply placeholder in place.
+        expect(mock.editReply).toHaveBeenCalledTimes(1);
+        expect(mock.followUp).not.toHaveBeenCalled();
+        expect(mock.deleteReply).not.toHaveBeenCalled();
         expect(mock.reply).not.toHaveBeenCalled();
         const [event, payload] = publish.mock.calls[0] as [string, AllSubscriptions['handledException']];
         expect(event).toBe('handledException');

--- a/packages/seedcord/tests/pagination/controls.test.ts
+++ b/packages/seedcord/tests/pagination/controls.test.ts
@@ -1,6 +1,5 @@
 import { SeedcordRangeError } from '@seedcord/errors/internal';
-import { pageCursor } from '@seedcord/kit';
-import { PAGE_MAX } from '@seedcord/kit/internal';
+import { PAGE_MAX, pageCursor } from '@seedcord/kit/internal';
 import { ButtonStyle, ComponentType } from 'discord.js';
 import { describe, expect, it } from 'vitest';
 

--- a/packages/seedcord/tests/pagination/controls.test.ts
+++ b/packages/seedcord/tests/pagination/controls.test.ts
@@ -1,0 +1,138 @@
+import { SeedcordRangeError } from '@seedcord/errors/internal';
+import { pageCursor } from '@seedcord/kit';
+import { PAGE_MAX } from '@seedcord/kit/internal';
+import { ButtonStyle, ComponentType } from 'discord.js';
+import { describe, expect, it } from 'vitest';
+
+import { Controls } from '@pagination/controls';
+
+import type { PageView } from '@seedcord/kit';
+import type { ActionRowBuilder, APIButtonComponentWithCustomId, ButtonBuilder } from 'discord.js';
+
+const cursor = pageCursor('bans');
+
+function arrayView(page: number, totalPages: number): PageView<number> {
+    return { items: [], page, perPage: 10, totalPages, hasPrev: page > 0, hasNext: page < totalPages - 1 };
+}
+
+// ButtonBuilder.data/.toJSON() is a union, narrow to the custom-id variant to read custom_id and label.
+function jsonOf(button: ButtonBuilder): APIButtonComponentWithCustomId {
+    const json = button.toJSON();
+    if (!('custom_id' in json)) throw new Error('control button has no custom_id');
+    return json;
+}
+function pageOf(button: ButtonBuilder): number {
+    return cursor.decode(jsonOf(button).custom_id).page;
+}
+function labelOf(button: ButtonBuilder): string | undefined {
+    return jsonOf(button).label;
+}
+function customIds(row: ActionRowBuilder<ButtonBuilder>): string[] {
+    return row.toJSON().components.map((component) => ('custom_id' in component ? component.custom_id : ''));
+}
+
+describe('controls.button', () => {
+    it('encodes the target page on each nav button', () => {
+        const controls = new Controls(cursor, arrayView(1, 3));
+        expect(pageOf(controls.button('first'))).toBe(0);
+        expect(pageOf(controls.button('prev'))).toBe(0);
+        expect(pageOf(controls.button('next'))).toBe(2);
+        expect(pageOf(controls.button('last'))).toBe(2);
+    });
+
+    it('disables prev/first on the first page and next/last on the last', () => {
+        const first = new Controls(cursor, arrayView(0, 3));
+        expect(first.button('first').data.disabled).toBe(true);
+        expect(first.button('prev').data.disabled).toBe(true);
+        expect(first.button('next').data.disabled).toBe(false);
+
+        const last = new Controls(cursor, arrayView(2, 3));
+        expect(last.button('next').data.disabled).toBe(true);
+        expect(last.button('last').data.disabled).toBe(true);
+    });
+
+    it('the indicator is a disabled button reading the 1-based page of total', () => {
+        const indicator = new Controls(cursor, arrayView(1, 3)).button('indicator');
+        expect(indicator.data.disabled).toBe(true);
+        expect(labelOf(indicator)).toBe('Page 2 of 3');
+    });
+
+    it('the indicator omits the total for an unknown-total view', () => {
+        const view: PageView<number> = { items: [], page: 4, perPage: 10, hasPrev: true, hasNext: true };
+        expect(labelOf(new Controls(cursor, view).button('indicator'))).toBe('Page 5');
+    });
+
+    it('disables last for an unknown-total source', () => {
+        const view: PageView<number> = { items: [], page: 0, perPage: 10, hasPrev: false, hasNext: true };
+        expect(new Controls(cursor, view).button('last').data.disabled).toBe(true);
+    });
+
+    it('clamps the encode target to the cursor bound so an enormous list does not throw', () => {
+        const controls = new Controls(cursor, arrayView(PAGE_MAX, PAGE_MAX + 2));
+        expect(() => controls.button('last')).not.toThrow();
+        expect(() => controls.button('next')).not.toThrow();
+    });
+
+    it('drops the default label for an icon-only button (emoji, no label)', () => {
+        const button = new Controls(cursor, arrayView(1, 3)).button('prev', { emoji: '⬅️' });
+        expect(labelOf(button)).toBeUndefined();
+        expect(jsonOf(button).emoji).toBeDefined();
+    });
+
+    it('keeps the default label when no emoji is given', () => {
+        expect(labelOf(new Controls(cursor, arrayView(1, 3)).button('prev'))).toBe('Prev');
+    });
+
+    it('keeps the indicator text even with an emoji', () => {
+        const indicator = new Controls(cursor, arrayView(1, 3)).button('indicator', { emoji: '📄' });
+        expect(labelOf(indicator)).toBe('Page 2 of 3');
+    });
+
+    it('mints a fresh builder on each call so nothing persists to mutate', () => {
+        const controls = new Controls(cursor, arrayView(1, 3));
+        expect(controls.button('next')).not.toBe(controls.button('next'));
+    });
+
+    it('applies cosmetics but forces the indicator disabled', () => {
+        const controls = new Controls(cursor, arrayView(1, 3));
+        const next = controls.button('next', { label: 'Forward', style: ButtonStyle.Primary });
+        expect(labelOf(next)).toBe('Forward');
+        expect(next.data.style).toBe(ButtonStyle.Primary);
+
+        const indicator = controls.button('indicator', { label: 'custom', style: ButtonStyle.Primary });
+        expect(labelOf(indicator)).toBe('custom');
+        expect(indicator.data.disabled).toBe(true);
+    });
+});
+
+describe('controls.row', () => {
+    it('assembles an action row of the chosen keys in order', () => {
+        const row = new Controls(cursor, arrayView(1, 3)).row('prev', 'indicator', 'next');
+        const json = row.toJSON();
+        expect(json.type).toBe(ComponentType.ActionRow);
+        expect(json.components).toHaveLength(3);
+    });
+
+    it('rejects more than five buttons in a row', () => {
+        const controls = new Controls(cursor, arrayView(1, 3));
+        expect(() => controls.row('first', 'prev', 'indicator', 'next', 'last', 'first')).toThrow(SeedcordRangeError);
+    });
+});
+
+describe('controls.row custom_id uniqueness', () => {
+    it('keeps every control distinct at the lower bound, where first/prev/indicator all target page 0', () => {
+        const ids = customIds(new Controls(cursor, arrayView(0, 3)).row('first', 'prev', 'indicator', 'next', 'last'));
+        expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    it('keeps first and prev distinct on page 1, where both target page 0', () => {
+        const ids = customIds(new Controls(cursor, arrayView(1, 3)).row('first', 'prev', 'indicator', 'next', 'last'));
+        expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    it('keeps an unknown-total row distinct at page 0, where prev clamps onto the indicator', () => {
+        const view: PageView<number> = { items: [], page: 0, perPage: 10, hasPrev: false, hasNext: true };
+        const ids = customIds(new Controls(cursor, view).row('prev', 'indicator', 'next'));
+        expect(new Set(ids).size).toBe(ids.length);
+    });
+});

--- a/packages/seedcord/tests/pagination/controls.test.ts
+++ b/packages/seedcord/tests/pagination/controls.test.ts
@@ -1,4 +1,4 @@
-import { SeedcordRangeError } from '@seedcord/errors/internal';
+import { SeedcordRangeError, SeedcordTypeError } from '@seedcord/errors/internal';
 import { PAGE_MAX, pageCursor } from '@seedcord/kit/internal';
 import { ButtonStyle, ComponentType } from 'discord.js';
 import { describe, expect, it } from 'vitest';
@@ -72,6 +72,12 @@ describe('controls.button', () => {
         expect(() => controls.button('next')).not.toThrow();
     });
 
+    it('disables next and last when the target page would exceed the cursor bound', () => {
+        const controls = new Controls(cursor, arrayView(PAGE_MAX, PAGE_MAX + 2));
+        expect(controls.button('next').data.disabled).toBe(true);
+        expect(controls.button('last').data.disabled).toBe(true);
+    });
+
     it('drops the default label for an icon-only button (emoji, no label)', () => {
         const button = new Controls(cursor, arrayView(1, 3)).button('prev', { emoji: '⬅️' });
         expect(labelOf(button)).toBeUndefined();
@@ -115,6 +121,14 @@ describe('controls.row', () => {
     it('rejects more than five buttons in a row', () => {
         const controls = new Controls(cursor, arrayView(1, 3));
         expect(() => controls.row('first', 'prev', 'indicator', 'next', 'last', 'first')).toThrow(SeedcordRangeError);
+    });
+
+    it('rejects an empty row', () => {
+        expect(() => new Controls(cursor, arrayView(1, 3)).row()).toThrow(SeedcordRangeError);
+    });
+
+    it('rejects a row with a duplicate control', () => {
+        expect(() => new Controls(cursor, arrayView(1, 3)).row('prev', 'prev')).toThrow(SeedcordTypeError);
     });
 });
 

--- a/packages/seedcord/tests/pagination/integration.test.ts
+++ b/packages/seedcord/tests/pagination/integration.test.ts
@@ -1,0 +1,112 @@
+import path from 'node:path';
+
+import { pageCursor } from '@seedcord/kit';
+import { ComponentType } from 'discord.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Seedcord } from '@src/Seedcord';
+
+import { testConfig } from '../utils/test-config';
+import { TestEnvironment } from '../utils/test-env';
+
+import '../utils/mock-client';
+import '../utils/mock-env';
+
+import type { APIContainerComponent } from 'discord.js';
+
+const seedcordPath = path.resolve(__dirname, '../../src/index').replace(/\\/g, '/');
+
+interface TestBot {
+    interactions: {
+        buttonMap: Map<string, unknown>;
+        init(): Promise<void>;
+        handleButton(interaction: unknown): Promise<void>;
+    };
+}
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type -- inference is fine for the mock
+function fakeButton(customId: string) {
+    return {
+        customId,
+        isAutocomplete: () => false,
+        isButton: () => true,
+        isChatInputCommand: () => false,
+        isContextMenuCommand: () => false,
+        isAnySelectMenu: () => false,
+        isModalSubmit: () => false,
+        deferUpdate: vi.fn().mockResolvedValue(undefined),
+        message: { id: 'paged-message' },
+        webhook: { editMessage: vi.fn().mockResolvedValue(undefined) },
+        user: { id: 'u1' },
+        guild: null,
+        guildId: 'g1',
+        channelId: 'c1',
+        id: 'i1',
+        deferred: false,
+        replied: false
+    };
+}
+
+function pageText(body: { components: { toJSON(): unknown }[] }): string {
+    const json = body.components[0]?.toJSON() as APIContainerComponent;
+    return json.components.reduce<string>(
+        (acc, part) => (part.type === ComponentType.TextDisplay ? acc + part.content : acc),
+        ''
+    );
+}
+
+describe('Paginator end-to-end through the real dispatcher', () => {
+    let testEnv: TestEnvironment;
+    let seedcord: Seedcord;
+
+    beforeEach(async () => {
+        // @ts-expect-error reset the singleton between tests
+        Seedcord.reset();
+        testEnv = new TestEnvironment('pagination-e2e-');
+        await testEnv.setup();
+    });
+
+    afterEach(async () => {
+        await testEnv.teardown();
+        vi.clearAllMocks();
+    });
+
+    it('file-scans a paginator nav handler, routes a click, decodes the page, and edits in place', async () => {
+        await testEnv.createFile(
+            'interactions/Letters.ts',
+            `
+            import { Paginator, ArraySource, ButtonRoute } from '${seedcordPath}';
+
+            export const Letters = new Paginator({
+                prefix: 'e2e-letters',
+                source: new ArraySource(() => ['a', 'b', 'c', 'd', 'e'], { perPage: 2 }),
+                renderItem: (letter) => letter
+            });
+
+            @ButtonRoute(Letters.cursor)
+            export class LettersNav extends Letters.Handler {}
+            `
+        );
+
+        const config = testConfig({ interactions: testEnv.resolvePath('interactions') });
+        seedcord = new Seedcord(config);
+        const controller = (seedcord.bot as unknown as TestBot).interactions;
+        await controller.init();
+
+        // the file-scan discovered the paginator's minted nav handler and registered it by the cursor prefix.
+        expect(controller.buttonMap.has('e2e-letters')).toBe(true);
+
+        // a click minted from page 2's wire (pageCursor is deterministic, same prefix + layout) routes through.
+        const click = fakeButton(pageCursor('e2e-letters').encode({ page: 2, slot: 0 }));
+        await controller.handleButton(click);
+
+        expect(click.deferUpdate).toHaveBeenCalledOnce();
+        expect(click.webhook.editMessage).toHaveBeenCalledOnce();
+        const [message, body] = click.webhook.editMessage.mock.calls[0] as [
+            unknown,
+            { components: { toJSON(): unknown }[] }
+        ];
+        expect(message).toBe(click.message);
+        expect(pageText(body)).toBe('e'); // page 2 of 5 items at perPage 2
+    });
+});

--- a/packages/seedcord/tests/pagination/integration.test.ts
+++ b/packages/seedcord/tests/pagination/integration.test.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 
-import { pageCursor } from '@seedcord/kit';
+import { pageCursor } from '@seedcord/kit/internal';
 import { ComponentType } from 'discord.js';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 

--- a/packages/seedcord/tests/pagination/paginator.test.ts
+++ b/packages/seedcord/tests/pagination/paginator.test.ts
@@ -1,0 +1,170 @@
+import 'reflect-metadata';
+
+import { ComponentDefsKey } from '@seedcord/kit/internal';
+import { ComponentType, MessageFlags } from 'discord.js';
+import { beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
+
+import { ButtonRoute } from '@bDecorators/Interactions';
+import { InteractionHandler } from '@handlers/interaction/InteractionHandler';
+import { Paginator } from '@pagination/Paginator';
+import { ArraySource } from '@pagination/sources';
+import { InteractionMetadataKey, InteractionRouteKeys, InteractionRoutes } from '@src/metadataKeys';
+
+import type { Repliables } from '@handlers/BaseHandler';
+import type { Core } from '@interfaces/Core';
+import type { PageContext } from '@pagination/PageContext';
+import type { APIContainerComponent, ButtonInteraction } from 'discord.js';
+
+const core = {} as unknown as Core;
+const letters = ['a', 'b', 'c', 'd', 'e'];
+
+const pager = new Paginator({
+    prefix: 'bans',
+    source: new ArraySource(() => letters, { perPage: 2 }),
+    renderItem: (letter) => letter
+});
+
+@ButtonRoute(pager.cursor)
+class BansNav extends pager.Handler {}
+
+// a paginator whose loader records the context the Paginator builds, to pin the DM guild-null threading.
+const seenContexts: PageContext[] = [];
+const Reminders = new Paginator({
+    prefix: 'reminders',
+    source: new ArraySource((ctx) => {
+        seenContexts.push(ctx);
+        return letters;
+    }),
+    renderItem: (letter) => letter
+});
+
+@ButtonRoute(Reminders.cursor)
+class RemindersNav extends Reminders.Handler {}
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type -- inference is fine for the mock
+function startEvent() {
+    return {
+        reply: vi.fn().mockResolvedValue(undefined),
+        fetchReply: vi.fn().mockResolvedValue({ id: 'page-message' }),
+        followUp: vi.fn().mockResolvedValue({ id: 'page-message' }),
+        user: { id: 'u1' },
+        guild: null,
+        replied: false,
+        deferred: false,
+        isMessageComponent: () => false,
+        isModalSubmit: () => false
+    };
+}
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type -- inference is fine for the mock
+function navEvent(customId: string) {
+    return {
+        customId,
+        deferUpdate: vi.fn().mockResolvedValue(undefined),
+        message: { id: 'paged-message' },
+        webhook: { editMessage: vi.fn().mockResolvedValue(undefined) },
+        user: { id: 'u1' },
+        guild: null
+    };
+}
+
+function containerText(components: { toJSON(): unknown }[]): string {
+    const json = components[0]?.toJSON() as APIContainerComponent;
+    return json.components.reduce<string>(
+        (acc, part) => (part.type === ComponentType.TextDisplay ? acc + part.content : acc),
+        ''
+    );
+}
+
+describe('Paginator.start', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('renders page 0 and sends it with the components-v2 flag', async () => {
+        const event = startEvent();
+        await pager.start(event as unknown as Repliables);
+
+        expect(event.reply).toHaveBeenCalledOnce();
+        const options = event.reply.mock.calls[0]?.[0] as { components: { toJSON(): unknown }[]; flags: number };
+        expect(options.flags & MessageFlags.IsComponentsV2).toBeTruthy();
+        expect(options.flags & MessageFlags.Ephemeral).toBeFalsy();
+        expect(containerText(options.components)).toBe('a\nb');
+    });
+
+    it('honors an ephemeral paginator', async () => {
+        const ephemeral = new Paginator({
+            prefix: 'invites',
+            source: new ArraySource(() => letters, { perPage: 2 }),
+            renderItem: (letter) => letter,
+            ephemeral: true
+        });
+        const event = startEvent();
+        await ephemeral.start(event as unknown as Repliables);
+        const options = event.reply.mock.calls[0]?.[0] as { flags: number };
+        expect(options.flags & MessageFlags.Ephemeral).toBeTruthy();
+    });
+});
+
+describe('Paginator.page', () => {
+    it('renders the requested page as a ReplyResponse', async () => {
+        const ctx = { interaction: {}, user: {}, guild: null } as unknown as PageContext;
+        const reply = await pager.page(ctx, 1);
+        expect(containerText(reply.components)).toBe('c\nd');
+    });
+});
+
+describe('Paginator nav handler', () => {
+    beforeEach(() => vi.clearAllMocks());
+
+    it('acks, decodes the target page off the wire, and edits the message in place', async () => {
+        const event = navEvent(pager.cursor.encode({ page: 2, slot: 0 }));
+        await new BansNav(event as unknown as ButtonInteraction<'cached'>, core).execute();
+
+        expect(event.deferUpdate).toHaveBeenCalledOnce();
+        expect(event.webhook.editMessage).toHaveBeenCalledOnce();
+        const [message, body] = event.webhook.editMessage.mock.calls[0] as [
+            unknown,
+            { components: { toJSON(): unknown }[]; flags: number }
+        ];
+        expect(message).toBe(event.message);
+        expect(body.flags).toBe(MessageFlags.IsComponentsV2);
+        expect(containerText(body.components)).toBe('e'); // page 2 of 5 items at perPage 2
+    });
+});
+
+describe('Paginator registration', () => {
+    it('the decorated .Handler subclass is a discoverable InteractionHandler routed by the cursor prefix', () => {
+        expect(BansNav.prototype).toBeInstanceOf(InteractionHandler);
+        expect(Reflect.hasMetadata(InteractionMetadataKey, BansNav)).toBe(true);
+        const routeKeys = Reflect.getMetadata(InteractionRouteKeys[InteractionRoutes.Button], BansNav) as string[];
+        expect(routeKeys).toContain(pager.cursor.prefix);
+        const defs = Reflect.getMetadata(ComponentDefsKey, BansNav) as unknown[];
+        expect(defs).toContain(pager.cursor);
+    });
+});
+
+describe('Paginator context', () => {
+    it('threads the interaction user and guild (DM null) into the PageContext it builds', async () => {
+        seenContexts.length = 0;
+        const event = navEvent(Reminders.cursor.encode({ page: 0, slot: 0 }));
+        await new RemindersNav(event as unknown as ButtonInteraction<'cached'>, core).execute();
+
+        const ctx = seenContexts[0];
+        expect(ctx?.interaction).toBe(event);
+        expect(ctx?.user).toBe(event.user);
+        expect(ctx?.guild).toBeNull();
+    });
+});
+
+describe('Paginator typing', () => {
+    it('infers the item type from the source into renderItem', () => {
+        const nums = new Paginator({
+            prefix: 'nums',
+            source: new ArraySource(() => [1, 2, 3]),
+            renderItem: (item) => {
+                expectTypeOf(item).toEqualTypeOf<number>();
+                return String(item);
+            }
+        });
+        expect(nums.cursor.prefix).toBe('nums');
+    });
+});

--- a/packages/seedcord/tests/pagination/render.test.ts
+++ b/packages/seedcord/tests/pagination/render.test.ts
@@ -1,0 +1,101 @@
+import { BuilderComponent, pageCursor } from '@seedcord/kit';
+import { ButtonBuilder, ButtonStyle, ComponentType, TextDisplayBuilder } from 'discord.js';
+import { describe, expect, it } from 'vitest';
+
+import { renderPage } from '@pagination/render';
+
+import type { PageView } from '@seedcord/kit';
+import type { ReplyResponse } from '@seedcord/types';
+import type { APIComponentInContainer, APIContainerComponent } from 'discord.js';
+
+const cursor = pageCursor('roles');
+
+function arrayView<Item>(items: Item[], page: number, totalPages: number): PageView<Item> {
+    return { items, page, perPage: 2, totalPages, hasPrev: page > 0, hasNext: page < totalPages - 1 };
+}
+
+function containerOf(reply: ReplyResponse): APIContainerComponent {
+    const json = reply.components[0]?.toJSON();
+    if (json?.type !== ComponentType.Container) throw new Error('expected a container');
+    return json;
+}
+function textLines(container: APIContainerComponent): string[] {
+    return container.components.reduce<string[]>((acc, part: APIComponentInContainer) => {
+        if (part.type === ComponentType.TextDisplay) acc.push(part.content);
+        return acc;
+    }, []);
+}
+function rowButtonCount(container: APIContainerComponent): number {
+    const row = container.components.find((part) => part.type === ComponentType.ActionRow);
+    return row?.type === ComponentType.ActionRow ? row.components.length : 0;
+}
+function sectionCount(container: APIContainerComponent): number {
+    return container.components.filter((part) => part.type === ComponentType.Section).length;
+}
+
+class ItemSection extends BuilderComponent<'section'> {
+    constructor(text: string) {
+        super('section');
+        this.instance
+            .addTextDisplayComponents(new TextDisplayBuilder().setContent(text))
+            .setButtonAccessory(
+                new ButtonBuilder().setCustomId(`go:${text}`).setLabel('Go').setStyle(ButtonStyle.Secondary)
+            );
+    }
+}
+
+describe('renderPage default container', () => {
+    it('lists string items as one text block and appends the five-control row', () => {
+        const reply = renderPage(arrayView(['a', 'b'], 0, 3), cursor, { renderItem: (item) => item });
+        const container = containerOf(reply);
+        expect(textLines(container)).toEqual(['a\nb']);
+        expect(rowButtonCount(container)).toBe(5);
+    });
+
+    it('stringifies items when no renderItem is given', () => {
+        const container = containerOf(renderPage(arrayView([1, 2], 0, 1), cursor, {}));
+        expect(textLines(container)).toEqual(['1\n2']);
+    });
+
+    it('renders a section per item when renderItem returns one', () => {
+        const reply = renderPage(arrayView(['x', 'y'], 0, 1), cursor, { renderItem: (item) => new ItemSection(item) });
+        const container = containerOf(reply);
+        expect(sectionCount(container)).toBe(2);
+        expect(rowButtonCount(container)).toBe(5);
+    });
+
+    it('passes the absolute index across pages to renderItem', () => {
+        const container = containerOf(
+            renderPage(arrayView(['c', 'd'], 1, 3), cursor, { renderItem: (item, index) => `${index}:${item}` })
+        );
+        expect(textLines(container)).toEqual(['2:c\n3:d']);
+    });
+
+    it('omits the last control for an unknown-total source', () => {
+        const view: PageView<string> = { items: ['a'], page: 0, perPage: 2, hasPrev: false, hasNext: true };
+        expect(rowButtonCount(containerOf(renderPage(view, cursor, { renderItem: (item) => item })))).toBe(3);
+    });
+});
+
+describe('renderPage render override', () => {
+    it('returns the user component array verbatim', () => {
+        const reply = renderPage(arrayView(['a'], 0, 1), cursor, {
+            render: (_view, controls) => [new TextDisplayBuilder().setContent('custom'), controls.row('prev', 'next')]
+        });
+        const first = reply.components[0]?.toJSON();
+        expect(first?.type).toBe(ComponentType.TextDisplay);
+        expect(reply.components).toHaveLength(2);
+    });
+
+    it('wraps a returned string in a text display', () => {
+        const reply = renderPage(arrayView(['a'], 0, 1), cursor, { render: () => 'just text' });
+        const first = reply.components[0]?.toJSON();
+        expect(first?.type).toBe(ComponentType.TextDisplay);
+        expect(first && 'content' in first ? first.content : '').toBe('just text');
+    });
+
+    it('passes a returned ReplyResponse through unchanged', () => {
+        const passthrough: ReplyResponse = { components: [new TextDisplayBuilder().setContent('done')] };
+        expect(renderPage(arrayView(['a'], 0, 1), cursor, { render: () => passthrough })).toBe(passthrough);
+    });
+});

--- a/packages/seedcord/tests/pagination/render.test.ts
+++ b/packages/seedcord/tests/pagination/render.test.ts
@@ -1,4 +1,5 @@
-import { BuilderComponent, pageCursor } from '@seedcord/kit';
+import { BuilderComponent } from '@seedcord/kit';
+import { pageCursor } from '@seedcord/kit/internal';
 import { ButtonBuilder, ButtonStyle, ComponentType, TextDisplayBuilder } from 'discord.js';
 import { describe, expect, it } from 'vitest';
 

--- a/packages/seedcord/tests/pagination/sources.test.ts
+++ b/packages/seedcord/tests/pagination/sources.test.ts
@@ -46,6 +46,13 @@ describe('ArraySource', () => {
         const view = await source.page(ctx, 0);
         expectTypeOf(view.items).toEqualTypeOf<string[]>();
     });
+
+    it('rejects a non-positive or non-integer perPage at construction', () => {
+        const load = (): number[] => [];
+        expect(() => new ArraySource(load, { perPage: 0 })).toThrow(SeedcordRangeError);
+        expect(() => new ArraySource(load, { perPage: -1 })).toThrow(SeedcordRangeError);
+        expect(() => new ArraySource(load, { perPage: 2.5 })).toThrow(SeedcordRangeError);
+    });
 });
 
 describe('CursorSource', () => {

--- a/packages/seedcord/tests/pagination/sources.test.ts
+++ b/packages/seedcord/tests/pagination/sources.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+
+import { ArraySource, CursorSource } from '@pagination/sources';
+
+import type { PageContext } from '@pagination/PageContext';
+
+// the sources only forward ctx to the loader, so a minimal fake is enough (mirrors handlers.test.ts).
+const ctx = {} as unknown as PageContext;
+
+describe('ArraySource', () => {
+    it('pages a loaded array through the pure math', async () => {
+        const source = new ArraySource(() => Array.from({ length: 25 }, (_, i) => i), { perPage: 10 });
+        const view = await source.page(ctx, 1);
+        expect(view.items).toEqual([10, 11, 12, 13, 14, 15, 16, 17, 18, 19]);
+        expect(view.totalPages).toBe(3);
+        expect(view.hasPrev).toBe(true);
+        expect(view.hasNext).toBe(true);
+    });
+
+    it('forwards the context to the loader', async () => {
+        const seen: PageContext[] = [];
+        const source = new ArraySource((received) => {
+            seen.push(received);
+            return [1, 2, 3];
+        });
+        await source.page(ctx, 0);
+        expect(seen[0]).toBe(ctx);
+    });
+
+    it('defaults perPage to 10', async () => {
+        const source = new ArraySource(() => Array.from({ length: 25 }, (_, i) => i));
+        const view = await source.page(ctx, 0);
+        expect(view.items).toHaveLength(10);
+        expect(view.totalPages).toBe(3);
+    });
+
+    it('awaits an async loader', async () => {
+        const source = new ArraySource(() => Promise.resolve([1, 2, 3]), { perPage: 2 });
+        const view = await source.page(ctx, 1);
+        expect(view.items).toEqual([3]);
+    });
+
+    it('infers the item type from the loader', async () => {
+        const source = new ArraySource(() => ['a', 'b']);
+        const view = await source.page(ctx, 0);
+        expectTypeOf(view.items).toEqualTypeOf<string[]>();
+    });
+});
+
+describe('CursorSource', () => {
+    it('wraps one fetched page with an unknown total', async () => {
+        const source = new CursorSource(() => ({ items: ['a', 'b'], hasNext: true }), { perPage: 2 });
+        const view = await source.page(ctx, 0);
+        expect(view.items).toEqual(['a', 'b']);
+        expect(view.page).toBe(0);
+        expect(view.perPage).toBe(2);
+        expect(view.totalPages).toBeUndefined();
+        expect(view.hasPrev).toBe(false);
+        expect(view.hasNext).toBe(true);
+    });
+
+    it('reports hasPrev from the page number', async () => {
+        const source = new CursorSource(() => ({ items: ['x'], hasNext: false }));
+        const view = await source.page(ctx, 3);
+        expect(view.page).toBe(3);
+        expect(view.hasPrev).toBe(true);
+        expect(view.hasNext).toBe(false);
+    });
+
+    it('forwards ctx, page, and perPage to the fetcher', async () => {
+        const calls: [PageContext, number, number][] = [];
+        const source = new CursorSource(
+            (received, page, perPage) => {
+                calls.push([received, page, perPage]);
+                return { items: [], hasNext: false };
+            },
+            { perPage: 5 }
+        );
+        await source.page(ctx, 2);
+        expect(calls[0]).toEqual([ctx, 2, 5]);
+    });
+
+    it('clamps a negative page to zero', async () => {
+        const source = new CursorSource(() => ({ items: [], hasNext: false }));
+        const view = await source.page(ctx, -3);
+        expect(view.page).toBe(0);
+        expect(view.hasPrev).toBe(false);
+    });
+});

--- a/packages/seedcord/tests/pagination/sources.test.ts
+++ b/packages/seedcord/tests/pagination/sources.test.ts
@@ -1,3 +1,4 @@
+import { SeedcordRangeError } from '@seedcord/errors/internal';
 import { describe, expect, expectTypeOf, it } from 'vitest';
 
 import { ArraySource, CursorSource } from '@pagination/sources';
@@ -85,5 +86,12 @@ describe('CursorSource', () => {
         const view = await source.page(ctx, -3);
         expect(view.page).toBe(0);
         expect(view.hasPrev).toBe(false);
+    });
+
+    it('rejects a non-positive or non-integer perPage at construction', () => {
+        const fetch = (): { items: number[]; hasNext: boolean } => ({ items: [], hasNext: false });
+        expect(() => new CursorSource(fetch, { perPage: 0 })).toThrow(SeedcordRangeError);
+        expect(() => new CursorSource(fetch, { perPage: -1 })).toThrow(SeedcordRangeError);
+        expect(() => new CursorSource(fetch, { perPage: 2.5 })).toThrow(SeedcordRangeError);
     });
 });

--- a/packages/seedcord/tsconfig.json
+++ b/packages/seedcord/tsconfig.json
@@ -12,6 +12,7 @@
             "@interfaces/*": ["./src/interfaces/*"],
             "@handlers/*": ["./src/handlers/*"],
             "@inputs/*": ["./src/inputs/*"],
+            "@pagination/*": ["./src/pagination/*"],
             "@miscellaneous/*": ["./src/miscellaneous/*"],
 
             // Paths inside src/bot

--- a/packages/seedcord/vitest.config.ts
+++ b/packages/seedcord/vitest.config.ts
@@ -18,6 +18,7 @@ export default mergeConfig(
                 '@interfaces': path.resolve(__dirname, './src/interfaces'),
                 '@handlers': path.resolve(__dirname, './src/handlers'),
                 '@inputs': path.resolve(__dirname, './src/inputs'),
+                '@pagination': path.resolve(__dirname, './src/pagination'),
                 '@miscellaneous': path.resolve(__dirname, './src/miscellaneous'),
 
                 // Paths inside bot


### PR DESCRIPTION
## Summary

Adds a pagination system to seedcord, fixes a deferred-reply bug in `ReplySender`, and renames the `SelectHandler` base to `SelectMenuHandler`. 

## Pagination

The headless math is in `@seedcord/kit`. `paginate(items, page, perPage)` clamps the page into range and returns a `PageView`, and throws `SeedcordRangeError` when `perPage` is not a positive integer. The typed page cursor (`pageCursor` / `PageCursor`) encodes a `page` and a `slot` into one bounded customId and stays in `@seedcord/kit/internal`.

The host-side `Paginator` is in `seedcord`. Each nav button encodes its target page, so a click resolves to an absolute page and survives a restart, and a persistent `@ButtonRoute` on the generated handler dispatches the clicks. Page data comes from a `PageSource`, either `ArraySource` for an in-memory list (a real total, all five controls) or `CursorSource` for one-page-at-a-time fetches (no total, so prev, indicator, and next only). The default renderer builds a Components V2 container, and a `render` override receives the page data and a `PaginatorControls` factory to build a custom tree.

`@seedcord/kit` exports `paginate` and `PageView`. `seedcord` exports `Paginator`, `ArraySource`, `CursorSource`, and `PaginatorControls`. The supporting types (`PageContext`, `PageSource`, `Renderable`, `ItemRender`, `PageRender`, `ControlKey`, `ControlCosmetics`) are visible through the API and resolve as doc link targets, and are kept off the reference list.

Validation rejects malformed input at author time. `CursorSource` rejects a non-positive or non-integer `perPage` to match `ArraySource`. `controls.row()` rejects an empty set, more than five controls, and a duplicate control, each of which would otherwise build a message Discord refuses. The nav buttons disable `next` and `last` once their target would exceed the cursor bound.

The mock bot also has runnable examples now, Roster (`ArraySource`), Feed (`CursorSource` with a custom render), and a headless Leaderboard that calls the kit math with its own cursor, plus a `defernotice` test for the deferred-reply path.

## ReplySender deferred-reply fix

A V2 reply built after `deferReply()` previously followed up with a new message and deleted the thinking placeholder, so the reply appeared and then vanished. The deferred branch now reads `interaction.ephemeral` to tell the two defer kinds apart. After `deferReply` (ephemeral is a boolean) it edits the placeholder in place with `editReply` and the `IsComponentsV2` flag. After `deferUpdate` (ephemeral is null, the source message is live) it follows up so the source message stays intact.

## Breaking, SelectHandler renamed to SelectMenuHandler

`SelectHandler` is now `SelectMenuHandler`, matching `SelectMenuRoute` and `SelectMenuKind`. A select-menu handler extends `SelectMenuHandler`. 