### PR TITLE
fix: gateway dispatch fixes + HMR decouple and rollback

### DIFF
--- a/.changeset/bus-hmr-registration.md
+++ b/.changeset/bus-hmr-registration.md
@@ -1,0 +1,5 @@
+---
+'seedcord': patch
+---
+
+Register the subscriber bus for HMR so editing a subscriber file hot-reloads it in dev. The wiring existed but was never invoked, so subscriber edits silently needed a full restart.

--- a/.changeset/duplicate-interaction-guards.md
+++ b/.changeset/duplicate-interaction-guards.md
@@ -1,0 +1,6 @@
+---
+'seedcord': patch
+'@seedcord/errors': patch
+---
+
+Throw on a duplicate interaction route, and on two interaction middleware classes sharing a name. Before, the later registration silently overwrote the earlier one.

--- a/.changeset/hmr-decouple.md
+++ b/.changeset/hmr-decouple.md
@@ -1,0 +1,8 @@
+---
+'seedcord': minor
+'@seedcord/types': patch
+'@seedcord/cli': patch
+'@seedcord/plugins': patch
+---
+
+Decouple HMR from vite's `import.meta.hot` behind a typed `DevChannel`. Drop the `HmrModuleHandler` `name` option where you construct the handler, it was only an internal cache key and is no longer accepted.

--- a/.changeset/hmr-rollback.md
+++ b/.changeset/hmr-rollback.md
@@ -1,0 +1,7 @@
+---
+'seedcord': minor
+'@seedcord/cli': minor
+'@seedcord/errors': patch
+---
+
+A failed hot-reload now restores the file's last-good version, so the handler stays registered through a broken edit until the next good save. Disable it with `hmr.rollback: false` in `seedcord.config.ts`.

--- a/.changeset/once-handler-concurrent-fire.md
+++ b/.changeset/once-handler-concurrent-fire.md
@@ -1,0 +1,5 @@
+---
+'seedcord': patch
+---
+
+Fix a `once` event handler running twice when the same event fired concurrently. Two overlapping fires both passed the spent-handler check before either marked it spent.

--- a/packages/cli/src/api/vite-hmr.d.ts
+++ b/packages/cli/src/api/vite-hmr.d.ts
@@ -1,6 +1,0 @@
-import type { SeedcordFrameworkEvents, SeedcordCliEvents } from '@seedcord/types/internal';
-
-// types the HMR wire events on the dev server (this.hot.send / .on) against the shared event maps.
-declare module 'vite/types/customEvent.d.ts' {
-    interface CustomEventMap extends SeedcordFrameworkEvents, SeedcordCliEvents {}
-}

--- a/packages/cli/src/commands/dev/runtime/HmrPlugin.ts
+++ b/packages/cli/src/commands/dev/runtime/HmrPlugin.ts
@@ -35,7 +35,6 @@ export class HmrPlugin extends StrictEventEmitter<{ event: [DevEvent] }> {
         return this.server?.environments.ssr.hot;
     }
 
-    // wrapHot keeps the seedcord:* typing off vite's ambient hot map. re-wrapping per access is cheap.
     private get dev(): DevChannel<SeedcordCliEvents, SeedcordFrameworkEvents> | undefined {
         return this.hot ? wrapHot<SeedcordCliEvents, SeedcordFrameworkEvents>(this.hot) : undefined;
     }
@@ -77,8 +76,7 @@ export class HmrPlugin extends StrictEventEmitter<{ event: [DevEvent] }> {
         });
     }
 
-    // debounce keyed per (file, type) because a rapid create-then-update of the same file is two distinct
-    // events, so one shared timestamp would drop the second.
+    // debounce keyed per (file, type), a shared timestamp drops the second of a rapid create-then-update
     private isDebounced(file: string, type: HmrEventType): boolean {
         const key = `${file}::${type}`;
         const now = Date.now();

--- a/packages/cli/src/commands/dev/runtime/HmrPlugin.ts
+++ b/packages/cli/src/commands/dev/runtime/HmrPlugin.ts
@@ -1,12 +1,19 @@
 import { relative, resolve } from 'node:path';
 
 import { Logger, StrictEventEmitter } from '@seedcord/services';
+import { wrapHot } from '@seedcord/types/internal';
 import chalk from 'chalk';
 import { minimatch } from 'minimatch';
 
 import type { DevEvent } from './events';
 import type { ResolvedSeedcordDevConfig } from '@core/config/schema';
-import type { HmrEventType, HmrUpdateEvent } from '@seedcord/types/internal';
+import type {
+    DevChannel,
+    HmrEventType,
+    HmrUpdateEvent,
+    SeedcordCliEvents,
+    SeedcordFrameworkEvents
+} from '@seedcord/types/internal';
 import type {
     EnvironmentModuleNode,
     HotUpdateOptions,
@@ -28,6 +35,11 @@ export class HmrPlugin extends StrictEventEmitter<{ event: [DevEvent] }> {
         return this.server?.environments.ssr.hot;
     }
 
+    // wrapHot keeps the seedcord:* typing off vite's ambient hot map. re-wrapping per access is cheap.
+    private get dev(): DevChannel<SeedcordCliEvents, SeedcordFrameworkEvents> | undefined {
+        return this.hot ? wrapHot<SeedcordCliEvents, SeedcordFrameworkEvents>(this.hot) : undefined;
+    }
+
     constructor(private readonly config: ResolvedSeedcordDevConfig) {
         super();
         this.logger = new Logger('HMR', { channel: 'hmr' });
@@ -42,11 +54,7 @@ export class HmrPlugin extends StrictEventEmitter<{ event: [DevEvent] }> {
     }
 
     public sendRefreshCommands(shouldRefresh: boolean): void {
-        if (this.server) {
-            if (this.hot) {
-                this.hot.send('seedcord:refresh-commands', { shouldRefresh });
-            }
-        }
+        this.dev?.send('seedcord:refresh-commands', { shouldRefresh });
     }
 
     private configureServer(server: ViteDevServer): void {
@@ -56,23 +64,21 @@ export class HmrPlugin extends StrictEventEmitter<{ event: [DevEvent] }> {
         server.watcher.on('addDir', (file) => this.handleFileEvent(file, 'createDir'));
         server.watcher.on('unlinkDir', (file) => this.handleFileEvent(file, 'deleteDir'));
 
-        if (this.hot) {
-            this.hot.on('seedcord:commands-update-prompt', (data) => {
-                this.emit('event', { type: 'command-update-prompt', files: data.files });
-            });
+        this.dev?.on('seedcord:commands-update-prompt', (data) => {
+            this.emit('event', { type: 'command-update-prompt', files: data.files });
+        });
 
-            this.hot.on('seedcord:register-critical-files', (data) => {
-                for (const pattern of data.patterns) {
-                    this.dynamicRestartPatterns.add(pattern);
-                }
+        this.dev?.on('seedcord:register-critical-files', (data) => {
+            for (const pattern of data.patterns) {
+                this.dynamicRestartPatterns.add(pattern);
+            }
 
-                this.logger.utils.list(data.patterns, 'Registered critical file patterns:');
-            });
-        }
+            this.logger.utils.list(data.patterns, 'Registered critical file patterns:');
+        });
     }
 
-    // Debounce per (file, type): a rapid create-then-update of the same file is two distinct events, so a
-    // single shared timestamp would drop the second. Returns true when the event should be suppressed.
+    // debounce keyed per (file, type) because a rapid create-then-update of the same file is two distinct
+    // events, so one shared timestamp would drop the second.
     private isDebounced(file: string, type: HmrEventType): boolean {
         const key = `${file}::${type}`;
         const now = Date.now();
@@ -95,11 +101,9 @@ export class HmrPlugin extends StrictEventEmitter<{ event: [DevEvent] }> {
 
         this.logger.info(`${typeColor(type.toUpperCase())} ${chalk.gray(relPath)}`);
 
-        const payload: HmrUpdateEvent = { file, type };
+        const payload: HmrUpdateEvent = { file, type, rollback: this.config.hmr?.rollback ?? true };
 
-        if (this.hot) {
-            this.hot.send('seedcord:hmr', payload);
-        }
+        this.dev?.send('seedcord:hmr', payload);
     }
 
     private hotUpdate(ctx: HotUpdateOptions): EnvironmentModuleNode[] {
@@ -136,16 +140,14 @@ export class HmrPlugin extends StrictEventEmitter<{ event: [DevEvent] }> {
             }
         }
 
-        // file-change tells the runtime to invalidate this module in its evaluated-modules graph.
+        // the runtime invalidates this module in its evaluated-modules graph on a file-change event.
         this.emit('event', { type: 'file-change', path: file });
 
-        const payload: HmrUpdateEvent = { file, type, affectedModules };
+        const payload: HmrUpdateEvent = { file, type, affectedModules, rollback: this.config.hmr?.rollback ?? true };
 
-        if (this.hot) {
-            this.hot.send('seedcord:hmr', payload);
-        }
+        this.dev?.send('seedcord:hmr', payload);
 
-        // Returning [] suppresses Vite's default client HMR; invalidation runs through the runtime instead.
+        // returning [] suppresses vite's default client HMR so invalidation runs through the runtime.
         return [];
     }
 

--- a/packages/cli/src/core/config/ConfigLoader.ts
+++ b/packages/cli/src/core/config/ConfigLoader.ts
@@ -41,6 +41,9 @@ function validateHmr(value: unknown): void {
     if (typeof value.restart !== 'undefined' && !isStringArray(value.restart)) {
         throw new SeedcordError(SeedcordErrorCode.CliConfigInvalidHmrRestart);
     }
+    if (typeof value.rollback !== 'undefined' && typeof value.rollback !== 'boolean') {
+        throw new SeedcordError(SeedcordErrorCode.CliConfigInvalidHmrRollback);
+    }
 }
 
 function validateConfig(raw: unknown): asserts raw is SeedcordDevConfig {

--- a/packages/cli/src/core/config/schema.ts
+++ b/packages/cli/src/core/config/schema.ts
@@ -30,6 +30,13 @@ export interface SeedcordHmrConfig {
     restart?: string[];
 
     /**
+     * Whether a failed hot-reload rolls back to the last-good version of the file.
+     *
+     * @defaultValue `true`
+     */
+    rollback?: boolean;
+
+    /**
      * Optional tsconfig path to use for type checking in dev mode.
      *
      * @defaultValue the nearest `tsconfig.json`

--- a/packages/cli/tests/config-loader.test.ts
+++ b/packages/cli/tests/config-loader.test.ts
@@ -27,10 +27,10 @@ const silentLogger: ILogger = {
 describe('ConfigLoader', () => {
     it('resolves paths and build defaults relative to config directory', async () => {
         const moduleLoader: ModuleLoader = {
-            importModule<TModule = unknown>(): TModule {
-                return {
+            importModule<TModule = unknown>(_entryPath: string): Promise<TModule> {
+                return Promise.resolve({
                     default: { instance: './bot.ts', root: './src', entry: './index.ts' } satisfies SeedcordDevConfig
-                } as TModule;
+                } as TModule);
             }
         };
 
@@ -49,8 +49,8 @@ describe('ConfigLoader', () => {
 
     it('throws when instance is missing', async () => {
         const moduleLoader: ModuleLoader = {
-            importModule<TModule = unknown>(): TModule {
-                return { default: { entry: './index.ts' } } as TModule;
+            importModule<TModule = unknown>(_entryPath: string): Promise<TModule> {
+                return Promise.resolve({ default: { entry: './index.ts' } } as TModule);
             }
         };
 
@@ -63,8 +63,8 @@ describe('ConfigLoader', () => {
 
     it('throws when entry is missing', async () => {
         const moduleLoader: ModuleLoader = {
-            importModule<TModule = unknown>(): TModule {
-                return { default: { instance: './bot.ts' } } as TModule;
+            importModule<TModule = unknown>(_entryPath: string): Promise<TModule> {
+                return Promise.resolve({ default: { instance: './bot.ts' } } as TModule);
             }
         };
 
@@ -78,10 +78,10 @@ describe('ConfigLoader', () => {
     it('carries hmr config through to the resolved config and resolves hmr.tsconfig', async () => {
         const hmr = { restart: ['**/*.json'], tsconfig: './tsconfig.dev.json' };
         const moduleLoader: ModuleLoader = {
-            importModule<TModule = unknown>(): TModule {
-                return {
+            importModule<TModule = unknown>(_entryPath: string): Promise<TModule> {
+                return Promise.resolve({
                     default: { instance: './bot.ts', entry: './index.ts', hmr } satisfies SeedcordDevConfig
-                } as TModule;
+                } as TModule);
             }
         };
 
@@ -95,8 +95,8 @@ describe('ConfigLoader', () => {
 
     it('rejects a non-object default export', async () => {
         const moduleLoader: ModuleLoader = {
-            importModule<TModule = unknown>(): TModule {
-                return { default: [] } as TModule;
+            importModule<TModule = unknown>(_entryPath: string): Promise<TModule> {
+                return Promise.resolve({ default: [] } as TModule);
             }
         };
 
@@ -107,8 +107,10 @@ describe('ConfigLoader', () => {
 
     it('rejects a non-array hmr.restart', async () => {
         const moduleLoader: ModuleLoader = {
-            importModule<TModule = unknown>(): TModule {
-                return { default: { instance: './bot.ts', entry: './index.ts', hmr: { restart: 'nope' } } } as TModule;
+            importModule<TModule = unknown>(_entryPath: string): Promise<TModule> {
+                return Promise.resolve({
+                    default: { instance: './bot.ts', entry: './index.ts', hmr: { restart: 'nope' } }
+                } as TModule);
             }
         };
 
@@ -119,10 +121,10 @@ describe('ConfigLoader', () => {
 
     it('rejects a non-boolean hmr.rollback', async () => {
         const moduleLoader: ModuleLoader = {
-            importModule<TModule = unknown>(): TModule {
-                return {
+            importModule<TModule = unknown>(_entryPath: string): Promise<TModule> {
+                return Promise.resolve({
                     default: { instance: './bot.ts', entry: './index.ts', hmr: { rollback: 'nope' } }
-                } as TModule;
+                } as TModule);
             }
         };
 

--- a/packages/cli/tests/config-loader.test.ts
+++ b/packages/cli/tests/config-loader.test.ts
@@ -116,6 +116,20 @@ describe('ConfigLoader', () => {
             new ConfigLoader(moduleLoader, silentLogger).load(join(process.cwd(), 'seedcord.config.ts'))
         ).rejects.toMatchObject({ code: SeedcordErrorCode.CliConfigInvalidHmrRestart });
     });
+
+    it('rejects a non-boolean hmr.rollback', async () => {
+        const moduleLoader: ModuleLoader = {
+            importModule<TModule = unknown>(): TModule {
+                return {
+                    default: { instance: './bot.ts', entry: './index.ts', hmr: { rollback: 'nope' } }
+                } as TModule;
+            }
+        };
+
+        await expect(
+            new ConfigLoader(moduleLoader, silentLogger).load(join(process.cwd(), 'seedcord.config.ts'))
+        ).rejects.toMatchObject({ code: SeedcordErrorCode.CliConfigInvalidHmrRollback });
+    });
 });
 
 describe('isSeedcordInstance', () => {

--- a/packages/cli/tests/hmr.test.ts
+++ b/packages/cli/tests/hmr.test.ts
@@ -57,8 +57,9 @@ describe('HmrPlugin', () => {
     it('carries the config rollback flag onto the hmr payload', () => {
         const plugin = new HmrPlugin({ ...mockConfig, hmr: { rollback: false } });
         const hotSend = vi.fn();
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- spy on the private hot getter
-        vi.spyOn(plugin as any, 'hot', 'get').mockReturnValue({ send: hotSend, on: vi.fn() });
+        // justified: spy on the private `hot` getter, which the public type does not expose
+        const hotHost = plugin as unknown as { hot: { send: typeof hotSend; on: ReturnType<typeof vi.fn> } };
+        vi.spyOn(hotHost, 'hot', 'get').mockReturnValue({ send: hotSend, on: vi.fn() });
 
         const watcher = new EventEmitter();
         const server = {

--- a/packages/cli/tests/hmr.test.ts
+++ b/packages/cli/tests/hmr.test.ts
@@ -54,6 +54,25 @@ describe('HmrPlugin', () => {
         expect(plugin.hotUpdate).toBeDefined();
     });
 
+    it('carries the config rollback flag onto the hmr payload', () => {
+        const plugin = new HmrPlugin({ ...mockConfig, hmr: { rollback: false } });
+        const hotSend = vi.fn();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- spy on the private hot getter
+        vi.spyOn(plugin as any, 'hot', 'get').mockReturnValue({ send: hotSend, on: vi.fn() });
+
+        const watcher = new EventEmitter();
+        const server = {
+            watcher,
+            environments: { ssr: { hot: { send: vi.fn(), on: vi.fn() } } }
+        } as unknown as ViteDevServer;
+        (plugin.plugin.configureServer as (s: ViteDevServer) => void)(server);
+
+        const file = join(process.cwd(), 'src/commands/ping.ts');
+        watcher.emit('add', file);
+
+        expect(hotSend).toHaveBeenCalledWith(HMR_EVENT_NAME, { file, type: 'create', rollback: false });
+    });
+
     describe('configureServer (File Events)', () => {
         let serverMock: ViteDevServer;
         let watcher: EventEmitter;
@@ -101,7 +120,8 @@ describe('HmrPlugin', () => {
             expect(loggerSpies.info).toHaveBeenCalledWith(expect.stringContaining('CREATE'));
             expect(hotSendMock).toHaveBeenCalledWith(HMR_EVENT_NAME, {
                 file,
-                type: 'create'
+                type: 'create',
+                rollback: true
             });
         });
 
@@ -112,7 +132,8 @@ describe('HmrPlugin', () => {
             expect(loggerSpies.info).toHaveBeenCalledWith(expect.stringContaining('DELETE'));
             expect(hotSendMock).toHaveBeenCalledWith(HMR_EVENT_NAME, {
                 file,
-                type: 'delete'
+                type: 'delete',
+                rollback: true
             });
         });
 
@@ -123,7 +144,8 @@ describe('HmrPlugin', () => {
             expect(loggerSpies.info).toHaveBeenCalledWith(expect.stringContaining('CREATEDIR'));
             expect(hotSendMock).toHaveBeenCalledWith(HMR_EVENT_NAME, {
                 file,
-                type: 'createDir'
+                type: 'createDir',
+                rollback: true
             });
         });
 
@@ -134,7 +156,8 @@ describe('HmrPlugin', () => {
             expect(loggerSpies.info).toHaveBeenCalledWith(expect.stringContaining('DELETEDIR'));
             expect(hotSendMock).toHaveBeenCalledWith(HMR_EVENT_NAME, {
                 file,
-                type: 'deleteDir'
+                type: 'deleteDir',
+                rollback: true
             });
         });
     });
@@ -204,7 +227,8 @@ describe('HmrPlugin', () => {
             expect(hotSendMock).toHaveBeenCalledWith(HMR_EVENT_NAME, {
                 file,
                 type: 'update',
-                affectedModules: expect.arrayContaining([file, importerFile]) as HmrUpdateEvent['affectedModules']
+                affectedModules: expect.arrayContaining([file, importerFile]) as HmrUpdateEvent['affectedModules'],
+                rollback: true
             });
         });
 
@@ -257,7 +281,8 @@ describe('HmrPlugin', () => {
             expect(hotSendMock).toHaveBeenCalledWith(HMR_EVENT_NAME, {
                 file,
                 type: 'update',
-                affectedModules: expect.arrayContaining([file, importerFile]) as HmrUpdateEvent['affectedModules']
+                affectedModules: expect.arrayContaining([file, importerFile]) as HmrUpdateEvent['affectedModules'],
+                rollback: true
             });
         });
 

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -11,7 +11,7 @@
             "@utils/*": ["./src/utils/*"],
             "@api/*": ["./src/api/*"]
         },
-        "types": ["react", "vite/client"],
+        "types": ["react"],
         "jsx": "react"
     },
     "include": [

--- a/packages/errors/src/ErrorCodes.ts
+++ b/packages/errors/src/ErrorCodes.ts
@@ -196,5 +196,7 @@ export enum SeedcordErrorCode {
     /** `commands --clean --all-guilds` matched more guilds than the safety threshold without `--yes`. */
     CliCleanLargeBotUnconfirmed = 3130,
     /** `commands --clean --apply` ran in a non-interactive environment without `--yes`, where it cannot prompt. */
-    CliCleanApplyNeedsYes = 3131
+    CliCleanApplyNeedsYes = 3131,
+    /** Config hmr rollback flag must be a boolean when provided. */
+    CliConfigInvalidHmrRollback = 3132
 }

--- a/packages/errors/src/ErrorCodes.ts
+++ b/packages/errors/src/ErrorCodes.ts
@@ -56,6 +56,11 @@ export enum SeedcordErrorCode {
     /** Middleware priority provided by the decorator was not a finite number. */
     DecoratorInvalidMiddlewarePriority = 1306,
 
+    /** Two interaction handlers registered the same route within a scope. */
+    InteractionDuplicateRoute = 1401,
+    /** Two different interaction middleware classes share a class name. */
+    InteractionDuplicateMiddleware = 1402,
+
     /** StrictEventEmitter.waitFor was aborted via its AbortSignal. */
     EventEmitterWaitForAborted = 1501,
     /** StrictEventEmitter.waitFor exceeded its configured timeout. */

--- a/packages/errors/src/ErrorMessages.ts
+++ b/packages/errors/src/ErrorMessages.ts
@@ -153,6 +153,7 @@ const messages = {
     [SeedcordErrorCode.CliConfigInvalidHmr]: () => 'Config `hmr` must be an object when provided.',
     [SeedcordErrorCode.CliConfigInvalidHmrRestart]: () =>
         'Config `hmr.restart` must be an array of strings when provided.',
+    [SeedcordErrorCode.CliConfigInvalidHmrRollback]: () => 'Config `hmr.rollback` must be a boolean when provided.',
     [SeedcordErrorCode.CliCodegenDuplicateRoute]: (route: string, firstFile: string, secondFile: string) =>
         `Two commands resolve to the same slash route \`${route}\`. Defined in ${firstFile} and ${secondFile}. Rename one.`,
     [SeedcordErrorCode.CliCodegenCommandsDirUnreadable]: (dir: string, reason: string) =>

--- a/packages/errors/src/ErrorMessages.ts
+++ b/packages/errors/src/ErrorMessages.ts
@@ -47,6 +47,11 @@ const messages = {
         'RegisterCommand("guild") requires a non-empty guilds array.',
     [SeedcordErrorCode.DecoratorInvalidMiddlewarePriority]: () => 'Middleware priority must be a finite number.',
 
+    [SeedcordErrorCode.InteractionDuplicateRoute]: (route: string, firstClass: string, secondClass: string) =>
+        `Two interaction handlers resolve to the same route \`${route}\`. Registered by ${firstClass} and ${secondClass}. Rename one.`,
+    [SeedcordErrorCode.InteractionDuplicateMiddleware]: (name: string) =>
+        `Two different interaction middleware classes share the name \`${name}\`. Rename one so they do not collide.`,
+
     [SeedcordErrorCode.EventEmitterWaitForAborted]: () => 'waitFor was aborted via its AbortSignal.',
     [SeedcordErrorCode.EventEmitterWaitForTimeout]: (timeout: number) => `waitFor timed out after ${timeout}ms.`,
 

--- a/packages/kit/tsconfig.json
+++ b/packages/kit/tsconfig.json
@@ -11,7 +11,7 @@
             "@pagination/*": ["./src/pagination/*"],
             "@stops/*": ["./src/stops/*"]
         },
-        "types": ["vite/client"]
+        "types": []
     },
     "include": ["src/**/*.ts", "tests/**/*.ts", "tsdown.config.ts", "vitest.config.ts"],
     "exclude": ["node_modules", "dist"]

--- a/packages/plugins/src/kysely-pg/KyselyPg.ts
+++ b/packages/plugins/src/kysely-pg/KyselyPg.ts
@@ -30,8 +30,8 @@ export interface KyselyArtifact {
 /**
  * Postgres plugin using Kysely.
  *
- * Handles setting up the connection pool, applying migrations, and
- * registering decorated services so they can be resolved from the core.
+ * Sets up the connection pool, applies migrations, and registers decorated
+ * services so the core can resolve them.
  */
 export class KyselyPg<Database extends object> extends Plugin {
     public readonly logger = new Logger('KyselyPg');
@@ -83,8 +83,7 @@ export class KyselyPg<Database extends object> extends Plugin {
             registerHandler: this.serviceRegistry.initializeService.bind(this.serviceRegistry),
             unregisterHandler: this.serviceRegistry.unregister.bind(this.serviceRegistry),
             getArtifacts: this.getArtifacts.bind(this),
-            logger: this.logger,
-            name: 'KyselyPg'
+            logger: this.logger
         });
     }
 
@@ -101,7 +100,7 @@ export class KyselyPg<Database extends object> extends Plugin {
     /**
      * Connects to Postgres, runs any startup migrations, and loads decorated services.
      *
-     * Safe to call multiple times; subsequent calls exit early.
+     * Safe to call multiple times, subsequent calls exit early.
      */
     public async init(): Promise<void> {
         if (this.isInitialised) return;

--- a/packages/plugins/src/mongo/Mongo.ts
+++ b/packages/plugins/src/mongo/Mongo.ts
@@ -49,8 +49,8 @@ export class Mongo extends Plugin {
         if (!this.servicesReady) {
             throw new SeedcordError(SeedcordErrorCode.PluginMongoServicesNotReady);
         }
-        // MongoServices is augmented per-consumer via declaration merging; the registry holds the
-        // instances opaquely and exposes the generated map shape at this public boundary.
+        // MongoServices is augmented per-consumer via declaration merging, so the registry's opaque
+        // instances surface as the generated map shape at this boundary.
         return this._services;
     }
 
@@ -79,8 +79,7 @@ export class Mongo extends Plugin {
             registerHandler: this.initializeService.bind(this),
             unregisterHandler: this.unregister.bind(this),
             getArtifacts: this.getArtifacts.bind(this),
-            logger: this.logger,
-            name: 'Mongo'
+            logger: this.logger
         });
     }
 
@@ -206,7 +205,7 @@ export class Mongo extends Plugin {
             (Reflect.getMetadata(ModelMetadataKey, Service) as mongoose.Model<unknown> | undefined)?.modelName;
 
         if (key && this._services[key]) {
-            // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- key is a runtime service name, not a static property
+            // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- key is a runtime service name
             delete this._services[key];
         }
 

--- a/packages/plugins/tests/kysely/Kysely.test.ts
+++ b/packages/plugins/tests/kysely/Kysely.test.ts
@@ -12,7 +12,7 @@ const pluginsPath = path.resolve(__dirname, '../../src/index').replace(/\\/g, '/
 
 describe('KyselyPg Plugin Integration', () => {
     let testEnv: TestEnvironment;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test fixture, the Database type param is irrelevant
     let kyselyPg: KyselyPg<any>;
     let mockCore: Core;
 
@@ -85,7 +85,7 @@ describe('KyselyPg Plugin Integration', () => {
 
         expect(kyselyPg.services).toHaveProperty('users');
 
-        // Simulate HMR update: Change key
+        // HMR update that changes the registered key
         await testEnv.createFile(
             `${servicesDir}/UserService.ts`,
             `
@@ -107,5 +107,101 @@ describe('KyselyPg Plugin Integration', () => {
 
         expect(kyselyPg.services).not.toHaveProperty('users');
         expect(kyselyPg.services).toHaveProperty('admins');
+    });
+
+    it('keeps other tracked services registered when one leaf reloads', async () => {
+        const servicesDir = 'services';
+        const userFile = await testEnv.createFile(
+            `${servicesDir}/UserService.ts`,
+            `
+            import { KpgService, RegisterKpgService } from '${pluginsPath}';
+
+            @RegisterKpgService('users')
+            export class UserService extends KpgService<any> {
+                public async findUser() {
+                    return 'user';
+                }
+            }
+            `
+        );
+        await testEnv.createFile(
+            `${servicesDir}/ProductService.ts`,
+            `
+            import { KpgService, RegisterKpgService } from '${pluginsPath}';
+
+            @RegisterKpgService('products')
+            export class ProductService extends KpgService<any> {
+                public async findProduct() {
+                    return 'product';
+                }
+            }
+            `
+        );
+
+        kyselyPg = new KyselyPg(mockCore, {
+            connectionString: 'postgres://localhost:5432/test',
+            migrations: { path: testEnv.resolvePath('migrations') },
+            dir: testEnv.resolvePath(servicesDir)
+        });
+
+        await kyselyPg.init();
+
+        expect(kyselyPg.services).toHaveProperty('users');
+        expect(kyselyPg.services).toHaveProperty('products');
+
+        // reload only the user leaf
+        await testEnv.createFile(
+            `${servicesDir}/UserService.ts`,
+            `
+            import { KpgService, RegisterKpgService } from '${pluginsPath}';
+
+            @RegisterKpgService('admins')
+            export class UserService extends KpgService<any> {
+                public async findUser() {
+                    return 'admin';
+                }
+            }
+            `
+        );
+
+        await kyselyPg.onHmr({ file: userFile, type: 'update' });
+
+        // the unchanged product leaf is still tracked, so the store survived the single-leaf reload
+        expect(kyselyPg.services).toHaveProperty('products');
+        expect(kyselyPg.services).toHaveProperty('admins');
+        expect(kyselyPg.services).not.toHaveProperty('users');
+    });
+
+    it('keeps the last-good service when a reload throws', async () => {
+        const servicesDir = 'services';
+        const userFile = await testEnv.createFile(
+            `${servicesDir}/UserService.ts`,
+            `
+            import { KpgService, RegisterKpgService } from '${pluginsPath}';
+
+            @RegisterKpgService('users')
+            export class UserService extends KpgService<any> {
+                public async findUser() {
+                    return 'user';
+                }
+            }
+            `
+        );
+
+        kyselyPg = new KyselyPg(mockCore, {
+            connectionString: 'postgres://localhost:5432/test',
+            migrations: { path: testEnv.resolvePath('migrations') },
+            dir: testEnv.resolvePath(servicesDir)
+        });
+
+        await kyselyPg.init();
+        expect(kyselyPg.services).toHaveProperty('users');
+
+        // a broken edit, the reload import throws
+        await testEnv.createFile(`${servicesDir}/UserService.ts`, 'export const broken = {{{ not valid');
+        await kyselyPg.onHmr({ file: userFile, type: 'update' });
+
+        // the failed reload rolled back, so the last-good service round-trips and stays registered
+        expect(kyselyPg.services).toHaveProperty('users');
     });
 });

--- a/packages/seedcord/src/Seedcord.ts
+++ b/packages/seedcord/src/Seedcord.ts
@@ -131,6 +131,7 @@ export class Seedcord extends Pluggable implements Core {
     private registerHmrAwareModules(): void {
         this.startup.addTask(StartupPhase.Configuration, 'HMR Registration', async () => {
             this.hmrManager.register(this.bot);
+            this.hmrManager.register(this.bus);
             for (const plugin of this.plugins) {
                 this.hmrManager.register(plugin);
             }

--- a/packages/seedcord/src/bot/controllers/CommandRegistry.ts
+++ b/packages/seedcord/src/bot/controllers/CommandRegistry.ts
@@ -11,6 +11,7 @@ import { Envapter } from 'envapt';
 
 import { contextMenuLeaves } from '@bUtilities/miscellaneous/contextMenuLeaves';
 import { slashRouteLeaves } from '@bUtilities/miscellaneous/slashRouteLeaves';
+import { getDevChannel } from '@hmr/devChannel';
 import { HmrModuleHandler } from '@hmr/HmrModuleHandler';
 import { CommandMetadataKey } from '@src/metadataKeys';
 
@@ -39,7 +40,7 @@ interface CommandArtifact {
  * Manages Discord application command registration and deployment.
  *
  * Scans command directories, builds command structures, and registers both global and guild-scoped commands
- * to Discord's API. Accessed via `core.bot.commands`, not constructed directly.
+ * to Discord's API. Accessed via `core.bot.commands`. Do not construct it directly.
  */
 export class CommandRegistry implements Initializeable, HmrAware {
     public readonly name = 'Commands';
@@ -69,8 +70,7 @@ export class CommandRegistry implements Initializeable, HmrAware {
             registerHandler: this.registerCommand.bind(this),
             unregisterHandler: this.unregisterCommand.bind(this),
             getArtifacts: this.getArtifacts.bind(this),
-            logger: this.logger,
-            name: 'Commands'
+            logger: this.logger
         });
     }
 
@@ -95,11 +95,9 @@ export class CommandRegistry implements Initializeable, HmrAware {
             'guild groups': this.guildCommands.size
         });
 
-        if (import.meta.hot) {
-            import.meta.hot.on('seedcord:refresh-commands', (data) => {
-                void this.refresh(data.shouldRefresh);
-            });
-        }
+        getDevChannel()?.on('seedcord:refresh-commands', (data) => {
+            void this.refresh(data.shouldRefresh);
+        });
     }
 
     /** @internal */
@@ -124,11 +122,9 @@ export class CommandRegistry implements Initializeable, HmrAware {
         if (commandsDir && event.file.startsWith(resolve(process.cwd(), commandsDir))) {
             this.pendingEvents.delete(event.file);
             this.pendingEvents.set(event.file, event);
-            if (import.meta.hot) {
-                import.meta.hot.send('seedcord:commands-update-prompt', {
-                    files: Array.from(this.pendingEvents.keys()).map((f) => formatFilePath(f))
-                });
-            }
+            getDevChannel()?.send('seedcord:commands-update-prompt', {
+                files: Array.from(this.pendingEvents.keys()).map((f) => formatFilePath(f))
+            });
         } else {
             await this.hmrHandler?.handle(event);
         }

--- a/packages/seedcord/src/bot/controllers/EventDispatcher.ts
+++ b/packages/seedcord/src/bot/controllers/EventDispatcher.ts
@@ -172,8 +172,7 @@ export class EventDispatcher implements Initializeable, HmrAware {
                 }
             }
         }
-        // spent follows the ctor identity, so leaving executedOnceHandlers alone here keeps an HMR rollback's
-        // re-registered ctor spent. a genuine reload brings a fresh ctor that is naturally unspent.
+        // spent follows the ctor identity, so leaving executedOnceHandlers alone keeps a rollback-restored ctor spent
     }
 
     private unregisterMiddleware(middlewareCtor: EventMiddlewareConstructor): void {
@@ -315,8 +314,7 @@ export class EventDispatcher implements Initializeable, HmrAware {
 
         for (const entry of handlersToExecute) {
             // mark a 'once' handler spent before running so a rethrow can't re-fire it. the has() re-check
-            // closes the window where a concurrent fire claimed it during the runMiddlewares await, past
-            // the snapshot above
+            // closes the window where a concurrent fire claimed it during the runMiddlewares await
             if (entry.frequency === 'once') {
                 if (this.executedOnceHandlers.has(entry.ctor)) continue;
                 this.executedOnceHandlers.add(entry.ctor);

--- a/packages/seedcord/src/bot/controllers/EventDispatcher.ts
+++ b/packages/seedcord/src/bot/controllers/EventDispatcher.ts
@@ -82,8 +82,7 @@ export class EventDispatcher implements Initializeable, HmrAware {
             unregisterHandler: this.unregisterHandler.bind(this),
             unregisterMiddleware: this.unregisterMiddleware.bind(this),
             getArtifacts: this.getArtifacts.bind(this),
-            logger: this.logger,
-            name: 'Event'
+            logger: this.logger
         });
     }
 
@@ -173,7 +172,8 @@ export class EventDispatcher implements Initializeable, HmrAware {
                 }
             }
         }
-        this.executedOnceHandlers.delete(handlerClass);
+        // spent follows the ctor identity, so leaving executedOnceHandlers alone here keeps an HMR rollback's
+        // re-registered ctor spent. a genuine reload brings a fresh ctor that is naturally unspent.
     }
 
     private unregisterMiddleware(middlewareCtor: EventMiddlewareConstructor): void {

--- a/packages/seedcord/src/bot/controllers/EventDispatcher.ts
+++ b/packages/seedcord/src/bot/controllers/EventDispatcher.ts
@@ -314,8 +314,13 @@ export class EventDispatcher implements Initializeable, HmrAware {
         if (!shouldContinue) return;
 
         for (const entry of handlersToExecute) {
-            // mark a 'once' handler spent before running it, so an abnormal rethrow cannot re-fire it
-            if (entry.frequency === 'once') this.executedOnceHandlers.add(entry.ctor);
+            // mark a 'once' handler spent before running so a rethrow can't re-fire it. the has() re-check
+            // closes the window where a concurrent fire claimed it during the runMiddlewares await, past
+            // the snapshot above
+            if (entry.frequency === 'once') {
+                if (this.executedOnceHandlers.has(entry.ctor)) continue;
+                this.executedOnceHandlers.add(entry.ctor);
+            }
 
             await this.processHandler(eventName, entry.ctor, args);
         }

--- a/packages/seedcord/src/bot/controllers/InteractionDispatcher.ts
+++ b/packages/seedcord/src/bot/controllers/InteractionDispatcher.ts
@@ -266,14 +266,15 @@ export class InteractionDispatcher implements Initializeable, HmrAware {
         const metadata = Reflect.getMetadata(MiddlewareMetadataKey, middlewareCtor) as MiddlewareMetadata | undefined;
         if (metadata?.type !== MiddlewareType.Interaction) return;
 
-        const existingIndex = this.middlewares.findIndex((entry) => entry.ctor.name === middlewareCtor.name);
+        // same class re-registered (double import or an HMR re-scan) is idempotent, matching event middleware
+        if (this.middlewares.some((entry) => entry.ctor === middlewareCtor)) return;
 
-        if (existingIndex !== -1) {
-            this.middlewares[existingIndex] = { ctor: middlewareCtor, priority: metadata.priority };
-        } else {
-            this.middlewares.push({ ctor: middlewareCtor, priority: metadata.priority });
+        // a different class sharing the name used to silently overwrite the first, surface it instead
+        if (this.middlewares.some((entry) => entry.ctor.name === middlewareCtor.name)) {
+            throw new SeedcordError(SeedcordErrorCode.InteractionDuplicateMiddleware, [middlewareCtor.name]);
         }
 
+        this.middlewares.push({ ctor: middlewareCtor, priority: metadata.priority });
         this.middlewares.sort((a, b) => a.priority - b.priority);
 
         this.logger.utils.registration(
@@ -302,7 +303,18 @@ export class InteractionDispatcher implements Initializeable, HmrAware {
             if (!areRoutes(meta)) continue;
 
             const routes = meta;
-            routes.forEach((route) => map.set(route, handlerClass));
+            routes.forEach((route) => {
+                const existing = map.get(route);
+                // a different class on the same route would silently shadow (last write would win), throw instead
+                if (existing && existing !== handlerClass) {
+                    throw new SeedcordError(SeedcordErrorCode.InteractionDuplicateRoute, [
+                        route,
+                        existing.name,
+                        handlerClass.name
+                    ]);
+                }
+                map.set(route, handlerClass);
+            });
 
             this.logger.utils.registration(handlerClass.name, formatFilePath(relativePath));
         }

--- a/packages/seedcord/src/bot/controllers/InteractionDispatcher.ts
+++ b/packages/seedcord/src/bot/controllers/InteractionDispatcher.ts
@@ -297,12 +297,14 @@ export class InteractionDispatcher implements Initializeable, HmrAware {
     }
 
     private registerHandler(handlerClass: HandlerConstructor, relativePath: string): void {
+        // a partial registration would orphan routes and break hmr rollback
+        const writes: [Collection<string, HandlerConstructor>, string][] = [];
+
         for (const [routeType, map] of this.routeTypes) {
             const meta: unknown = Reflect.getMetadata(InteractionRouteKeys[routeType], handlerClass);
             if (!areRoutes(meta)) continue;
 
-            const routes = meta;
-            routes.forEach((route) => {
+            for (const route of meta) {
                 const existing = map.get(route);
                 // a different class on the same route would silently shadow (last write wins), so this throws
                 if (existing && existing !== handlerClass) {
@@ -312,11 +314,13 @@ export class InteractionDispatcher implements Initializeable, HmrAware {
                         handlerClass.name
                     ]);
                 }
-                map.set(route, handlerClass);
-            });
+                writes.push([map, route]);
+            }
 
             this.logger.utils.registration(handlerClass.name, formatFilePath(relativePath));
         }
+
+        for (const [map, route] of writes) map.set(route, handlerClass);
     }
 
     /** @internal For use in dev mode */

--- a/packages/seedcord/src/bot/controllers/InteractionDispatcher.ts
+++ b/packages/seedcord/src/bot/controllers/InteractionDispatcher.ts
@@ -1,4 +1,4 @@
-/* eslint-disable max-lines */
+/* eslint-disable max-lines -- one handler method per interaction type keeps the router in one file */
 import { SeedcordErrorCode } from '@seedcord/errors';
 import { SeedcordError } from '@seedcord/errors/internal';
 import { prefixOf } from '@seedcord/kit/internal';
@@ -114,7 +114,7 @@ export class InteractionDispatcher implements Initializeable, HmrAware {
             for (const ignoredKey of ignoredKeysFromConfig) this.keysToIgnore.add(ignoredKey);
         }
 
-        // the in-process getConfirmation() collector handles these clicks, so ignore them here or the global
+        // the in-process getConfirmation() collector consumes these clicks, so ignore them here or the global
         // router double-acks them.
         this.keysToIgnore.add(CONFIRM_DEF);
 
@@ -141,14 +141,13 @@ export class InteractionDispatcher implements Initializeable, HmrAware {
             unregisterHandler: this.unregisterHandler.bind(this),
             unregisterMiddleware: this.unregisterMiddleware.bind(this),
             getArtifacts: this.getArtifacts.bind(this),
-            logger: this.logger,
-            name: 'Interaction'
+            logger: this.logger
         });
     }
 
     /**
      * Warns for each command route with no registered `@SlashRoute` handler, which would fall through to
-     * UnhandledEvent at runtime. Warns rather than throws since a bot may route commands outside the registry.
+     * UnhandledEvent at runtime. It warns and does not throw, because a bot may route commands outside the registry.
      *
      * @internal
      */
@@ -269,7 +268,7 @@ export class InteractionDispatcher implements Initializeable, HmrAware {
         // same class re-registered (double import or an HMR re-scan) is idempotent, matching event middleware
         if (this.middlewares.some((entry) => entry.ctor === middlewareCtor)) return;
 
-        // a different class sharing the name used to silently overwrite the first, surface it instead
+        // a different class sharing the name would silently overwrite the first, so this throws to surface it
         if (this.middlewares.some((entry) => entry.ctor.name === middlewareCtor.name)) {
             throw new SeedcordError(SeedcordErrorCode.InteractionDuplicateMiddleware, [middlewareCtor.name]);
         }
@@ -305,7 +304,7 @@ export class InteractionDispatcher implements Initializeable, HmrAware {
             const routes = meta;
             routes.forEach((route) => {
                 const existing = map.get(route);
-                // a different class on the same route would silently shadow (last write would win), throw instead
+                // a different class on the same route would silently shadow (last write wins), so this throws
                 if (existing && existing !== handlerClass) {
                     throw new SeedcordError(SeedcordErrorCode.InteractionDuplicateRoute, [
                         route,

--- a/packages/seedcord/src/bot/controllers/InteractionDispatcher.ts
+++ b/packages/seedcord/src/bot/controllers/InteractionDispatcher.ts
@@ -147,7 +147,7 @@ export class InteractionDispatcher implements Initializeable, HmrAware {
 
     /**
      * Warns for each command route with no registered `@SlashRoute` handler, which would fall through to
-     * UnhandledEvent at runtime. It warns and does not throw, because a bot may route commands outside the registry.
+     * UnhandledEvent at runtime. A bot may route commands outside the registry, so this does not throw.
      *
      * @internal
      */

--- a/packages/seedcord/src/hmr/HmrManager.ts
+++ b/packages/seedcord/src/hmr/HmrManager.ts
@@ -1,9 +1,12 @@
 import { Logger } from '@seedcord/services';
+import { wrapHot } from '@seedcord/types/internal';
 import { formatFilePath } from '@seedcord/utils';
 import chalk from 'chalk';
 import { Envapter } from 'envapt';
 
-import type { HmrAware, HmrUpdateEvent } from '@seedcord/types/internal';
+import { getDevChannel, setDevChannel } from './devChannel';
+
+import type { HmrAware, HmrUpdateEvent, SeedcordCliEvents, SeedcordFrameworkEvents } from '@seedcord/types/internal';
 
 export class HmrManager {
     private readonly logger = new Logger('HMR', { channel: 'hmr' });
@@ -13,10 +16,15 @@ export class HmrManager {
 
     /** @internal */
     public init(): void {
-        if (import.meta.hot && (Envapter.isDevelopment || Envapter.isTest)) {
+        if (!import.meta.hot) return;
+        // the one raw `import.meta.hot` read in the framework, captured into the dev-channel singleton
+        // so every other framework site reads it through getDevChannel
+        setDevChannel(wrapHot<SeedcordFrameworkEvents, SeedcordCliEvents>(import.meta.hot));
+
+        if (Envapter.isDevelopment || Envapter.isTest) {
             this.logger.info('Enabled');
 
-            import.meta.hot.on('seedcord:hmr', (payload) => {
+            getDevChannel()?.on('seedcord:hmr', (payload) => {
                 const affected = payload.affectedModules?.length ?? 0;
                 this.logger.info(`${chalk.bold('1')} module changed, ${chalk.bold(affected)} affected modules`);
 

--- a/packages/seedcord/src/hmr/HmrModuleHandler.ts
+++ b/packages/seedcord/src/hmr/HmrModuleHandler.ts
@@ -106,7 +106,6 @@ export class HmrModuleHandler<THandler, TMiddleware = void, TArtifacts = unknown
         }
     }
 
-    // reloads one file, restoring the last-good units if the reload fails and rollback is enabled
     private async reloadWithRollback(file: string, rollbackEnabled: boolean): Promise<void> {
         const { logger } = this.options;
         const snapshot = this.snapshotUnits(file);
@@ -230,8 +229,7 @@ export class HmrModuleHandler<THandler, TMiddleware = void, TArtifacts = unknown
         }
     }
 
-    // snapshot the file's tracked units so a failed reload can re-register the last-good ones. the units
-    // are class objects, so restoring re-registers the same classes and a db plugin's connection is untouched
+    // units are class objects, so restoring re-registers the same classes and a db plugin's connection is untouched
     private snapshotUnits(file: string): { handlers: THandler[]; middlewares: TMiddleware[] } {
         return {
             handlers: Array.from(this.store.fileToHandlers.get(file) ?? []),

--- a/packages/seedcord/src/hmr/HmrModuleHandler.ts
+++ b/packages/seedcord/src/hmr/HmrModuleHandler.ts
@@ -14,10 +14,6 @@ interface HmrStore<THandler, TMiddleware, TArtifacts> {
     handlerArtifacts: Map<THandler, TArtifacts>;
 }
 
-interface HmrData {
-    hmr?: Record<string, HmrStore<unknown, unknown, unknown>>;
-}
-
 /**
  * Options for configuring the HmrModuleHandler.
  *
@@ -44,8 +40,6 @@ interface HmrModuleHandlerOptions<THandler, TMiddleware = void, TArtifacts = unk
     getArtifacts?: (handler: THandler) => TArtifacts;
     /** Logger instance for logging HMR activities.*/
     logger: Logger;
-    /** Name of the module handler, used in logging. */
-    name: string;
 }
 
 /**
@@ -60,26 +54,16 @@ export class HmrModuleHandler<THandler, TMiddleware = void, TArtifacts = unknown
     private readonly options: HmrModuleHandlerOptions<THandler, TMiddleware, TArtifacts>;
 
     constructor(options: HmrModuleHandlerOptions<THandler, TMiddleware, TArtifacts>) {
-        // Copy rather than mutate the caller's options object when scoping the logger to the hmr channel.
+        // spread into a new object so scoping the logger to the hmr channel leaves the caller's options unchanged.
         this.options = { ...options, logger: options.logger.inChannel('hmr') };
 
-        if (import.meta.hot) {
-            const data = import.meta.hot.data as HmrData;
-            data.hmr ??= {};
-            this.store = data.hmr[this.options.name] = (data.hmr[this.options.name] as
-                | HmrStore<THandler, TMiddleware, TArtifacts>
-                | undefined) ?? {
-                fileToHandlers: new Map(),
-                fileToMiddlewares: new Map(),
-                handlerArtifacts: new Map()
-            };
-        } else {
-            this.store = {
-                fileToHandlers: new Map(),
-                fileToMiddlewares: new Map(),
-                handlerArtifacts: new Map()
-            };
-        }
+        // the Maps survive a leaf reload by ordinary object lifetime, the Seedcord singleton is never
+        // reconstructed and a reload re-imports only the changed file, so no import.meta.hot.data stash is needed
+        this.store = {
+            fileToHandlers: new Map(),
+            fileToMiddlewares: new Map(),
+            handlerArtifacts: new Map()
+        };
     }
 
     /**
@@ -91,6 +75,7 @@ export class HmrModuleHandler<THandler, TMiddleware = void, TArtifacts = unknown
     public async handle(event: HmrUpdateEvent): Promise<void> {
         const { file, affectedModules, type } = event;
         const { logger, handlersDir, middlewaresDir } = this.options;
+        const rollbackEnabled = event.rollback ?? true;
 
         if (type === 'delete' || type === 'deleteDir') {
             this.unload(file);
@@ -117,10 +102,26 @@ export class HmrModuleHandler<THandler, TMiddleware = void, TArtifacts = unknown
                 continue;
             }
 
-            this.unload(fileToReload);
-
-            await this.reloadFile(fileToReload);
+            await this.reloadWithRollback(fileToReload, rollbackEnabled);
         }
+    }
+
+    // reloads one file, restoring the last-good units if the reload fails and rollback is enabled
+    private async reloadWithRollback(file: string, rollbackEnabled: boolean): Promise<void> {
+        const { logger } = this.options;
+        const snapshot = this.snapshotUnits(file);
+        this.unload(file);
+
+        const reloaded = await this.reloadFile(file);
+        if (reloaded) return;
+
+        // drop any partial registration the failed reload left, so the file ends in a clean state
+        this.unload(file);
+        if (!rollbackEnabled) return;
+
+        // restore the last-good units, a typo keeps them live until the next good save
+        this.restoreUnits(file, snapshot);
+        logger.warn(`${chalk.yellow.bold('Rolled back')} ${chalk.gray(formatFilePath(file))} to the last-good version`);
     }
 
     /**
@@ -189,18 +190,17 @@ export class HmrModuleHandler<THandler, TMiddleware = void, TArtifacts = unknown
         }
     }
 
-    private async reloadFile(file: string): Promise<void> {
+    private async reloadFile(file: string): Promise<boolean> {
         const { logger, isHandler, isMiddleware, registerHandler, registerMiddleware } = this.options;
 
         if (!existsSync(file)) {
             logger.info(`File does not exist, skipping reload: ${formatFilePath(file)}`);
-            return;
+            return false;
         }
 
         try {
             let fileUrl = pathToFileURL(file).href;
-            // In the vitest environment, we need to bust the cache manually because
-            // we are simulating HMR without a real Vite server handling the module graph updates.
+            // vitest has no real vite server managing the module graph, so bust the import cache manually.
             if (process.env.VITEST === 'true') fileUrl += `?update=${Date.now()}`;
 
             const imported = (await import(fileUrl)) as Record<string, unknown>;
@@ -222,8 +222,34 @@ export class HmrModuleHandler<THandler, TMiddleware = void, TArtifacts = unknown
                     );
                 }
             }
+
+            return true;
         } catch (error) {
             logger.error(`Failed to reload file: ${file}`, error);
+            return false;
+        }
+    }
+
+    // snapshot the file's tracked units so a failed reload can re-register the last-good ones. the units
+    // are class objects, so restoring re-registers the same classes and a db plugin's connection is untouched
+    private snapshotUnits(file: string): { handlers: THandler[]; middlewares: TMiddleware[] } {
+        return {
+            handlers: Array.from(this.store.fileToHandlers.get(file) ?? []),
+            middlewares: Array.from(this.store.fileToMiddlewares.get(file) ?? [])
+        };
+    }
+
+    private restoreUnits(file: string, snapshot: { handlers: THandler[]; middlewares: TMiddleware[] }): void {
+        for (const handler of snapshot.handlers) {
+            this.options.registerHandler(handler, file);
+            this.trackHandler(file, handler);
+        }
+
+        if (this.options.registerMiddleware) {
+            for (const middleware of snapshot.middlewares) {
+                this.options.registerMiddleware(middleware, file);
+                this.trackMiddleware(file, middleware);
+            }
         }
     }
 }

--- a/packages/seedcord/src/hmr/devChannel.ts
+++ b/packages/seedcord/src/hmr/devChannel.ts
@@ -4,7 +4,7 @@ import type { DevChannel, SeedcordCliEvents, SeedcordFrameworkEvents } from '@se
 // package exposes only ".", so an unbarreled singleton stays unreachable by user and plugin code at runtime.
 let channel: DevChannel<SeedcordFrameworkEvents, SeedcordCliEvents> | undefined;
 
-export function setDevChannel(next: DevChannel<SeedcordFrameworkEvents, SeedcordCliEvents>): void {
+export function setDevChannel(next: DevChannel<SeedcordFrameworkEvents, SeedcordCliEvents> | undefined): void {
     channel = next;
 }
 

--- a/packages/seedcord/src/hmr/devChannel.ts
+++ b/packages/seedcord/src/hmr/devChannel.ts
@@ -1,0 +1,13 @@
+import type { DevChannel, SeedcordCliEvents, SeedcordFrameworkEvents } from '@seedcord/types/internal';
+
+// the dev wire, held in a module-private singleton. NEVER export this from hmr/index.ts. the seedcord
+// package exposes only ".", so an unbarreled singleton stays unreachable by user and plugin code at runtime.
+let channel: DevChannel<SeedcordFrameworkEvents, SeedcordCliEvents> | undefined;
+
+export function setDevChannel(next: DevChannel<SeedcordFrameworkEvents, SeedcordCliEvents>): void {
+    channel = next;
+}
+
+export function getDevChannel(): DevChannel<SeedcordFrameworkEvents, SeedcordCliEvents> | undefined {
+    return channel;
+}

--- a/packages/seedcord/src/interfaces/Plugin.ts
+++ b/packages/seedcord/src/interfaces/Plugin.ts
@@ -2,6 +2,8 @@ import { SeedcordErrorCode } from '@seedcord/errors';
 import { SeedcordError } from '@seedcord/errors/internal';
 import { StrictEventEmitter } from '@seedcord/services';
 
+import { getDevChannel } from '@hmr/devChannel';
+
 import type { Core } from './Core';
 import type {
     SENoEvents,
@@ -29,7 +31,7 @@ export abstract class Plugin<TPluginEvents extends SEEventMapLike<TPluginEvents>
     extends StrictEventEmitter<TPluginEvents>
     implements Initializeable, HmrAware
 {
-    /** Logger instance for this plugin - must be implemented by subclasses */
+    /** Logger instance for this plugin. */
     public abstract logger: Logger;
 
     public name: string = this.constructor.name;
@@ -39,15 +41,14 @@ export abstract class Plugin<TPluginEvents extends SEEventMapLike<TPluginEvents>
     }
 
     /**
-     * Initialize the plugin - implement setup logic here
-     * @virtual Override this method in your plugin classes
+     * Initialize the plugin.
+     * @virtual
      */
     abstract init(): Promise<void>;
 
     /**
-     * Reloads plugin state on an HMR update.
-     * @param _event - The HMR update event
-     * @virtual Override this method to handle HMR updates
+     * Reloads plugin state on an HMR update. The base implementation is a no-op, override it in your plugin.
+     * @virtual
      */
     public onHmr(_event: HmrUpdateEvent): Promise<void> {
         return Promise.resolve();
@@ -58,9 +59,7 @@ export abstract class Plugin<TPluginEvents extends SEEventMapLike<TPluginEvents>
      * @param patterns - Glob patterns relative to the project root
      */
     protected registerCriticalFiles(patterns: string[]): void {
-        if (import.meta.hot) {
-            import.meta.hot.send('seedcord:register-critical-files', { patterns });
-        }
+        getDevChannel()?.send('seedcord:register-critical-files', { patterns });
     }
 
     /** @internal */

--- a/packages/seedcord/src/subscribers/Bus.ts
+++ b/packages/seedcord/src/subscribers/Bus.ts
@@ -33,8 +33,8 @@ type SubscriberArtifact = SubscriptionKey[];
  *
  * Provides a centralized system for registering and executing custom subscribers
  * throughout the application lifecycle. Bus subscribers are loaded from configured directories
- * and can be triggered programmatically or by framework events. Accessed via `core.bus`, not
- * constructed directly.
+ * and can be triggered programmatically or by framework events. Accessed via `core.bus`. Do not
+ * construct it directly.
  */
 export class Bus extends Plugin<SubscriptionTuples> {
     public readonly logger = new Logger('Subscribers');
@@ -56,8 +56,7 @@ export class Bus extends Plugin<SubscriptionTuples> {
                 registerHandler: this.registerSubscriber.bind(this),
                 unregisterHandler: this.unregisterSubscriber.bind(this),
                 getArtifacts: this.getArtifacts.bind(this),
-                logger: this.logger,
-                name: 'Subscribers'
+                logger: this.logger
             });
         }
     }
@@ -76,8 +75,8 @@ export class Bus extends Plugin<SubscriptionTuples> {
         this.registerSubscriber(UnknownException);
         this.registerSubscriber(HandledException);
 
-        // both webhook urls are required at startup, the bot refuses to boot without them rather than
-        // silently dropping fault reports when the first exception fires.
+        // require both webhook urls at boot so a missing one stops the boot, never silently dropping fault
+        // reports when the first exception fires.
         Envapter.require('UNKNOWN_EXCEPTION_WEBHOOK_URL', 'HANDLED_EXCEPTION_WEBHOOK_URL');
 
         const subscribersDir = this.core.config.subscribers.path;
@@ -137,7 +136,7 @@ export class Bus extends Plugin<SubscriptionTuples> {
                 handlers.splice(index, 1);
             }
         }
-        this.executedOnceHandlers.delete(handler);
+        // spent follows the ctor identity, so leaving executedOnceHandlers alone keeps a rollback-restored subscriber spent
     }
 
     private isSubscriber(obj: unknown): obj is SubscriberConstructor {

--- a/packages/seedcord/src/vite-hmr.d.ts
+++ b/packages/seedcord/src/vite-hmr.d.ts
@@ -1,5 +1,0 @@
-import type { SeedcordFrameworkEvents, SeedcordCliEvents } from '@seedcord/types/internal';
-
-declare module 'vite/types/customEvent.d.ts' {
-    interface CustomEventMap extends SeedcordFrameworkEvents, SeedcordCliEvents {}
-}

--- a/packages/seedcord/tests/events/EventDispatcher.test.ts
+++ b/packages/seedcord/tests/events/EventDispatcher.test.ts
@@ -256,6 +256,43 @@ describe('EventDispatcher Integration', () => {
         expect(message.reply).toHaveBeenCalledTimes(1);
     });
 
+    it('keeps a spent once handler spent after a failed reload rolls it back', async () => {
+        const eventsDir = 'events';
+        const filePath = await testEnv.createFile(
+            `${eventsDir}/OnceRollback.ts`,
+            `
+            import { EventHandler, RegisterEvent } from '${seedcordPath}';
+            import { Events } from 'discord.js';
+
+            @RegisterEvent(['messageCreate', { frequency: 'once' }])
+            export class OnceRollback extends EventHandler<Events.MessageCreate> {
+                public async execute() {
+                    await this.match({ messageCreate: (message) => message.reply('once') });
+                }
+            }
+            `
+        );
+
+        const config = testConfig({ events: testEnv.resolvePath(eventsDir) });
+
+        seedcord = new Seedcord(config);
+        // justified: TestBot exposes the private events controller for assertion
+        const testBot = seedcord.bot as unknown as TestBot;
+        await testBot.events.init();
+
+        const message = { reply: vi.fn() };
+        await testBot.events.processEvent('messageCreate', [message]);
+        expect(message.reply).toHaveBeenCalledTimes(1);
+
+        // a broken edit, the reload fails and rolls the handler back
+        await testEnv.createFile(`${eventsDir}/OnceRollback.ts`, 'export const broken = {{{ not valid');
+        await testBot.events.onHmr({ file: filePath, type: 'update' });
+
+        // the rolled-back handler is the same spent ctor, so a second fire must not re-run it
+        await testBot.events.processEvent('messageCreate', [message]);
+        expect(message.reply).toHaveBeenCalledTimes(1);
+    });
+
     it('should handle HMR updates for event handlers', async () => {
         const eventsDir = 'events';
         const filePath = await testEnv.createFile(

--- a/packages/seedcord/tests/events/EventDispatcher.test.ts
+++ b/packages/seedcord/tests/events/EventDispatcher.test.ts
@@ -165,6 +165,97 @@ describe('EventDispatcher Integration', () => {
         await expect(testBot.events.processEvent('guildMemberAdd', [{}])).resolves.toBeUndefined();
     });
 
+    it('runs a once handler exactly once when the same event fires concurrently', async () => {
+        const eventsDir = 'events';
+        await testEnv.createFile(
+            `${eventsDir}/OnceConcurrent.ts`,
+            `
+            import { EventHandler, RegisterEvent } from '${seedcordPath}';
+            import { Events } from 'discord.js';
+
+            @RegisterEvent(['messageCreate', { frequency: 'once' }])
+            export class OnceConcurrent extends EventHandler<Events.MessageCreate> {
+                public async execute() {
+                    await this.match({ messageCreate: (message) => message.reply('once') });
+                }
+            }
+            `
+        );
+
+        const config = testConfig({ events: testEnv.resolvePath(eventsDir) });
+
+        seedcord = new Seedcord(config);
+        // justified: TestBot exposes the private events controller for assertion
+        const testBot = seedcord.bot as unknown as TestBot;
+        await testBot.events.init();
+
+        // both fires run their once-filter snapshot before either marks spent, because
+        // `await runMiddlewares` yields between the snapshot and the mark
+        const message = { reply: vi.fn() };
+        await Promise.all([
+            testBot.events.processEvent('messageCreate', [message]),
+            testBot.events.processEvent('messageCreate', [message])
+        ]);
+
+        expect(message.reply).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not consume a once handler when middleware blocks the fire', async () => {
+        const eventsDir = 'events';
+        const middlewaresDir = 'event-mw';
+
+        await testEnv.createFile(
+            `${eventsDir}/OnceAfterBlock.ts`,
+            `
+            import { EventHandler, RegisterEvent } from '${seedcordPath}';
+            import { Events } from 'discord.js';
+
+            @RegisterEvent(['messageCreate', { frequency: 'once' }])
+            export class OnceAfterBlock extends EventHandler<Events.MessageCreate> {
+                public async execute() {
+                    await this.match({ messageCreate: (message) => message.reply('ran') });
+                }
+            }
+            `
+        );
+
+        await testEnv.createFile(
+            `${middlewaresDir}/BlockFirst.ts`,
+            `
+            import { Middleware, MiddlewareType, EventMiddleware, Silence } from '${seedcordPath}';
+
+            let fires = 0;
+
+            @Middleware(MiddlewareType.Event, 0)
+            export class BlockFirst extends EventMiddleware {
+                public async execute() {
+                    fires++;
+                    if (fires === 1) throw new Silence('block the first fire');
+                }
+            }
+            `
+        );
+
+        const config = testConfig({
+            events: testEnv.resolvePath(eventsDir),
+            eventMiddlewares: testEnv.resolvePath(middlewaresDir)
+        });
+
+        seedcord = new Seedcord(config);
+        // justified: TestBot exposes the private events controller for assertion
+        const testBot = seedcord.bot as unknown as TestBot;
+        await testBot.events.init();
+
+        // a middleware block stops the whole event, so it must not spend the once budget
+        const message = { reply: vi.fn() };
+        await testBot.events.processEvent('messageCreate', [message]);
+        expect(message.reply).not.toHaveBeenCalled();
+
+        // the second fire passes middleware, so the once handler still runs
+        await testBot.events.processEvent('messageCreate', [message]);
+        expect(message.reply).toHaveBeenCalledTimes(1);
+    });
+
     it('should handle HMR updates for event handlers', async () => {
         const eventsDir = 'events';
         const filePath = await testEnv.createFile(

--- a/packages/seedcord/tests/hmr/devChannel.test.ts
+++ b/packages/seedcord/tests/hmr/devChannel.test.ts
@@ -1,0 +1,112 @@
+import path from 'node:path';
+
+import { Logger } from '@seedcord/services';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import { setDevChannel } from '@hmr/devChannel';
+import { Plugin } from '@interfaces/Plugin';
+import { Seedcord } from '@src/Seedcord';
+
+import { testConfig } from '../utils/test-config';
+import { TestEnvironment } from '../utils/test-env';
+
+import '../utils/mock-client';
+import '../utils/mock-env';
+
+import type { Core } from '@interfaces/Core';
+import type { DevChannel, SeedcordCliEvents, SeedcordFrameworkEvents } from '@seedcord/types/internal';
+import type { Mock } from 'vitest';
+
+const seedcordPath = path.resolve(__dirname, '../../src/index').replace(/\\/g, '/');
+
+type FrameworkChannel = DevChannel<SeedcordFrameworkEvents, SeedcordCliEvents>;
+type SendMock = Mock<(event: string, data: unknown) => void>;
+type OnMock = Mock<(event: string, cb: (data: unknown) => void) => void>;
+
+function fakeChannel(): { channel: FrameworkChannel; send: SendMock; on: OnMock } {
+    const send = vi.fn<(event: string, data: unknown) => void>();
+    const on = vi.fn<(event: string, cb: (data: unknown) => void) => void>();
+    // justified: a minimal stand-in for the dev wire so routing can be asserted without a vite server
+    const channel = { send, on } as unknown as FrameworkChannel;
+    return { channel, send, on };
+}
+
+class CriticalPlugin extends Plugin {
+    public logger = new Logger('CriticalPlugin');
+    public async init(): Promise<void> {
+        await Promise.resolve();
+    }
+    public declareCritical(patterns: string[]): void {
+        this.registerCriticalFiles(patterns);
+    }
+}
+
+const PING_COMMAND = `
+    import { BuilderComponent, RegisterCommand } from '${seedcordPath}';
+
+    @RegisterCommand('global')
+    export class PingCommand extends BuilderComponent<'command'> {
+        constructor() {
+            super('command');
+            this.instance.setName('ping').setDescription('Replies with Pong!');
+        }
+    }
+`;
+
+describe('dev channel routing', () => {
+    let testEnv: TestEnvironment;
+
+    beforeEach(async () => {
+        // @ts-expect-error reset the Seedcord singleton between tests
+        Seedcord.reset();
+        testEnv = new TestEnvironment('hmr-route-');
+        await testEnv.setup();
+    });
+
+    afterEach(async () => {
+        await testEnv.teardown();
+        vi.clearAllMocks();
+    });
+
+    it('registerCriticalFiles sends through the dev channel', () => {
+        const { channel, send } = fakeChannel();
+        setDevChannel(channel);
+
+        // justified: registerCriticalFiles never reads core, only the dev channel
+        const plugin = new CriticalPlugin({} as Core);
+        plugin.declareCritical(['migrations/*']);
+
+        expect(send).toHaveBeenCalledWith('seedcord:register-critical-files', { patterns: ['migrations/*'] });
+    });
+
+    it('CommandRegistry listens for refresh-commands through the dev channel', async () => {
+        const { channel, on } = fakeChannel();
+        setDevChannel(channel);
+
+        await testEnv.createFile('commands/Ping.ts', PING_COMMAND);
+        const config = testConfig({ commands: testEnv.resolvePath('commands') });
+        const seedcord = new Seedcord(config);
+        if (!seedcord.bot.commands) throw new Error('Commands not initialized');
+        await seedcord.bot.commands.init();
+
+        expect(on).toHaveBeenCalledWith('seedcord:refresh-commands', expect.any(Function));
+    });
+
+    it('CommandRegistry.onHmr prompts a commands update through the dev channel', async () => {
+        const { channel, send } = fakeChannel();
+        setDevChannel(channel);
+
+        const commandFile = await testEnv.createFile('commands/Ping.ts', PING_COMMAND);
+        const config = testConfig({ commands: testEnv.resolvePath('commands') });
+        const seedcord = new Seedcord(config);
+        if (!seedcord.bot.commands) throw new Error('Commands not initialized');
+        await seedcord.bot.commands.init();
+
+        await seedcord.bot.commands.onHmr({ file: commandFile, type: 'update' });
+
+        const sentEvents = send.mock.calls.map((args) => args[0]);
+        expect(sentEvents).toContain('seedcord:commands-update-prompt');
+        const promptPayload = send.mock.calls.find((args) => args[0] === 'seedcord:commands-update-prompt')?.[1];
+        expect(promptPayload).toHaveProperty('files');
+    });
+});

--- a/packages/seedcord/tests/hmr/devChannel.test.ts
+++ b/packages/seedcord/tests/hmr/devChannel.test.ts
@@ -65,6 +65,8 @@ describe('dev channel routing', () => {
 
     afterEach(async () => {
         await testEnv.teardown();
+        // drop the fake channel so a later test never inherits it
+        setDevChannel(undefined);
         vi.clearAllMocks();
     });
 

--- a/packages/seedcord/tests/interactions/InteractionDispatcher.test.ts
+++ b/packages/seedcord/tests/interactions/InteractionDispatcher.test.ts
@@ -57,6 +57,11 @@ interface TestBot {
     interactions: PrivateInteractionDispatcher;
 }
 
+// justified: reach the private interactions dispatcher off the bot to assert its routing state
+function controllerOf(instance: Seedcord): PrivateInteractionDispatcher {
+    return (instance.bot as unknown as TestBot).interactions;
+}
+
 describe('InteractionDispatcher Integration', () => {
     let testEnv: TestEnvironment;
     let seedcord: Seedcord;
@@ -132,7 +137,7 @@ describe('InteractionDispatcher Integration', () => {
         const config = testConfig({ interactions: testEnv.resolvePath(interactionsDir) });
 
         seedcord = new Seedcord(config);
-        const controller = (seedcord.bot as unknown as TestBot).interactions;
+        const controller = controllerOf(seedcord);
 
         const error: unknown = await controller.init().then(
             () => null,
@@ -183,7 +188,7 @@ describe('InteractionDispatcher Integration', () => {
         });
 
         seedcord = new Seedcord(config);
-        const controller = (seedcord.bot as unknown as TestBot).interactions;
+        const controller = controllerOf(seedcord);
 
         const error: unknown = await controller.init().then(
             () => null,
@@ -214,8 +219,7 @@ describe('InteractionDispatcher Integration', () => {
         const config = testConfig({ interactions: testEnv.resolvePath(interactionsDir) });
 
         seedcord = new Seedcord(config);
-        // justified: TestBot exposes the private interactions controller for assertion
-        const controller = (seedcord.bot as unknown as TestBot).interactions;
+        const controller = controllerOf(seedcord);
         await controller.init();
 
         const interaction = fakeSlash('boom');
@@ -233,7 +237,7 @@ describe('InteractionDispatcher Integration', () => {
         const config = testConfig({ interactions: testEnv.resolvePath('interactions'), ignoreCustomIds: [ClickId] });
 
         seedcord = new Seedcord(config);
-        const controller = (seedcord.bot as unknown as TestBot).interactions;
+        const controller = controllerOf(seedcord);
         // justified: spy on the private routing entry to assert the ignore gate runs before it
         const processSpy = vi.spyOn(controller, 'processInteraction').mockResolvedValue(undefined);
 
@@ -248,7 +252,7 @@ describe('InteractionDispatcher Integration', () => {
         const config = testConfig({ interactions: testEnv.resolvePath('interactions') });
 
         seedcord = new Seedcord(config);
-        const controller = (seedcord.bot as unknown as TestBot).interactions;
+        const controller = controllerOf(seedcord);
         const processSpy = vi.spyOn(controller, 'processInteraction').mockResolvedValue(undefined);
 
         await controller.handleButton({ customId: CONFIRM_DEF.encode({ choice: 'confirm' }) });
@@ -277,7 +281,7 @@ describe('InteractionDispatcher Integration', () => {
         const config = testConfig({ interactions: testEnv.resolvePath(interactionsDir) });
 
         seedcord = new Seedcord(config);
-        const controller = (seedcord.bot as unknown as TestBot).interactions;
+        const controller = controllerOf(seedcord);
         await controller.init();
         expect(controller.slashMap.has('ping')).toBe(true);
 
@@ -315,7 +319,7 @@ describe('InteractionDispatcher Integration', () => {
         const config = testConfig({ interactions: testEnv.resolvePath(interactionsDir) });
 
         seedcord = new Seedcord(config);
-        const controller = (seedcord.bot as unknown as TestBot).interactions;
+        const controller = controllerOf(seedcord);
         await controller.init();
         expect(controller.slashMap.has('alpha')).toBe(true);
         expect(controller.slashMap.has('beta')).toBe(true);
@@ -367,7 +371,7 @@ describe('InteractionDispatcher Integration', () => {
         const config = testConfig({ interactions: testEnv.resolvePath(interactionsDir) });
 
         seedcord = new Seedcord(config);
-        const controller = (seedcord.bot as unknown as TestBot).interactions;
+        const controller = controllerOf(seedcord);
         await controller.init();
         expect(controller.slashMap.has('ping')).toBe(true);
 
@@ -453,7 +457,7 @@ describe('InteractionDispatcher Integration', () => {
         const config = testConfig({ interactions: testEnv.resolvePath('interactions') });
 
         seedcord = new Seedcord(config);
-        const controller = (seedcord.bot as unknown as TestBot).interactions;
+        const controller = controllerOf(seedcord);
         await controller.init();
 
         const interaction = fakeSlash('allowed');
@@ -489,7 +493,7 @@ describe('InteractionDispatcher Integration', () => {
         const config = testConfig({ interactions: testEnv.resolvePath('interactions') });
 
         seedcord = new Seedcord(config);
-        const controller = (seedcord.bot as unknown as TestBot).interactions;
+        const controller = controllerOf(seedcord);
         await controller.init();
 
         const interaction = fakeSlash('refused');
@@ -522,7 +526,7 @@ describe('InteractionDispatcher Integration', () => {
         const config = testConfig({ interactions: testEnv.resolvePath('interactions'), ownerIds: ['someone-else'] });
 
         seedcord = new Seedcord(config);
-        const controller = (seedcord.bot as unknown as TestBot).interactions;
+        const controller = controllerOf(seedcord);
         await controller.init();
 
         const interaction = fakeSlash('owner');
@@ -556,7 +560,7 @@ describe('InteractionDispatcher Integration', () => {
         const config = testConfig({ interactions: testEnv.resolvePath('interactions'), ownerIds: ['u1'] });
 
         seedcord = new Seedcord(config);
-        const controller = (seedcord.bot as unknown as TestBot).interactions;
+        const controller = controllerOf(seedcord);
         await controller.init();
 
         const interaction = fakeSlash('owner');

--- a/packages/seedcord/tests/interactions/InteractionDispatcher.test.ts
+++ b/packages/seedcord/tests/interactions/InteractionDispatcher.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- one integration suite per dispatcher, splitting fragments the shared test env */
 import path from 'node:path';
 
 import { SeedcordErrorCode } from '@seedcord/errors';
@@ -350,6 +351,74 @@ describe('InteractionDispatcher Integration', () => {
         await expect(controller.onHmr({ file: filePath, type: 'update' })).resolves.toBeUndefined();
         expect(controller.slashMap.has('alpha')).toBe(true);
         expect(controller.slashMap.has('beta')).toBe(true);
+    });
+
+    it('rolls back when a multi-route handler reload collides on a later route owned by another file', async () => {
+        const interactionsDir = 'interactions';
+
+        await testEnv.createFile(
+            `${interactionsDir}/Keeper.ts`,
+            `
+            import { CustomId, ButtonHandler, ButtonRoute } from '${seedcordPath}';
+
+            const Shared = new CustomId('shared');
+
+            @ButtonRoute(Shared)
+            export class KeeperButton extends ButtonHandler<[typeof Shared]> {
+                public async execute() {
+                    await this.event.reply('keeper');
+                }
+            }
+            `
+        );
+
+        const multiPath = await testEnv.createFile(
+            `${interactionsDir}/Multi.ts`,
+            `
+            import { CustomId, ButtonHandler, ButtonRoute } from '${seedcordPath}';
+
+            const Own = new CustomId('own');
+
+            @ButtonRoute(Own)
+            export class MultiButton extends ButtonHandler<[typeof Own]> {
+                public async execute() {
+                    await this.event.reply('own');
+                }
+            }
+            `
+        );
+
+        const config = testConfig({ interactions: testEnv.resolvePath(interactionsDir) });
+
+        seedcord = new Seedcord(config);
+        const controller = controllerOf(seedcord);
+        await controller.init();
+        expect(controller.buttonMap.has('own')).toBe(true);
+        expect(controller.buttonMap.has('shared')).toBe(true);
+        const lastGood = controller.buttonMap.get('own');
+
+        // the edit claims a route Keeper owns, so registration throws after setting 'own', orphaning it
+        await testEnv.createFile(
+            `${interactionsDir}/Multi.ts`,
+            `
+            import { CustomId, ButtonHandler, ButtonRoute } from '${seedcordPath}';
+
+            const Own = new CustomId('own');
+            const Shared = new CustomId('shared');
+
+            @ButtonRoute(Own, Shared)
+            export class MultiButton extends ButtonHandler<[typeof Own, typeof Shared]> {
+                public async execute() {
+                    await this.event.reply('own');
+                }
+            }
+            `
+        );
+
+        // rollback restores the last-good handler and must not re-collide on the orphaned route
+        await expect(controller.onHmr({ file: multiPath, type: 'update' })).resolves.toBeUndefined();
+        expect(controller.buttonMap.get('own')).toBe(lastGood);
+        expect(controller.buttonMap.has('shared')).toBe(true);
     });
 
     it('drops the failed unit when the event disables rollback', async () => {

--- a/packages/seedcord/tests/interactions/InteractionDispatcher.test.ts
+++ b/packages/seedcord/tests/interactions/InteractionDispatcher.test.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 
+import { SeedcordErrorCode } from '@seedcord/errors';
 import { CustomId } from '@seedcord/kit';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
@@ -97,6 +98,100 @@ describe('InteractionDispatcher Integration', () => {
 
         const controller = testBot.interactions;
         expect(controller.slashMap.has('ping')).toBe(true);
+    });
+
+    it('throws when two handlers register the same interaction route, naming both', async () => {
+        const interactionsDir = 'interactions';
+        await testEnv.createFile(
+            `${interactionsDir}/PingOne.ts`,
+            `
+            import { SlashHandler, SlashRoute } from '${seedcordPath}';
+
+            @SlashRoute('ping')
+            export class PingOne extends SlashHandler<'ping'> {
+                public async execute() {
+                    await this.event.reply('one');
+                }
+            }
+            `
+        );
+        await testEnv.createFile(
+            `${interactionsDir}/PingTwo.ts`,
+            `
+            import { SlashHandler, SlashRoute } from '${seedcordPath}';
+
+            @SlashRoute('ping')
+            export class PingTwo extends SlashHandler<'ping'> {
+                public async execute() {
+                    await this.event.reply('two');
+                }
+            }
+            `
+        );
+
+        const config = testConfig({ interactions: testEnv.resolvePath(interactionsDir) });
+
+        seedcord = new Seedcord(config);
+        const controller = (seedcord.bot as unknown as TestBot).interactions;
+
+        const error: unknown = await controller.init().then(
+            () => null,
+            (caught: unknown) => caught
+        );
+        expect(error).toMatchObject({ code: SeedcordErrorCode.InteractionDuplicateRoute });
+        const message = error instanceof Error ? error.message : String(error);
+        expect(message).toContain('PingOne');
+        expect(message).toContain('PingTwo');
+    });
+
+    it('throws when two interaction middleware classes share a name instead of overwriting', async () => {
+        const middlewaresDir = 'interaction-mw';
+
+        await testEnv.createFile(
+            'interactions/Noop.ts',
+            `
+            import { SlashHandler, SlashRoute } from '${seedcordPath}';
+
+            @SlashRoute('noop')
+            export class Noop extends SlashHandler<'noop'> {
+                public async execute() {
+                    await Promise.resolve();
+                }
+            }
+            `
+        );
+
+        for (const file of ['RateLimitA', 'RateLimitB']) {
+            await testEnv.createFile(
+                `${middlewaresDir}/${file}.ts`,
+                `
+                import { Middleware, MiddlewareType, InteractionMiddleware } from '${seedcordPath}';
+
+                @Middleware(MiddlewareType.Interaction, 0)
+                export class RateLimit extends InteractionMiddleware {
+                    public async execute() {
+                        await Promise.resolve();
+                    }
+                }
+                `
+            );
+        }
+
+        const config = testConfig({
+            interactions: testEnv.resolvePath('interactions'),
+            interactionMiddlewares: testEnv.resolvePath(middlewaresDir)
+        });
+
+        seedcord = new Seedcord(config);
+        const controller = (seedcord.bot as unknown as TestBot).interactions;
+
+        const error: unknown = await controller.init().then(
+            () => null,
+            (caught: unknown) => caught
+        );
+        expect(error).toMatchObject({ code: SeedcordErrorCode.InteractionDuplicateMiddleware });
+        const message = error instanceof Error ? error.message : String(error);
+        expect(message).toContain('RateLimit');
     });
 
     it('routes a thrown error from a handler through the boundary to a reply', async () => {

--- a/packages/seedcord/tests/interactions/InteractionDispatcher.test.ts
+++ b/packages/seedcord/tests/interactions/InteractionDispatcher.test.ts
@@ -258,6 +258,126 @@ describe('InteractionDispatcher Integration', () => {
         expect(processSpy).toHaveBeenCalledTimes(1);
     });
 
+    it('rolls back to the last-good handler when a reload fails', async () => {
+        const interactionsDir = 'interactions';
+        const filePath = await testEnv.createFile(
+            `${interactionsDir}/Ping.ts`,
+            `
+            import { SlashHandler, SlashRoute } from '${seedcordPath}';
+
+            @SlashRoute('ping')
+            export class PingHandler extends SlashHandler<'ping'> {
+                public async execute() {
+                    await this.event.reply('pong');
+                }
+            }
+            `
+        );
+
+        const config = testConfig({ interactions: testEnv.resolvePath(interactionsDir) });
+
+        seedcord = new Seedcord(config);
+        const controller = (seedcord.bot as unknown as TestBot).interactions;
+        await controller.init();
+        expect(controller.slashMap.has('ping')).toBe(true);
+
+        // a broken edit, the reload import throws
+        await testEnv.createFile(`${interactionsDir}/Ping.ts`, 'export const broken = {{{ not valid');
+        await controller.onHmr({ file: filePath, type: 'update' });
+
+        // the failed reload restored the last-good handler and kept the route
+        expect(controller.slashMap.has('ping')).toBe(true);
+    });
+
+    it('rolls back both handlers when a reload introduces a duplicate route in one file', async () => {
+        const interactionsDir = 'interactions';
+        const filePath = await testEnv.createFile(
+            `${interactionsDir}/Pair.ts`,
+            `
+            import { SlashHandler, SlashRoute } from '${seedcordPath}';
+
+            @SlashRoute('alpha')
+            export class AlphaHandler extends SlashHandler<'alpha'> {
+                public async execute() {
+                    await this.event.reply('a');
+                }
+            }
+
+            @SlashRoute('beta')
+            export class BetaHandler extends SlashHandler<'beta'> {
+                public async execute() {
+                    await this.event.reply('b');
+                }
+            }
+            `
+        );
+
+        const config = testConfig({ interactions: testEnv.resolvePath(interactionsDir) });
+
+        seedcord = new Seedcord(config);
+        const controller = (seedcord.bot as unknown as TestBot).interactions;
+        await controller.init();
+        expect(controller.slashMap.has('alpha')).toBe(true);
+        expect(controller.slashMap.has('beta')).toBe(true);
+
+        // a broken edit, both handlers now claim 'alpha', so the reload throws a duplicate-route mid-registration
+        await testEnv.createFile(
+            `${interactionsDir}/Pair.ts`,
+            `
+            import { SlashHandler, SlashRoute } from '${seedcordPath}';
+
+            @SlashRoute('alpha')
+            export class AlphaHandler extends SlashHandler<'alpha'> {
+                public async execute() {
+                    await this.event.reply('a');
+                }
+            }
+
+            @SlashRoute('alpha')
+            export class BetaHandler extends SlashHandler<'alpha'> {
+                public async execute() {
+                    await this.event.reply('a');
+                }
+            }
+            `
+        );
+
+        // rollback must clear the partial registration first, so restoring both old routes does not re-collide
+        await expect(controller.onHmr({ file: filePath, type: 'update' })).resolves.toBeUndefined();
+        expect(controller.slashMap.has('alpha')).toBe(true);
+        expect(controller.slashMap.has('beta')).toBe(true);
+    });
+
+    it('drops the failed unit when the event disables rollback', async () => {
+        const interactionsDir = 'interactions';
+        const filePath = await testEnv.createFile(
+            `${interactionsDir}/Ping.ts`,
+            `
+            import { SlashHandler, SlashRoute } from '${seedcordPath}';
+
+            @SlashRoute('ping')
+            export class PingHandler extends SlashHandler<'ping'> {
+                public async execute() {
+                    await this.event.reply('pong');
+                }
+            }
+            `
+        );
+
+        const config = testConfig({ interactions: testEnv.resolvePath(interactionsDir) });
+
+        seedcord = new Seedcord(config);
+        const controller = (seedcord.bot as unknown as TestBot).interactions;
+        await controller.init();
+        expect(controller.slashMap.has('ping')).toBe(true);
+
+        // a broken edit with rollback disabled, so the route is dropped
+        await testEnv.createFile(`${interactionsDir}/Ping.ts`, 'export const broken = {{{ not valid');
+        await controller.onHmr({ file: filePath, type: 'update', rollback: false });
+
+        expect(controller.slashMap.has('ping')).toBe(false);
+    });
+
     it('should handle HMR updates for interaction handlers', async () => {
         const interactionsDir = 'interactions';
         const filePath = await testEnv.createFile(
@@ -412,7 +532,7 @@ describe('InteractionDispatcher Integration', () => {
             () => controller.slashMap.get('owner')
         );
 
-        // the non-owner is refused, so execute never replied 'executed', the boundary rendered NotOwner instead
+        // the non-owner is refused, so execute never replied 'executed', the boundary rendered NotOwner
         expect(interaction.reply).not.toHaveBeenCalledWith('executed');
         expect(interaction.reply).toHaveBeenCalledTimes(1);
     });

--- a/packages/seedcord/tests/subscribers/Bus.test.ts
+++ b/packages/seedcord/tests/subscribers/Bus.test.ts
@@ -156,6 +156,7 @@ describe('Bus Integration', () => {
 
         const onHmr = vi.spyOn(seedcord.bus, 'onHmr');
         const event: HmrUpdateEvent = { file: filePath, type: 'update' };
+        // justified: reach the private hmrManager to assert the Bus is wired into HMR dispatch
         const { hmrManager } = seedcord as unknown as PrivateSeedcordHmr;
         await hmrManager.handleUpdate(event);
 

--- a/packages/seedcord/tests/subscribers/Bus.test.ts
+++ b/packages/seedcord/tests/subscribers/Bus.test.ts
@@ -9,6 +9,8 @@ import { TestEnvironment } from '../utils/test-env';
 import '../utils/mock-client';
 import '../utils/mock-env';
 
+import type { HmrUpdateEvent } from '@seedcord/types/internal';
+
 const seedcordPath = path.resolve(__dirname, '../../src/index').replace(/\\/g, '/');
 
 interface RegisteredSubscriberHandlerEntry {
@@ -18,6 +20,14 @@ interface RegisteredSubscriberHandlerEntry {
 
 interface PrivateBus {
     subscribersMap: Map<string, RegisteredSubscriberHandlerEntry[]>;
+}
+
+interface PrivateHmrManager {
+    handleUpdate(event: HmrUpdateEvent): Promise<void>;
+}
+
+interface PrivateSeedcordHmr {
+    hmrManager: PrivateHmrManager;
 }
 
 describe('Bus Integration', () => {
@@ -119,5 +129,36 @@ describe('Bus Integration', () => {
         const customHandlerAfter = handlersAfter?.[1]?.ctor;
         expect(customHandlerAfter).not.toBe(customHandlerBefore);
         expect(customHandlerAfter?.name).toBe('LogSubscriber');
+    });
+
+    it('registers the Bus with the HMR manager, so an update dispatch reaches it', async () => {
+        const subscribersDir = 'subscribers';
+        const filePath = await testEnv.createFile(
+            `${subscribersDir}/LogSubscriber.ts`,
+            `
+            import { Subscriber, Subscribe } from '${seedcordPath}';
+
+            @Subscribe('unknownException')
+            export class LogSubscriber extends Subscriber {
+                public async execute() {
+                    console.log('Subscriber executed');
+                }
+            }
+            `
+        );
+
+        const config = testConfig({ subscribers: testEnv.resolvePath(subscribersDir) });
+
+        seedcord = new Seedcord(config);
+        // HMR registration runs in the Configuration phase, before Bot Init (which needs a real token
+        // the test env omits), so let the later phase fail, the wiring we assert has already run
+        await seedcord.startup.run().catch(() => undefined);
+
+        const onHmr = vi.spyOn(seedcord.bus, 'onHmr');
+        const event: HmrUpdateEvent = { file: filePath, type: 'update' };
+        const { hmrManager } = seedcord as unknown as PrivateSeedcordHmr;
+        await hmrManager.handleUpdate(event);
+
+        expect(onHmr).toHaveBeenCalledWith(event);
     });
 });

--- a/packages/seedcord/tests/utils/test-config.ts
+++ b/packages/seedcord/tests/utils/test-config.ts
@@ -2,7 +2,9 @@ import type { Config, CustomIdMatcher } from '@seedcord/types';
 
 interface TestConfigOverrides {
     interactions?: string;
+    interactionMiddlewares?: string;
     events?: string;
+    eventMiddlewares?: string;
     commands?: string;
     subscribers?: string;
     ignoreCustomIds?: CustomIdMatcher[];
@@ -10,15 +12,31 @@ interface TestConfigOverrides {
 }
 
 export function testConfig(overrides: TestConfigOverrides = {}): Config {
-    const { interactions, events, commands, subscribers, ignoreCustomIds, ownerIds } = overrides;
+    const {
+        interactions,
+        interactionMiddlewares,
+        events,
+        eventMiddlewares,
+        commands,
+        subscribers,
+        ignoreCustomIds,
+        ownerIds
+    } = overrides;
 
     const config: Config = {
         bot: {
             interactions:
                 interactions === undefined
                     ? { path: null }
-                    : { path: interactions, ...(ignoreCustomIds && { ignoreCustomIds }) },
-            events: events === undefined ? { path: null } : { path: events },
+                    : {
+                          path: interactions,
+                          ...(ignoreCustomIds && { ignoreCustomIds }),
+                          ...(interactionMiddlewares && { middlewares: interactionMiddlewares })
+                      },
+            events:
+                events === undefined
+                    ? { path: null }
+                    : { path: events, ...(eventMiddlewares && { middlewares: eventMiddlewares }) },
             commands: commands === undefined ? { path: null } : { path: commands },
             clientOptions: { intents: [] }
         },

--- a/packages/types/src/Hmr.ts
+++ b/packages/types/src/Hmr.ts
@@ -51,8 +51,7 @@ export interface DevChannel<TSend, TRecv> {
 }
 
 // the minimal raw-hot shape, satisfied by both vite's `import.meta.hot` and the CLI's `NormalizedHotChannel`.
-// vite types our `seedcord:*` payloads as `any` (they sit outside its CustomEventMap), so the typed
-// DevChannel above is the real contract callers see.
+// vite types our `seedcord:*` payloads as `any` (they sit outside its CustomEventMap).
 interface RawHot {
     send(event: string, data?: unknown): void;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- mirrors vite's own InferCustomEventPayload fallback

--- a/packages/types/src/Hmr.ts
+++ b/packages/types/src/Hmr.ts
@@ -54,8 +54,7 @@ export interface DevChannel<TSend, TRecv> {
 // vite types our `seedcord:*` payloads as `any` (they sit outside its CustomEventMap).
 interface RawHot {
     send(event: string, data?: unknown): void;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- mirrors vite's own InferCustomEventPayload fallback
-    on(event: string, cb: (data: any) => void): void;
+    on(event: string, cb: (data: unknown) => void): void;
 }
 
 /**
@@ -66,6 +65,7 @@ interface RawHot {
 export function wrapHot<TSend, TRecv>(hot: RawHot): DevChannel<TSend, TRecv> {
     return {
         send: (event, data) => hot.send(event, data),
-        on: (event, cb) => hot.on(event, cb)
+        // justified: RawHot types every payload as unknown, the wire contract guarantees it matches TRecv[Key]
+        on: (event, cb) => hot.on(event, cb as (data: unknown) => void)
     };
 }

--- a/packages/types/src/Hmr.ts
+++ b/packages/types/src/Hmr.ts
@@ -7,6 +7,8 @@ export interface HmrUpdateEvent {
     type: HmrEventType;
     /** Files affected by this update, such as importers. Only populated for `update` events. */
     affectedModules?: string[];
+    /** Whether a failed reload of this file rolls back to the last-good unit. Defaults to true. */
+    rollback?: boolean;
 }
 
 /** A module that processes hot updates. */
@@ -35,4 +37,36 @@ export interface SeedcordFrameworkEvents {
 export interface SeedcordCliEvents {
     'seedcord:hmr': HmrUpdateEvent;
     'seedcord:refresh-commands': { shouldRefresh: boolean };
+}
+
+/**
+ * A typed dev channel over a raw vite hot object, carrying the framework and CLI HMR wire so neither
+ * side needs the ambient `vite-hmr.d.ts` augmentation.
+ *
+ * @internal
+ */
+export interface DevChannel<TSend, TRecv> {
+    send<Key extends keyof TSend & string>(event: Key, data: TSend[Key]): void;
+    on<Key extends keyof TRecv & string>(event: Key, cb: (data: TRecv[Key]) => void): void;
+}
+
+// the minimal raw-hot shape, satisfied by both vite's `import.meta.hot` and the CLI's `NormalizedHotChannel`.
+// vite types our `seedcord:*` payloads as `any` (they sit outside its CustomEventMap), so the typed
+// DevChannel above is the real contract callers see.
+interface RawHot {
+    send(event: string, data?: unknown): void;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- mirrors vite's own InferCustomEventPayload fallback
+    on(event: string, cb: (data: any) => void): void;
+}
+
+/**
+ * Wraps a raw vite hot object as a typed {@link DevChannel}.
+ *
+ * @internal
+ */
+export function wrapHot<TSend, TRecv>(hot: RawHot): DevChannel<TSend, TRecv> {
+    return {
+        send: (event, data) => hot.send(event, data),
+        on: (event, cb) => hot.on(event, cb)
+    };
 }

--- a/packages/types/src/internal.index.ts
+++ b/packages/types/src/internal.index.ts
@@ -1,2 +1,3 @@
 export * from './brand';
 export type * from './Hmr';
+export { wrapHot } from './Hmr';

--- a/packages/types/tests/hmr.test.ts
+++ b/packages/types/tests/hmr.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { wrapHot } from '../src/Hmr';
+
+import type { SeedcordCliEvents, SeedcordFrameworkEvents } from '../src/Hmr';
+
+describe('wrapHot', () => {
+    it('delegates send to the raw hot with the event and payload', () => {
+        const send = vi.fn();
+        const channel = wrapHot<SeedcordFrameworkEvents, SeedcordCliEvents>({ send, on: vi.fn() });
+
+        channel.send('seedcord:register-critical-files', { patterns: ['migrations/*'] });
+
+        expect(send).toHaveBeenCalledWith('seedcord:register-critical-files', { patterns: ['migrations/*'] });
+    });
+
+    it('delegates on to the raw hot and forwards the payload to the callback', () => {
+        let registered: ((data: unknown) => void) | undefined;
+        const on = vi.fn((_event: string, cb: (data: unknown) => void) => {
+            registered = cb;
+        });
+        const channel = wrapHot<SeedcordFrameworkEvents, SeedcordCliEvents>({ send: vi.fn(), on });
+
+        const received: string[] = [];
+        channel.on('seedcord:hmr', (payload) => received.push(payload.file));
+
+        expect(on).toHaveBeenCalledWith('seedcord:hmr', expect.any(Function));
+        registered?.({ file: 'x.ts', type: 'update' });
+        expect(received).toEqual(['x.ts']);
+    });
+
+    it('types the wire, so a wrong payload or direction is a compile error', () => {
+        const channel = wrapHot<SeedcordFrameworkEvents, SeedcordCliEvents>({ send: vi.fn(), on: vi.fn() });
+
+        channel.send('seedcord:register-critical-files', { patterns: ['x'] });
+        // @ts-expect-error wrong payload field type
+        channel.send('seedcord:register-critical-files', { patterns: 123 });
+        // @ts-expect-error wrong direction, seedcord:hmr is a receive event
+        channel.send('seedcord:hmr', { file: 'x', type: 'update' });
+        // @ts-expect-error unknown event name
+        channel.on('seedcord:nope', () => undefined);
+
+        expect(channel).toBeDefined();
+    });
+});


### PR DESCRIPTION
## Changes

- a `once` handler ran twice under concurrent fires (the spent-set snapshot was read before the middleware await marked it). Re-checks synchronously now.
- duplicate interaction routes silently shadowed and same-named middleware overwrote. Both throw a named error now.
- the Bus was never registered for HMR, so editing a subscriber file never hot-reloaded. Registered now.
- decouple HMR from vite's `import.meta.hot` behind a typed `DevChannel` (both `vite-hmr.d.ts` deleted), plus failed-reload rollback. Toggle with `hmr.rollback: false` in `seedcord.config.ts`.

## Breaking

- The `HmrModuleHandler` `name` option is removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hot-reload now supports automatic rollback to the last known good state when a reload fails.
  * Development HMR messaging is routed through a shared channel for more consistent refresh behavior.
* **Bug Fixes**
  * Duplicate interaction route/middleware registrations now fail fast with clear errors instead of overwriting.
  * “Once” handlers no longer run multiple times during concurrent events.
  * Event and subscriber hot-reload are more reliable; failed HMR no longer corrupts prior “once” state.
* **Configuration**
  * Added `hmr.rollback` (boolean) with validation and optional disabling of rollback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->