### PR TITLE
feat: button prop rules and constructor data

### DIFF
--- a/.changeset/button-builder-rules.md
+++ b/.changeset/button-builder-rules.md
@@ -1,0 +1,5 @@
+---
+'eslint-plugin-discordjs': minor
+---
+
+Add `require-button-props`, a rule reporting a sealed button missing its style or its style's required props (customId, url, skuId, label/emoji). Extend `no-conflicting-button-props` with style-aware checks (url on styles 1-4, skuId conflicts under any style, the Premium prop bans), read builder constructor data in both key casings across the button, select-menu bound, and limit rules, and count the array-form and rest-form call conventions in `no-discord-limit-exceeded`.

--- a/packages/eslint-plugin-discordjs/README.md
+++ b/packages/eslint-plugin-discordjs/README.md
@@ -44,9 +44,10 @@ If your config already sets up typed linting, drop the `languageOptions` block a
 | --- | --- |
 | [no-mixed-message-format](docs/rules/no-mixed-message-format.md) | components v2 builders mixed with `content`/`embeds`/`poll`/`stickers`, Discord rejects the payload |
 | [require-components-v2-flag](docs/rules/require-components-v2-flag.md) | v2 components without `MessageFlags.IsComponentsV2` |
-| [select-menu-min-exceeds-max](docs/rules/select-menu-min-exceeds-max.md) | `setMinValues` above `setMaxValues`, no builder error, the API rejects it |
-| [no-discord-limit-exceeded](docs/rules/no-discord-limit-exceeded.md) | more items than a builder's hard cap (5 row components, 25 options/fields/choices) |
-| [no-conflicting-button-props](docs/rules/no-conflicting-button-props.md) | a Link button with a customId, or a url on a non-link style |
+| [select-menu-min-exceeds-max](docs/rules/select-menu-min-exceeds-max.md) | a minimum above the maximum, from setters or constructor data, the API rejects it |
+| [no-discord-limit-exceeded](docs/rules/no-discord-limit-exceeded.md) | more items than a builder's hard cap (5 row components, 25 options/fields/choices), constructor data included |
+| [no-conflicting-button-props](docs/rules/no-conflicting-button-props.md) | customId with url, a url or skuId on the wrong style, a Premium button with a customId, label, url, or emoji |
+| [require-button-props](docs/rules/require-button-props.md) | a sealed button missing its style or its style's required props (customId, url, skuId, label/emoji) |
 | [no-choices-and-autocomplete](docs/rules/no-choices-and-autocomplete.md) | autocomplete and static choices on one slash option |
 | [required-option-before-optional](docs/rules/required-option-before-optional.md) | a required slash option after an optional one |
 | [valid-command-name](docs/rules/valid-command-name.md) | slash command and option names Discord rejects |

--- a/packages/eslint-plugin-discordjs/docs/rules/no-conflicting-button-props.md
+++ b/packages/eslint-plugin-discordjs/docs/rules/no-conflicting-button-props.md
@@ -2,15 +2,17 @@
 
 Disallow conflicting props on a button builder.
 
-A button cannot set both a `customId` and a `url`, and a `ButtonStyle.Link` button uses a `url` and cannot have a `customId`. Discord rejects either combination.
+A button cannot set both a `customId` and a `url`. A Link button takes a `url` and cannot have a `customId` or a `skuId`. The other non-premium styles take a `customId` and cannot have a `url` or a `skuId`. A Premium button takes only a `skuId` and cannot have a `customId`, `label`, `url`, or `emoji`. The builders throw a `RangeError` at `toJSON` for every one of these combinations, and `disableValidators()` skips none of them.
 
-The rule fires on a single fluent chain. Props split across separate statements are not flagged.
+The rule reads a single fluent chain plus the constructor data behind it, so `new ButtonBuilder({ url })` counts the same as `.setURL(url)`, in either key casing. Props split across separate statements are not flagged, and style-specific checks only apply when the style is a static value. A `skuId` beside a `customId`, `label`, `url`, or `emoji` reports without any style, the pair throws under every style.
 
 ## Incorrect
 
 ```ts
 new ButtonBuilder().setCustomId('x').setURL('https://example.com');
 new ButtonBuilder().setStyle(ButtonStyle.Link).setCustomId('x');
+new ButtonBuilder({ style: ButtonStyle.Danger, label: 'x' }).setURL('https://example.com');
+new ButtonBuilder().setStyle(ButtonStyle.Premium).setSKUId('123').setLabel('x');
 ```
 
 ## Correct
@@ -18,4 +20,5 @@ new ButtonBuilder().setStyle(ButtonStyle.Link).setCustomId('x');
 ```ts
 new ButtonBuilder().setStyle(ButtonStyle.Primary).setCustomId('x');
 new ButtonBuilder().setStyle(ButtonStyle.Link).setURL('https://example.com');
+new ButtonBuilder().setStyle(ButtonStyle.Premium).setSKUId('123');
 ```

--- a/packages/eslint-plugin-discordjs/docs/rules/no-discord-limit-exceeded.md
+++ b/packages/eslint-plugin-discordjs/docs/rules/no-discord-limit-exceeded.md
@@ -6,6 +6,8 @@ Some builders have a hard cap that Discord rejects, an action row holds 5 compon
 
 It also covers the seedcord form. A `this.instance` chain inside a `RowComponent` or `BuilderComponent<'embed' | 'menu_string'>` resolves to the same cap through the class's generic.
 
+Constructor data seeds the count, so `new ActionRowBuilder({ components })` counts its items before any chained adds, and a later `setComponents` replaces them.
+
 A spread or variable whose type is a fixed-arity tuple (an `as const` array) counts through its arity, so `addComponents(...six)` with a six-element tuple is flagged. Anything else dynamic, a plain-array spread, a `.map()` result, or a builder that is not capped (a container), means the count is a runtime value, so nothing is flagged.
 
 ## Incorrect

--- a/packages/eslint-plugin-discordjs/docs/rules/require-button-props.md
+++ b/packages/eslint-plugin-discordjs/docs/rules/require-button-props.md
@@ -1,0 +1,34 @@
+# require-button-props
+
+Require every prop the button style must carry before the payload reaches Discord.
+
+Each style has required props. Primary, Secondary, Success, and Danger buttons require a `customId`. A Link button requires a `url`. A Premium button requires a `skuId`. Every non-premium button also requires a label or an emoji, the builders throw at `toJSON` without one. A builder with no style at all reports too, Discord rejects a button without one.
+
+The rule reports only when every prop the button will carry is readable from the file. The chain must start at a bare discord.js `new ButtonBuilder(...)` (constructor data counts like setters, in either key casing) with a static style, and the finished value must be sealed, meaning dropped as a statement, passed to a discord.js method like `addComponents`, or bound to a variable whose later statement chains are all readable. A builder passed to your own function, returned, aliased into another binding, reassigned, built through a subclass, copied with `.from()`, or constructed from spread data stays unflagged, later code could still add the missing prop. A variable that only feeds `ButtonBuilder.from()` is a template and skips the checks, its copies carry the completion.
+
+An exported incomplete builder reports even though another module could import and complete it. That pattern mutates a shared instance across every importer, copy with `ButtonBuilder.from()` instead, or disable the line for a deliberate case:
+
+```ts
+// eslint-disable-next-line discordjs/require-button-props -- completed by the importer
+export const btn = new ButtonBuilder().setStyle(ButtonStyle.Danger).setLabel('x');
+```
+
+## Incorrect
+
+```ts
+new ButtonBuilder().setStyle(ButtonStyle.Link).setLabel('Docs'); // no url
+row.addComponents(new ButtonBuilder().setStyle(ButtonStyle.Danger).setLabel('x')); // no customId
+export const btn = new ButtonBuilder().setStyle(ButtonStyle.Link).setURL(url); // no label or emoji
+new ButtonBuilder().setLabel('x'); // no style
+```
+
+## Correct
+
+```ts
+new ButtonBuilder().setStyle(ButtonStyle.Link).setURL(url).setLabel('Docs');
+
+const b = new ButtonBuilder().setStyle(ButtonStyle.Danger).setLabel('x');
+b.setCustomId('confirm');
+
+finish(new ButtonBuilder().setStyle(ButtonStyle.Danger)); // your function may complete it
+```

--- a/packages/eslint-plugin-discordjs/docs/rules/select-menu-min-exceeds-max.md
+++ b/packages/eslint-plugin-discordjs/docs/rules/select-menu-min-exceeds-max.md
@@ -4,7 +4,7 @@ Disallow a select menu whose minimum selections exceed its maximum.
 
 Each setter validates its own range, so `setMinValues(5)` and `setMaxValues(2)` both pass alone, and the builder serializes the pair without a cross-check. A user cannot pick more than `max_values` items, so a `min_values` above it is unsatisfiable and Discord rejects the message at send.
 
-The rule reads both bounds from a single chain on any discord.js select menu builder (they all extend `BaseSelectMenuBuilder`). A bound is a numeric literal (a cast like `5 as number` only changes the checker's view, the literal is still the runtime value) or a const whose type is a number literal, anything dynamic is not statically provable, so nothing is flagged. When a setter repeats, the last call is the one compared.
+The rule reads both bounds from a single chain on any discord.js select menu builder (they all extend `BaseSelectMenuBuilder`) and from the constructor data behind it, so `new StringSelectMenuBuilder({ min_values: 3 })` counts the same as `.setMinValues(3)` and a chained setter wins over its data key. A bound is a numeric literal (a cast like `5 as number` only changes the checker's view, the literal is still the runtime value) or a const whose type is a number literal, anything dynamic is not statically provable, so nothing is flagged. When a setter repeats, the last call is the one compared.
 
 ## Incorrect
 

--- a/packages/eslint-plugin-discordjs/src/buttons.ts
+++ b/packages/eslint-plugin-discordjs/src/buttons.ts
@@ -1,0 +1,54 @@
+import { calleeProperty, getProperty, lastCall } from '@seedcord/eslint-utils';
+
+import type { TSESTree } from '@typescript-eslint/utils';
+
+// stable Discord wire values, keyed for the message text
+export const STYLE_NAMES: Record<number, string> = {
+    1: 'Primary',
+    2: 'Secondary',
+    3: 'Success',
+    4: 'Danger',
+    5: 'Link',
+    6: 'Premium'
+};
+export const LINK = 5;
+export const PREMIUM = 6;
+
+export type ButtonProp = 'customId' | 'label' | 'url' | 'emoji' | 'skuId';
+
+// each prop's setter and its snake_case constructor data key. discord.js also accepts the
+// camelCase form (the prop name itself) and snake_cases it at construction
+const PROP_SOURCES = [
+    ['customId', 'setCustomId', 'custom_id'],
+    ['label', 'setLabel', 'label'],
+    ['url', 'setURL', 'url'],
+    ['emoji', 'setEmoji', 'emoji'],
+    ['skuId', 'setSKUId', 'sku_id']
+] as const satisfies readonly (readonly [ButtonProp, string, string])[];
+
+export interface ButtonFacts {
+    props: Map<ButtonProp, TSESTree.Node>;
+    styleSource: TSESTree.CallExpressionArgument | TSESTree.Property['value'] | undefined;
+}
+
+export function gatherFacts(
+    calls: TSESTree.CallExpression[],
+    data: TSESTree.ObjectExpression | undefined
+): ButtonFacts {
+    const props = new Map<ButtonProp, TSESTree.Node>();
+    for (const [prop, method, key] of PROP_SOURCES) {
+        const call = lastCall(calls, method);
+        const site =
+            call !== undefined
+                ? calleeProperty(call)
+                : data === undefined
+                  ? undefined
+                  : (getProperty(data, key) ?? getProperty(data, prop));
+        if (site !== undefined) props.set(prop, site);
+    }
+    // a chained setStyle runs after the constructor, so it wins over a data style
+    const styleSource =
+        lastCall(calls, 'setStyle')?.arguments[0] ??
+        (data === undefined ? undefined : getProperty(data, 'style')?.value);
+    return { props, styleSource };
+}

--- a/packages/eslint-plugin-discordjs/src/index.ts
+++ b/packages/eslint-plugin-discordjs/src/index.ts
@@ -4,6 +4,7 @@ import noDiscordLimitExceeded from './rules/no-discord-limit-exceeded';
 import noMixedMessageFormat from './rules/no-mixed-message-format';
 import preferEphemeralFlag from './rules/prefer-ephemeral-flag';
 import preferV2Component from './rules/prefer-v2-component';
+import requireButtonProps from './rules/require-button-props';
 import requireComponentsV2Flag from './rules/require-components-v2-flag';
 import requiredOptionBeforeOptional from './rules/required-option-before-optional';
 import selectMenuMinExceedsMax from './rules/select-menu-min-exceeds-max';
@@ -18,6 +19,7 @@ const rules = {
     'no-mixed-message-format': noMixedMessageFormat,
     'prefer-ephemeral-flag': preferEphemeralFlag,
     'prefer-v2-component': preferV2Component,
+    'require-button-props': requireButtonProps,
     'require-components-v2-flag': requireComponentsV2Flag,
     'required-option-before-optional': requiredOptionBeforeOptional,
     'select-menu-min-exceeds-max': selectMenuMinExceedsMax,

--- a/packages/eslint-plugin-discordjs/src/rules/no-conflicting-button-props.ts
+++ b/packages/eslint-plugin-discordjs/src/rules/no-conflicting-button-props.ts
@@ -1,21 +1,22 @@
-import { extendsDjsType, chainRoot, collectChain, isChainTop, methodName } from '@seedcord/eslint-utils';
+import {
+    constructorData,
+    enclosingChainTop,
+    extendsDjsType,
+    chainRoot,
+    collectChain,
+    isChainTop,
+    staticNumber,
+    trustedConstructorData
+} from '@seedcord/eslint-utils';
 import { ESLintUtils } from '@typescript-eslint/utils';
 
+import { gatherFacts, LINK, PREMIUM, STYLE_NAMES } from '../buttons';
 import { createRule } from '../createRule';
 
-import type { ParserServicesWithTypeInformation, TSESTree } from '@typescript-eslint/utils';
+import type { ButtonFacts, ButtonProp } from '../buttons';
+import type { TSESTree } from '@typescript-eslint/utils';
 
-const BUTTON_STYLE_LINK = 5; // stable Discord wire value for a link button
-
-function setsLinkStyle(call: TSESTree.CallExpression, services: ParserServicesWithTypeInformation): boolean {
-    if (methodName(call) !== 'setStyle') return false;
-    const arg = call.arguments[0];
-    if (arg === undefined) return false;
-    // the type covers every form (literal, enum member, const), and a shadowed ButtonStyle resolves
-    // to its own value
-    const type = services.getTypeAtLocation(arg);
-    return type.isNumberLiteral() && type.value === BUTTON_STYLE_LINK;
-}
+const PREMIUM_FORBIDDEN: readonly ButtonProp[] = ['customId', 'label', 'url', 'emoji'];
 
 export default createRule({
     name: 'no-conflicting-button-props',
@@ -26,7 +27,11 @@ export default createRule({
         },
         messages: {
             idAndUrl: 'A button cannot set both a customId and a url.',
-            linkWithCustomId: 'A link button uses a url and cannot have a customId.'
+            linkWithCustomId: 'A Link button uses a url and cannot have a customId.',
+            urlOnNonLink: 'A {{style}} button cannot have a url. Only a Link button takes one.',
+            skuIdOnNonPremium: 'A {{style}} button cannot have a skuId. Only a Premium button takes one.',
+            skuIdWithProp: 'A button cannot set both a skuId and a {{prop}}.',
+            premiumProp: 'A Premium button cannot have a {{prop}}, only a skuId.'
         },
         schema: []
     },
@@ -35,20 +40,67 @@ export default createRule({
         const services = ESLintUtils.getParserServices(context);
         const checker = services.program.getTypeChecker();
 
+        function reportPremiumProps(props: Map<ButtonProp, TSESTree.Node>): void {
+            for (const prop of PREMIUM_FORBIDDEN) {
+                const site = props.get(prop);
+                if (site === undefined) continue;
+                context.report({ node: site, messageId: 'premiumProp', data: { prop } });
+            }
+        }
+
+        function reportConflicts(anchor: TSESTree.Node, style: number | undefined, facts: ButtonFacts): void {
+            const { props } = facts;
+            const customId = props.get('customId');
+            const url = props.get('url');
+            if (customId !== undefined && url !== undefined) {
+                context.report({ node: anchor, messageId: 'idAndUrl' });
+            } else if (customId !== undefined && style === LINK) {
+                context.report({ node: anchor, messageId: 'linkWithCustomId' });
+            } else if (url !== undefined && style !== undefined && style < LINK) {
+                context.report({ node: url, messageId: 'urlOnNonLink', data: { style: STYLE_NAMES[style] } });
+            }
+
+            const skuId = props.get('skuId');
+            if (skuId === undefined) return;
+            if (style !== undefined) {
+                context.report({ node: skuId, messageId: 'skuIdOnNonPremium', data: { style: STYLE_NAMES[style] } });
+                return;
+            }
+            // premium forbids these props and every other style forbids the skuId, so the pair
+            // throws no matter what the style turns out to be
+            for (const prop of PREMIUM_FORBIDDEN) {
+                if (props.has(prop)) {
+                    context.report({ node: skuId, messageId: 'skuIdWithProp', data: { prop } });
+                }
+            }
+        }
+
+        function check(anchor: TSESTree.Node, calls: TSESTree.CallExpression[], root: TSESTree.Node): void {
+            // cheap AST facts before the type lookup is worth paying for
+            const facts = gatherFacts(calls, constructorData(root));
+            if (facts.props.size === 0 && facts.styleSource === undefined) return;
+
+            const rootType = services.getTypeAtLocation(root);
+            if (!extendsDjsType(checker, rootType, 'ButtonBuilder')) return;
+
+            const trusted = gatherFacts(calls, trustedConstructorData(root, rootType));
+
+            // the type resolves every literal form (enum member, raw value, const, shadowed ButtonStyle) to its own value
+            const style = staticNumber(trusted.styleSource, services);
+
+            if (style === PREMIUM) reportPremiumProps(trusted.props);
+            else reportConflicts(anchor, style, trusted);
+        }
+
         return {
             CallExpression(node) {
                 if (!isChainTop(node)) return;
-                if (!extendsDjsType(checker, services.getTypeAtLocation(chainRoot(node)), 'ButtonBuilder')) return;
-
-                const calls = collectChain(node);
-                const hasCustomId = calls.some((call) => methodName(call) === 'setCustomId');
-                const hasUrl = calls.some((call) => methodName(call) === 'setURL');
-
-                if (hasCustomId && hasUrl) {
-                    context.report({ node, messageId: 'idAndUrl' });
-                } else if (hasCustomId && calls.some((call) => setsLinkStyle(call, services))) {
-                    context.report({ node, messageId: 'linkWithCustomId' });
-                }
+                check(node, collectChain(node), chainRoot(node));
+            },
+            NewExpression(node) {
+                // a chained root is anchored by its chain-top CallExpression visit instead
+                if (enclosingChainTop(node) !== node) return;
+                check(node, [], node);
             }
         };
     }

--- a/packages/eslint-plugin-discordjs/src/rules/no-discord-limit-exceeded.ts
+++ b/packages/eslint-plugin-discordjs/src/rules/no-discord-limit-exceeded.ts
@@ -1,4 +1,14 @@
-import { extendsDjsType, chainRoot, collectChain, isChainTop, methodName } from '@seedcord/eslint-utils';
+import {
+    constructorData,
+    enclosingChainTop,
+    extendsDjsType,
+    chainRoot,
+    collectChain,
+    getProperty,
+    isChainTop,
+    methodName,
+    trustedConstructorData
+} from '@seedcord/eslint-utils';
 import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
 
 import { createRule } from '../createRule';
@@ -10,6 +20,7 @@ interface Limit {
     builders: ReadonlySet<string>;
     addMethod: string;
     setMethod: string;
+    dataKey?: string;
     cap: number;
     detail: string;
 }
@@ -19,6 +30,7 @@ const LIMITS: readonly Limit[] = [
         builders: new Set(['ActionRowBuilder']),
         addMethod: 'addComponents',
         setMethod: 'setComponents',
+        dataKey: 'components',
         cap: 5,
         detail: 'An action row holds at most 5 components'
     },
@@ -26,6 +38,7 @@ const LIMITS: readonly Limit[] = [
         builders: new Set(['StringSelectMenuBuilder']),
         addMethod: 'addOptions',
         setMethod: 'setOptions',
+        dataKey: 'options',
         cap: 25,
         detail: 'A select menu holds at most 25 options'
     },
@@ -33,9 +46,11 @@ const LIMITS: readonly Limit[] = [
         builders: new Set(['EmbedBuilder']),
         addMethod: 'addFields',
         setMethod: 'setFields',
+        dataKey: 'fields',
         cap: 25,
         detail: 'An embed holds at most 25 fields'
     },
+    // the slash option builders take no constructor data
     {
         builders: new Set(['SlashCommandStringOption', 'SlashCommandIntegerOption', 'SlashCommandNumberOption']),
         addMethod: 'addChoices',
@@ -83,40 +98,64 @@ function arrayLength(
     return count;
 }
 
+// discord.js normalizeArray reads a sole leading array argument (or array-typed variable) as the
+// whole list and drops the remaining arguments
+function callItems(
+    call: TSESTree.CallExpression,
+    services: ParserServicesWithTypeInformation,
+    checker: ts.TypeChecker
+): number | undefined {
+    const first = call.arguments[0];
+    if (first === undefined) return 0;
+    if (first.type === AST_NODE_TYPES.ArrayExpression) return arrayLength(first, services, checker);
+    if (first.type !== AST_NODE_TYPES.SpreadElement) {
+        const type = services.getTypeAtLocation(first);
+        if (checker.isArrayLikeType(type)) return tupleLength(type, checker);
+    }
+    let count = 0;
+    for (const arg of call.arguments) {
+        if (arg.type === AST_NODE_TYPES.SpreadElement) {
+            const arity = spreadCount(arg, services, checker);
+            if (arity === undefined) return undefined;
+            count += arity;
+        } else {
+            count += 1;
+        }
+    }
+    return count;
+}
+
 function countStaticItems(
     calls: TSESTree.CallExpression[],
     limit: Limit,
+    data: TSESTree.ObjectExpression | undefined,
     services: ParserServicesWithTypeInformation,
     checker: ts.TypeChecker
 ): number | undefined {
     let count = 0;
     let matched = false;
+
+    // the constructor runs first, so its items seed the count
+    const seed = data !== undefined && limit.dataKey !== undefined ? getProperty(data, limit.dataKey) : undefined;
+    if (seed !== undefined) {
+        const length =
+            seed.value.type === AST_NODE_TYPES.ArrayExpression
+                ? arrayLength(seed.value, services, checker)
+                : tupleLength(services.getTypeAtLocation(seed.value), checker);
+        if (length === undefined) return undefined;
+        count = length;
+        matched = true;
+    }
+
     // reversed to source order, so a later setMethod wins over earlier adds
     for (const call of [...calls].reverse()) {
         const name = methodName(call);
-        if (name === limit.addMethod) {
-            matched = true;
-            for (const arg of call.arguments) {
-                if (arg.type === AST_NODE_TYPES.SpreadElement) {
-                    const arity = spreadCount(arg, services, checker);
-                    if (arity === undefined) return undefined;
-                    count += arity;
-                } else {
-                    count += 1;
-                }
-            }
-        } else if (name === limit.setMethod) {
-            matched = true;
-            const arg = call.arguments[0];
-            const length =
-                arg?.type === AST_NODE_TYPES.ArrayExpression
-                    ? arrayLength(arg, services, checker)
-                    : arg !== undefined && arg.type !== AST_NODE_TYPES.SpreadElement
-                      ? tupleLength(services.getTypeAtLocation(arg), checker)
-                      : undefined;
-            if (length === undefined) return undefined;
-            count = length; // setMethod replaces, so this resets the count
-        }
+        if (name !== limit.addMethod && name !== limit.setMethod) continue;
+        matched = true;
+        const items = callItems(call, services, checker);
+        if (items === undefined) return undefined;
+        // the setMethod replaces, so it resets the count
+        count = name === limit.addMethod ? count + items : items;
     }
     return matched ? count : undefined;
 }
@@ -129,7 +168,7 @@ export default createRule({
             description: 'Disallow exceeding a Discord builder limit with a statically-known number of items.'
         },
         messages: {
-            tooMany: '{{detail}}. This chain declares {{count}}.'
+            tooMany: '{{detail}}. This builder declares {{count}}.'
         },
         schema: []
     },
@@ -138,23 +177,39 @@ export default createRule({
         const services = ESLintUtils.getParserServices(context);
         const checker = services.program.getTypeChecker();
 
+        function check(anchor: TSESTree.Node, calls: TSESTree.CallExpression[], root: TSESTree.Node): void {
+            const rawData = constructorData(root);
+            const methods = new Set(calls.map((call) => methodName(call)));
+            // skip the type lookup when no capped method or data key is present
+            const relevant = LIMITS.some(
+                (limit) =>
+                    methods.has(limit.addMethod) ||
+                    methods.has(limit.setMethod) ||
+                    (rawData !== undefined &&
+                        limit.dataKey !== undefined &&
+                        getProperty(rawData, limit.dataKey) !== undefined)
+            );
+            if (!relevant) return;
+
+            const rootType = services.getTypeAtLocation(root);
+            const limit = LIMITS.find((entry) => extendsDjsType(checker, rootType, entry.builders));
+            if (!limit) return;
+
+            const count = countStaticItems(calls, limit, trustedConstructorData(root, rootType), services, checker);
+            if (count !== undefined && count > limit.cap) {
+                context.report({ node: anchor, messageId: 'tooMany', data: { detail: limit.detail, count } });
+            }
+        }
+
         return {
             CallExpression(node) {
                 if (!isChainTop(node)) return;
-
-                const calls = collectChain(node);
-                const methods = new Set(calls.map((call) => methodName(call)));
-                // skip the type lookup when no capped method is on the chain
-                if (!LIMITS.some((limit) => methods.has(limit.addMethod) || methods.has(limit.setMethod))) return;
-
-                const type = services.getTypeAtLocation(chainRoot(node));
-                const limit = LIMITS.find((entry) => extendsDjsType(checker, type, entry.builders));
-                if (!limit) return;
-
-                const count = countStaticItems(calls, limit, services, checker);
-                if (count !== undefined && count > limit.cap) {
-                    context.report({ node, messageId: 'tooMany', data: { detail: limit.detail, count } });
-                }
+                check(node, collectChain(node), chainRoot(node));
+            },
+            NewExpression(node) {
+                // a chained root is anchored by its chain-top CallExpression visit instead
+                if (enclosingChainTop(node) !== node) return;
+                check(node, [], node);
             }
         };
     }

--- a/packages/eslint-plugin-discordjs/src/rules/require-button-props.ts
+++ b/packages/eslint-plugin-discordjs/src/rules/require-button-props.ts
@@ -1,0 +1,168 @@
+import {
+    constructorData,
+    enclosingChainTop,
+    extendsDjsType,
+    collectChain,
+    isFromDiscordJs,
+    methodName,
+    staticNumber
+} from '@seedcord/eslint-utils';
+import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
+
+import { gatherFacts, LINK, PREMIUM, STYLE_NAMES } from '../buttons';
+import { createRule } from '../createRule';
+
+import type { ButtonFacts } from '../buttons';
+import type { ParserServicesWithTypeInformation, TSESLint, TSESTree } from '@typescript-eslint/utils';
+import type * as ts from 'typescript';
+
+interface TypeInfo {
+    services: ParserServicesWithTypeInformation;
+    checker: ts.TypeChecker;
+    sourceCode: TSESLint.SourceCode;
+}
+
+// discord.js's own methods read a builder argument without adding props to it
+function isDjsConsumption(call: TSESTree.CallExpression, arg: TSESTree.Expression, info: TypeInfo): boolean {
+    if (call.callee.type !== AST_NODE_TYPES.MemberExpression) return false;
+    if (!call.arguments.includes(arg)) return false;
+    return isFromDiscordJs(info.services.getTypeAtLocation(call.callee.object).getSymbol());
+}
+
+// the setter calls that a single read adds, [] for plain consumption, undefined when the builder
+// escapes somewhere props could still be added
+function referenceCalls(id: TSESTree.Identifier, info: TypeInfo): TSESTree.CallExpression[] | undefined {
+    const top = enclosingChainTop(id);
+    if (top !== id && top.type === AST_NODE_TYPES.CallExpression) {
+        const calls = collectChain(top);
+        // a setter chain returns the builder itself, so its result must be dropped or consumed,
+        // never bound where props could still be added
+        if (!extendsDjsType(info.checker, info.services.getTypeAtLocation(top), 'ButtonBuilder')) return calls;
+        if (top.parent.type === AST_NODE_TYPES.ExpressionStatement) return calls;
+        if (top.parent.type === AST_NODE_TYPES.CallExpression && isDjsConsumption(top.parent, top, info)) {
+            return calls;
+        }
+        return undefined;
+    }
+    if (id.parent.type === AST_NODE_TYPES.CallExpression && isDjsConsumption(id.parent, id, info)) {
+        // a from() source is a template, its copies carry the completion
+        return methodName(id.parent) === 'from' ? undefined : [];
+    }
+    // exporting an incomplete builder is flagged deliberately, cross-module completion mutates a
+    // shared instance and stays out of scope
+    if (
+        id.parent.type === AST_NODE_TYPES.ExportSpecifier ||
+        id.parent.type === AST_NODE_TYPES.ExportDefaultDeclaration
+    ) {
+        return [];
+    }
+    return undefined;
+}
+
+// setter calls from every later statement that reads the variable, or undefined when the builder
+// escapes through a reference
+function completionCalls(
+    declarator: TSESTree.VariableDeclarator,
+    info: TypeInfo
+): TSESTree.CallExpression[] | undefined {
+    const variable = info.sourceCode.getDeclaredVariables(declarator)[0];
+    if (variable === undefined) return undefined;
+
+    const chains: TSESTree.CallExpression[][] = [];
+    for (const ref of variable.references) {
+        if (ref.init) continue;
+        if (ref.isWrite() || ref.identifier.type !== AST_NODE_TYPES.Identifier) return undefined;
+        const calls = referenceCalls(ref.identifier, info);
+        if (calls === undefined) return undefined;
+        chains.push(calls);
+    }
+    // reversed so gatherFacts reads the last statement's calls first, matching run order
+    return chains.reverse().flat();
+}
+
+// the calls that run on the finished value, or undefined when later code could still add props
+function reachableCalls(
+    top: TSESTree.CallExpression | TSESTree.NewExpression,
+    info: TypeInfo
+): TSESTree.CallExpression[] | undefined {
+    const calls = top.type === AST_NODE_TYPES.CallExpression ? collectChain(top) : [];
+    const parent = top.parent;
+    if (parent.type === AST_NODE_TYPES.VariableDeclarator && parent.id.type === AST_NODE_TYPES.Identifier) {
+        const later = completionCalls(parent, info);
+        return later === undefined ? undefined : [...later, ...calls];
+    }
+    if (parent.type === AST_NODE_TYPES.ExpressionStatement) return calls;
+    if (parent.type === AST_NODE_TYPES.CallExpression && isDjsConsumption(parent, top, info)) return calls;
+    return undefined;
+}
+
+export default createRule({
+    name: 'require-button-props',
+    meta: {
+        type: 'problem',
+        docs: {
+            description: 'Require every prop the button style must carry before the payload reaches Discord.'
+        },
+        messages: {
+            missingStyle: 'A button requires a style. Discord rejects one without it.',
+            missingUrl: 'A Link button requires a url.',
+            missingSkuId: 'A Premium button requires a skuId.',
+            missingCustomId: 'A {{style}} button requires a customId.',
+            missingLabel: 'A {{style}} button requires a label or an emoji.'
+        },
+        schema: []
+    },
+    defaultOptions: [],
+    create(context) {
+        const services = ESLintUtils.getParserServices(context);
+        const info: TypeInfo = { services, checker: services.program.getTypeChecker(), sourceCode: context.sourceCode };
+
+        function reportMissing(anchor: TSESTree.Node, style: number, facts: ButtonFacts): void {
+            const { props } = facts;
+            if (style === PREMIUM) {
+                if (!props.has('skuId')) context.report({ node: anchor, messageId: 'missingSkuId' });
+                return;
+            }
+            if (style === LINK && !props.has('url')) {
+                context.report({ node: anchor, messageId: 'missingUrl' });
+            }
+            if (style < LINK && !props.has('customId')) {
+                context.report({ node: anchor, messageId: 'missingCustomId', data: { style: STYLE_NAMES[style] } });
+            }
+            // builders reject a label-less, emoji-less non-premium button at toJSON
+            if (!props.has('label') && !props.has('emoji')) {
+                context.report({ node: anchor, messageId: 'missingLabel', data: { style: STYLE_NAMES[style] } });
+            }
+        }
+
+        return {
+            NewExpression(node) {
+                // a bare discord.js ButtonBuilder construction is the only root that shows every
+                // prop the button will carry, so subclasses and .from() copies stay out
+                const type = services.getTypeAtLocation(node);
+                if (!isFromDiscordJs(type.getSymbol()) || !extendsDjsType(info.checker, type, 'ButtonBuilder')) return;
+
+                // an unreadable data argument can carry any prop, and so can a spread inside it
+                const data = constructorData(node);
+                if (node.arguments.length > 0 && data === undefined) return;
+                if (data?.properties.some((p) => p.type === AST_NODE_TYPES.SpreadElement) === true) return;
+
+                // where the finished value lands decides whether later code can still add props
+                const top = enclosingChainTop(node);
+                const calls = reachableCalls(top, info);
+                if (calls === undefined) return;
+
+                const facts = gatherFacts(calls, data);
+                if (facts.styleSource === undefined) {
+                    context.report({ node: top, messageId: 'missingStyle' });
+                    return;
+                }
+                // a style that is set but not static keeps the requirements unknowable
+                const style = staticNumber(facts.styleSource, services);
+                if (style === undefined) return;
+
+                reportMissing(top, style, facts);
+            }
+        };
+    }
+});

--- a/packages/eslint-plugin-discordjs/src/rules/select-menu-min-exceeds-max.ts
+++ b/packages/eslint-plugin-discordjs/src/rules/select-menu-min-exceeds-max.ts
@@ -1,33 +1,41 @@
 import {
+    calleeProperty,
+    constructorData,
+    enclosingChainTop,
     extendsDjsType,
     chainRoot,
     collectChain,
+    getProperty,
     isChainTop,
-    methodName,
-    unwrapAssertions
+    lastCall,
+    staticNumber,
+    trustedConstructorData
 } from '@seedcord/eslint-utils';
-import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
+import { ESLintUtils } from '@typescript-eslint/utils';
 
 import { createRule } from '../createRule';
 
-import type { ParserServicesWithTypeInformation, TSESTree } from '@typescript-eslint/utils';
+import type { TSESTree } from '@typescript-eslint/utils';
 
-// collectChain is outermost-first, so the first match is the last call executed, and that one wins
-function lastCall(calls: TSESTree.CallExpression[], name: string): TSESTree.CallExpression | undefined {
-    return calls.find((call) => methodName(call) === name);
+interface Bound {
+    source: TSESTree.CallExpressionArgument | TSESTree.Property['value'] | undefined;
+    site: TSESTree.Node;
 }
 
-function staticNumber(
-    arg: TSESTree.CallExpressionArgument | undefined,
-    services: ParserServicesWithTypeInformation
-): number | undefined {
-    if (arg === undefined || arg.type === AST_NODE_TYPES.SpreadElement) return undefined;
-    // a cast only changes the checker's view, the literal behind it is the runtime value
-    const target = unwrapAssertions(arg);
-    if (target.type === AST_NODE_TYPES.Literal && typeof target.value === 'number') return target.value;
-    // a const bound resolves through its number-literal type
-    const type = services.getTypeAtLocation(target);
-    return type.isNumberLiteral() ? type.value : undefined;
+// a chained setter runs after the constructor, so it wins over the data key. discord.js also
+// accepts the camelCase key and snake_cases it at construction
+function boundOf(
+    calls: TSESTree.CallExpression[],
+    data: TSESTree.ObjectExpression | undefined,
+    method: string,
+    key: string,
+    camelKey: string
+): Bound | undefined {
+    const call = lastCall(calls, method);
+    if (call !== undefined) return { source: call.arguments[0], site: calleeProperty(call) };
+    const prop = data === undefined ? undefined : (getProperty(data, key) ?? getProperty(data, camelKey));
+    if (prop !== undefined) return { source: prop.value, site: prop };
+    return undefined;
 }
 
 export default createRule({
@@ -38,7 +46,8 @@ export default createRule({
             description: 'Disallow a select menu whose minimum selections exceed its maximum.'
         },
         messages: {
-            minOverMax: 'setMinValues({{min}}) is greater than setMaxValues({{max}}). Discord rejects the select menu.'
+            minOverMax:
+                'A minimum of {{min}} selections exceeds the maximum of {{max}}. Discord rejects the select menu.'
         },
         schema: []
     },
@@ -47,28 +56,37 @@ export default createRule({
         const services = ESLintUtils.getParserServices(context);
         const checker = services.program.getTypeChecker();
 
+        function check(calls: TSESTree.CallExpression[], root: TSESTree.Node): void {
+            // both bounds must be present from some source before the type lookup
+            const rawData = constructorData(root);
+            if (boundOf(calls, rawData, 'setMinValues', 'min_values', 'minValues') === undefined) return;
+            if (boundOf(calls, rawData, 'setMaxValues', 'max_values', 'maxValues') === undefined) return;
+
+            const rootType = services.getTypeAtLocation(root);
+            if (!extendsDjsType(checker, rootType, 'BaseSelectMenuBuilder')) return;
+
+            const data = trustedConstructorData(root, rootType);
+            const min = boundOf(calls, data, 'setMinValues', 'min_values', 'minValues');
+            const max = boundOf(calls, data, 'setMaxValues', 'max_values', 'maxValues');
+            if (min === undefined || max === undefined) return;
+
+            const minValue = staticNumber(min.source, services);
+            const maxValue = staticNumber(max.source, services);
+            if (minValue === undefined || maxValue === undefined || minValue <= maxValue) return;
+
+            // so the squiggle lands on the offending bound
+            context.report({ node: min.site, messageId: 'minOverMax', data: { min: minValue, max: maxValue } });
+        }
+
         return {
             CallExpression(node) {
                 if (!isChainTop(node)) return;
-
-                const calls = collectChain(node);
-                // both setters must be on the chain before the type lookup is worth paying for
-                const minCall = lastCall(calls, 'setMinValues');
-                const maxCall = lastCall(calls, 'setMaxValues');
-                if (minCall === undefined || maxCall === undefined) return;
-
-                if (!extendsDjsType(checker, services.getTypeAtLocation(chainRoot(node)), 'BaseSelectMenuBuilder')) {
-                    return;
-                }
-
-                const min = staticNumber(minCall.arguments[0], services);
-                const max = staticNumber(maxCall.arguments[0], services);
-                if (min === undefined || max === undefined || min <= max) return;
-
-                // so the squiggle lands on the offending setter
-                const target =
-                    minCall.callee.type === AST_NODE_TYPES.MemberExpression ? minCall.callee.property : minCall;
-                context.report({ node: target, messageId: 'minOverMax', data: { min, max } });
+                check(collectChain(node), chainRoot(node));
+            },
+            NewExpression(node) {
+                // a chained root is anchored by its chain-top CallExpression visit instead
+                if (enclosingChainTop(node) !== node) return;
+                check([], node);
             }
         };
     }

--- a/packages/eslint-plugin-discordjs/tests/rules/no-conflicting-button-props.test.ts
+++ b/packages/eslint-plugin-discordjs/tests/rules/no-conflicting-button-props.test.ts
@@ -56,6 +56,43 @@ ruleTester.run('no-conflicting-button-props', rule, {
             new ButtonBuilder()
                 .setStyle(ButtonStyle.Link)
                 .setCustomId('x');
+        `,
+        // a style only known at runtime stays unflagged
+        dedent`
+            import { ButtonBuilder, ButtonStyle } from 'discord.js';
+            declare const style: ButtonStyle;
+            new ButtonBuilder()
+                .setStyle(style)
+                .setURL('https://example.com')
+                .setLabel('y');
+        `,
+        // a premium button, skuId only
+        dedent`
+            import { ButtonBuilder, ButtonStyle } from 'discord.js';
+            new ButtonBuilder()
+                .setStyle(ButtonStyle.Premium)
+                .setSKUId('123')
+                .setDisabled(true);
+        `,
+        // a subclass constructor argument is not API data
+        dedent`
+            import { ButtonBuilder } from 'discord.js';
+            class NavButton extends ButtonBuilder {
+                constructor(opts: { url: string; custom_id: string }) {
+                    super();
+                    void opts;
+                }
+            }
+            new NavButton({ url: 'https://example.com', custom_id: 'x' });
+        `,
+        // the last setStyle wins, and it moves the button off the Link style
+        dedent`
+            import { ButtonBuilder, ButtonStyle } from 'discord.js';
+            new ButtonBuilder()
+                .setStyle(ButtonStyle.Link)
+                .setStyle(ButtonStyle.Primary)
+                .setCustomId('x')
+                .setLabel('y');
         `
     ],
     invalid: [
@@ -68,6 +105,93 @@ ruleTester.run('no-conflicting-button-props', rule, {
                     .setLabel('y');
             `,
             errors: [{ messageId: 'idAndUrl' }]
+        },
+        {
+            code: dedent`
+                import { ButtonBuilder, ButtonStyle } from 'discord.js';
+                new ButtonBuilder()
+                    .setStyle(ButtonStyle.Danger)
+                    .setURL('https://example.com')
+                    .setLabel('y');
+            `,
+            errors: [{ messageId: 'urlOnNonLink', data: { style: 'Danger' } }]
+        },
+        {
+            code: dedent`
+                import { ButtonBuilder, ButtonStyle } from 'discord.js';
+                new ButtonBuilder()
+                    .setStyle(ButtonStyle.Secondary)
+                    .setCustomId('x')
+                    .setLabel('y')
+                    .setSKUId('123');
+            `,
+            errors: [{ messageId: 'skuIdOnNonPremium', data: { style: 'Secondary' } }]
+        },
+        {
+            code: dedent`
+                import { ButtonBuilder, ButtonStyle } from 'discord.js';
+                new ButtonBuilder()
+                    .setStyle(ButtonStyle.Premium)
+                    .setSKUId('123')
+                    .setLabel('y')
+                    .setEmoji({ name: 'x' });
+            `,
+            errors: [
+                { messageId: 'premiumProp', data: { prop: 'label' } },
+                { messageId: 'premiumProp', data: { prop: 'emoji' } }
+            ]
+        },
+        {
+            // constructor data carries the same state as the setters
+            code: dedent`
+                import { ButtonBuilder } from 'discord.js';
+                new ButtonBuilder({ custom_id: 'x', label: 'y' })
+                    .setURL('https://example.com');
+            `,
+            errors: [{ messageId: 'idAndUrl' }]
+        },
+        {
+            code: dedent`
+                import { ButtonBuilder, ButtonStyle } from 'discord.js';
+                new ButtonBuilder({ style: ButtonStyle.Success, label: 'y' })
+                    .setURL('https://example.com');
+            `,
+            errors: [{ messageId: 'urlOnNonLink', data: { style: 'Success' } }]
+        },
+        {
+            // no chain at all, the conflict sits entirely in the constructor
+            code: dedent`
+                import { ButtonBuilder } from 'discord.js';
+                new ButtonBuilder({ custom_id: 'x', url: 'https://example.com', label: 'y' });
+            `,
+            errors: [{ messageId: 'idAndUrl' }]
+        },
+        {
+            // discord.js snake_cases camelCase data at construction
+            code: dedent`
+                import { ButtonBuilder } from 'discord.js';
+                new ButtonBuilder({ customId: 'x', label: 'y' }).setURL('https://example.com');
+            `,
+            errors: [{ messageId: 'idAndUrl' }]
+        },
+        {
+            // skuId with any premium-forbidden prop throws under every style
+            code: dedent`
+                import { ButtonBuilder } from 'discord.js';
+                new ButtonBuilder().setSKUId('123').setCustomId('x');
+            `,
+            errors: [{ messageId: 'skuIdWithProp', data: { prop: 'customId' } }]
+        },
+        {
+            // the chained setStyle runs after the constructor and wins
+            code: dedent`
+                import { ButtonBuilder, ButtonStyle } from 'discord.js';
+                new ButtonBuilder({ style: ButtonStyle.Primary })
+                    .setStyle(ButtonStyle.Link)
+                    .setCustomId('x')
+                    .setLabel('y');
+            `,
+            errors: [{ messageId: 'linkWithCustomId' }]
         },
         {
             code: dedent`
@@ -121,7 +245,7 @@ ruleTester.run('no-conflicting-button-props', rule, {
             errors: [{ messageId: 'linkWithCustomId' }]
         },
         {
-            // ButtonStyle.Link stored in a const - the type resolves to the numeric literal 5
+            // ButtonStyle.Link stored in a const, the type resolves to the numeric literal 5
             code: dedent`
                 import { ButtonBuilder, ButtonStyle } from 'discord.js';
                 const linkStyle = ButtonStyle.Link;

--- a/packages/eslint-plugin-discordjs/tests/rules/no-discord-limit-exceeded.test.ts
+++ b/packages/eslint-plugin-discordjs/tests/rules/no-discord-limit-exceeded.test.ts
@@ -31,6 +31,11 @@ ruleTester.run('no-discord-limit-exceeded', rule, {
             import { ActionRowBuilder } from 'discord.js';
             new ActionRowBuilder().addComponents({}, {}, {}, {}).setComponents([{}, {}]);
         `,
+        // setComponents also replaces the constructor items
+        dedent`
+            import { ActionRowBuilder } from 'discord.js';
+            new ActionRowBuilder({ components: [${objs(6)}] }).setComponents([{}, {}]);
+        `,
         // setComponents with a variable, the count is not statically known
         dedent`
             import { ActionRowBuilder, ButtonBuilder } from 'discord.js';
@@ -76,6 +81,38 @@ ruleTester.run('no-discord-limit-exceeded', rule, {
             code: dedent`
                 import { ActionRowBuilder } from 'discord.js';
                 new ActionRowBuilder().addComponents({}, {}, {}, {}, {}, {});
+            `,
+            errors: [{ messageId: 'tooMany' }]
+        },
+        {
+            // the constructor data alone exceeds the cap, no chain
+            code: dedent`
+                import { ActionRowBuilder } from 'discord.js';
+                new ActionRowBuilder({ components: [${objs(6)}] });
+            `,
+            errors: [{ messageId: 'tooMany' }]
+        },
+        {
+            // constructor items and chained adds sum past the cap
+            code: dedent`
+                import { ActionRowBuilder } from 'discord.js';
+                new ActionRowBuilder({ components: [${objs(3)}] }).addComponents({}, {}, {});
+            `,
+            errors: [{ messageId: 'tooMany' }]
+        },
+        {
+            // a sole leading array argument is the whole list at runtime
+            code: dedent`
+                import { ActionRowBuilder } from 'discord.js';
+                new ActionRowBuilder().addComponents([${objs(6)}]);
+            `,
+            errors: [{ messageId: 'tooMany' }]
+        },
+        {
+            // the set methods take the rest form too
+            code: dedent`
+                import { ActionRowBuilder } from 'discord.js';
+                new ActionRowBuilder().setComponents(${objs(6)});
             `,
             errors: [{ messageId: 'tooMany' }]
         },

--- a/packages/eslint-plugin-discordjs/tests/rules/require-button-props.test.ts
+++ b/packages/eslint-plugin-discordjs/tests/rules/require-button-props.test.ts
@@ -1,0 +1,201 @@
+import dedent from 'dedent';
+
+import rule from '../../src/rules/require-button-props';
+import { createTypedRuleTester } from '../typed-rule-tester';
+
+const ruleTester = createTypedRuleTester();
+
+ruleTester.run('require-button-props', rule, {
+    valid: [
+        // a complete link button
+        dedent`
+            import { ButtonBuilder, ButtonStyle } from 'discord.js';
+            new ButtonBuilder()
+                .setStyle(ButtonStyle.Link)
+                .setURL('https://example.com')
+                .setLabel('Docs');
+        `,
+        // a dynamic style is unknowable, and so are its requirements
+        dedent`
+            import { ButtonBuilder, ButtonStyle } from 'discord.js';
+            declare const style: ButtonStyle;
+            new ButtonBuilder().setStyle(style).setLabel('x');
+        `,
+        // constructor data carries the customId
+        dedent`
+            import { ButtonBuilder, ButtonStyle } from 'discord.js';
+            new ButtonBuilder({ custom_id: 'x' })
+                .setStyle(ButtonStyle.Danger)
+                .setLabel('Delete');
+        `,
+        // discord.js snake_cases camelCase data at construction
+        dedent`
+            import { ButtonBuilder, ButtonStyle } from 'discord.js';
+            new ButtonBuilder({ customId: 'confirm', style: ButtonStyle.Danger, label: 'Delete' });
+        `,
+        // an unreadable data argument can carry any prop
+        dedent`
+            import { ButtonBuilder, ButtonStyle } from 'discord.js';
+            import type { APIButtonComponent } from 'discord.js';
+            declare const data: Partial<APIButtonComponent>;
+            new ButtonBuilder(data).setStyle(ButtonStyle.Danger);
+        `,
+        // a spread inside the data literal can carry any prop
+        dedent`
+            import { ButtonBuilder, ButtonStyle } from 'discord.js';
+            declare const base: { label: string };
+            new ButtonBuilder({ ...base, style: ButtonStyle.Danger, custom_id: 'x' });
+        `,
+        // a .from() copy starts with the source's props
+        dedent`
+            import { ButtonBuilder, ButtonStyle } from 'discord.js';
+            declare const base: ButtonBuilder;
+            ButtonBuilder.from(base).setStyle(ButtonStyle.Link);
+        `,
+        // a base fed to from() is a template, its copies carry the completion
+        dedent`
+            import { ButtonBuilder, ButtonStyle } from 'discord.js';
+            const base = new ButtonBuilder().setStyle(ButtonStyle.Secondary);
+            ButtonBuilder.from(base).setCustomId('x').setLabel('y');
+        `,
+        // a subclass constructor can set props of its own
+        dedent`
+            import { ButtonBuilder, ButtonStyle } from 'discord.js';
+            class NavButton extends ButtonBuilder {
+                constructor() {
+                    super({ custom_id: 'nav' });
+                }
+            }
+            new NavButton().setStyle(ButtonStyle.Secondary).setLabel('x');
+        `,
+        // a later statement completes the builder
+        dedent`
+            import { ButtonBuilder, ButtonStyle } from 'discord.js';
+            const b = new ButtonBuilder().setStyle(ButtonStyle.Danger).setLabel('x');
+            b.setCustomId('y');
+        `,
+        // every prop arrives through statement chains on the variable
+        dedent`
+            import { ButtonBuilder, ButtonStyle } from 'discord.js';
+            const b = new ButtonBuilder();
+            b.setStyle(ButtonStyle.Danger).setLabel('x');
+            b.setCustomId('y');
+        `,
+        // a function taking the builder can add props the rule cannot read
+        dedent`
+            import { ButtonBuilder, ButtonStyle } from 'discord.js';
+            declare function finish(b: ButtonBuilder): void;
+            const b = new ButtonBuilder().setStyle(ButtonStyle.Danger).setLabel('x');
+            finish(b);
+        `,
+        // same for the chain handed to a function inline
+        dedent`
+            import { ButtonBuilder, ButtonStyle } from 'discord.js';
+            declare function wrap(b: ButtonBuilder): ButtonBuilder;
+            wrap(new ButtonBuilder().setStyle(ButtonStyle.Danger).setLabel('x'));
+        `
+    ],
+    invalid: [
+        {
+            code: dedent`
+                import { ButtonBuilder, ButtonStyle } from 'discord.js';
+                new ButtonBuilder()
+                    .setStyle(ButtonStyle.Link)
+                    .setLabel('Docs');
+            `,
+            errors: [{ messageId: 'missingUrl' }]
+        },
+        {
+            code: dedent`
+                import { ButtonBuilder, ButtonStyle } from 'discord.js';
+                new ButtonBuilder()
+                    .setStyle(ButtonStyle.Premium);
+            `,
+            errors: [{ messageId: 'missingSkuId' }]
+        },
+        {
+            code: dedent`
+                import { ButtonBuilder, ButtonStyle } from 'discord.js';
+                new ButtonBuilder()
+                    .setStyle(ButtonStyle.Danger)
+                    .setLabel('Delete');
+            `,
+            errors: [{ messageId: 'missingCustomId', data: { style: 'Danger' } }]
+        },
+        {
+            // builders reject a label-less, emoji-less button at toJSON
+            code: dedent`
+                import { ButtonBuilder, ButtonStyle } from 'discord.js';
+                new ButtonBuilder()
+                    .setStyle(ButtonStyle.Link)
+                    .setURL('https://example.com');
+            `,
+            errors: [{ messageId: 'missingLabel', data: { style: 'Link' } }]
+        },
+        {
+            // style never set from any source, the API requires one
+            code: dedent`
+                import { ButtonBuilder } from 'discord.js';
+                new ButtonBuilder().setLabel('x');
+            `,
+            errors: [{ messageId: 'missingStyle' }]
+        },
+        {
+            // both gaps report, one per missing prop
+            code: dedent`
+                import { ButtonBuilder, ButtonStyle } from 'discord.js';
+                new ButtonBuilder().setStyle(ButtonStyle.Danger);
+            `,
+            errors: [
+                { messageId: 'missingCustomId', data: { style: 'Danger' } },
+                { messageId: 'missingLabel', data: { style: 'Danger' } }
+            ]
+        },
+        {
+            // no later statement completes the exported builder
+            code: dedent`
+                import { ButtonBuilder, ButtonStyle } from 'discord.js';
+                export const btn = new ButtonBuilder()
+                    .setStyle(ButtonStyle.Link)
+                    .setURL('https://example.com');
+            `,
+            errors: [{ messageId: 'missingLabel', data: { style: 'Link' } }]
+        },
+        {
+            // a named re-export is the same case as export const
+            code: dedent`
+                import { ButtonBuilder, ButtonStyle } from 'discord.js';
+                const btn = new ButtonBuilder().setStyle(ButtonStyle.Link).setURL('https://example.com');
+                export { btn };
+            `,
+            errors: [{ messageId: 'missingLabel', data: { style: 'Link' } }]
+        },
+        {
+            code: dedent`
+                import { ButtonBuilder, ButtonStyle } from 'discord.js';
+                const btn = new ButtonBuilder().setStyle(ButtonStyle.Link).setURL('https://example.com');
+                export default btn;
+            `,
+            errors: [{ messageId: 'missingLabel', data: { style: 'Link' } }]
+        },
+        {
+            // discord.js consumption seals the builder as-is
+            code: dedent`
+                import { ActionRowBuilder, ButtonBuilder, ButtonStyle } from 'discord.js';
+                declare const row: ActionRowBuilder<ButtonBuilder>;
+                const b = new ButtonBuilder().setStyle(ButtonStyle.Danger).setLabel('x');
+                row.addComponents(b);
+            `,
+            errors: [{ messageId: 'missingCustomId', data: { style: 'Danger' } }]
+        },
+        {
+            code: dedent`
+                import { ActionRowBuilder, ButtonBuilder, ButtonStyle } from 'discord.js';
+                new ActionRowBuilder<ButtonBuilder>().addComponents(
+                    new ButtonBuilder().setStyle(ButtonStyle.Danger).setLabel('x')
+                );
+            `,
+            errors: [{ messageId: 'missingCustomId', data: { style: 'Danger' } }]
+        }
+    ]
+});

--- a/packages/eslint-plugin-discordjs/tests/rules/select-menu-min-exceeds-max.test.ts
+++ b/packages/eslint-plugin-discordjs/tests/rules/select-menu-min-exceeds-max.test.ts
@@ -72,6 +72,30 @@ ruleTester.run('select-menu-min-exceeds-max', rule, {
             errors: [{ messageId: 'minOverMax' }]
         },
         {
+            // both bounds in the constructor, no chain
+            code: dedent`
+                import { StringSelectMenuBuilder } from 'discord.js';
+                new StringSelectMenuBuilder({ custom_id: 'c', min_values: 3, max_values: 2 });
+            `,
+            errors: [{ messageId: 'minOverMax' }]
+        },
+        {
+            // one bound in the constructor, the other chained
+            code: dedent`
+                import { StringSelectMenuBuilder } from 'discord.js';
+                new StringSelectMenuBuilder({ custom_id: 'c', min_values: 3 }).setMaxValues(2);
+            `,
+            errors: [{ messageId: 'minOverMax' }]
+        },
+        {
+            // discord.js snake_cases camelCase data at construction
+            code: dedent`
+                import { StringSelectMenuBuilder } from 'discord.js';
+                new StringSelectMenuBuilder({ customId: 'c', minValues: 3, maxValues: 2 });
+            `,
+            errors: [{ messageId: 'minOverMax' }]
+        },
+        {
             // max set before min, the order does not matter
             code: dedent`
                 import { StringSelectMenuBuilder } from 'discord.js';

--- a/packages/eslint-utils/src/typeUtils.ts
+++ b/packages/eslint-utils/src/typeUtils.ts
@@ -1,4 +1,7 @@
+import { AST_NODE_TYPES } from '@typescript-eslint/utils';
 import { TypeFlags } from 'typescript';
+
+import { constructorData, unwrapAssertions } from './utils';
 
 import type { ParserServicesWithTypeInformation, TSESTree } from '@typescript-eslint/utils';
 import type * as ts from 'typescript';
@@ -47,6 +50,33 @@ function walkBaseChain(checker: ts.TypeChecker, type: ts.Type, match: (symbol: t
 export function extendsDjsType(checker: ts.TypeChecker, type: ts.Type, names: string | ReadonlySet<string>): boolean {
     const wanted = typeof names === 'string' ? new Set([names]) : names;
     return walkBaseChain(checker, type, (symbol) => wanted.has(symbol.getName()) && isFromDiscordJs(symbol));
+}
+
+// a user subclass constructor may repurpose the data argument, so it only counts on
+// discord.js's own classes
+export function trustedConstructorData(root: TSESTree.Node, rootType: ts.Type): TSESTree.ObjectExpression | undefined {
+    const data = constructorData(root);
+    return data !== undefined && isFromDiscordJs(rootType.getSymbol()) ? data : undefined;
+}
+
+export function staticNumber(
+    node: TSESTree.CallExpressionArgument | TSESTree.Property['value'] | undefined,
+    services: ParserServicesWithTypeInformation
+): number | undefined {
+    if (
+        node === undefined ||
+        node.type === AST_NODE_TYPES.SpreadElement ||
+        node.type === AST_NODE_TYPES.AssignmentPattern ||
+        node.type === AST_NODE_TYPES.TSEmptyBodyFunctionExpression
+    ) {
+        return undefined;
+    }
+    // a cast only changes the checker's view, the literal behind it is the runtime value
+    const target = unwrapAssertions(node);
+    if (target.type === AST_NODE_TYPES.Literal && typeof target.value === 'number') return target.value;
+    // a const bound resolves through its number-literal type
+    const type = services.getTypeAtLocation(target);
+    return type.isNumberLiteral() ? type.value : undefined;
 }
 
 // a boolean literal's value is only reachable through its printed name

--- a/packages/eslint-utils/src/utils.ts
+++ b/packages/eslint-utils/src/utils.ts
@@ -67,6 +67,30 @@ export function chainRoot(top: TSESTree.CallExpression): TSESTree.Node {
     return current;
 }
 
+// the outermost call of the fluent chain built on this expression, or the expression itself when unchained
+export function enclosingChainTop<Node extends TSESTree.Node>(node: Node): Node | TSESTree.CallExpression {
+    let current: Node | TSESTree.CallExpression = node;
+    while (
+        current.parent?.type === AST_NODE_TYPES.MemberExpression &&
+        current.parent.object === current &&
+        current.parent.parent.type === AST_NODE_TYPES.CallExpression &&
+        current.parent.parent.callee === current.parent
+    ) {
+        current = current.parent.parent;
+    }
+    return current;
+}
+
+// collectChain is outermost-first, so the first match is the last call executed, and that one wins
+export function lastCall(calls: TSESTree.CallExpression[], name: string): TSESTree.CallExpression | undefined {
+    return calls.find((call) => methodName(call) === name);
+}
+
+// the property token of a member call, the natural report target for an offending setter
+export function calleeProperty(call: TSESTree.CallExpression): TSESTree.Node {
+    return call.callee.type === AST_NODE_TYPES.MemberExpression ? call.callee.property : call;
+}
+
 // a later reassignment means the initializer is not the value that reaches the use site
 export function resolveConstInit(
     sourceCode: TSESLint.SourceCode,
@@ -91,6 +115,15 @@ export function getProperty(node: TSESTree.ObjectExpression, name: string): TSES
     return node.properties.find(
         (prop): prop is TSESTree.Property => prop.type === AST_NODE_TYPES.Property && propertyKeyIs(prop, name)
     );
+}
+
+// the data object literal behind a builder chain's `new X({ ... })` root
+export function constructorData(root: TSESTree.Node): TSESTree.ObjectExpression | undefined {
+    if (root.type !== AST_NODE_TYPES.NewExpression) return undefined;
+    const arg = root.arguments[0];
+    if (arg === undefined || arg.type === AST_NODE_TYPES.SpreadElement) return undefined;
+    const value = unwrapAssertions(arg);
+    return value.type === AST_NODE_TYPES.ObjectExpression ? value : undefined;
 }
 
 // unwrap as / satisfies / <T> so the expression behind them is still readable


### PR DESCRIPTION
- New `require-button-props`: a sealed button missing its style or its style's required props. Bails on any lifetime it cannot read (user functions, returns, aliases, subclasses, `.from()` copies, opaque or spread data). An exported incomplete builder reports.
- `no-conflicting-button-props`: url on styles 1-4, skuId outside Premium, customId/label/url/emoji on Premium, skuId paired with any of those under an unknown style.
- Constructor data counts like setters in the button, select-bound, and limit rules, both key casings, chainless `new Builder({ ... })` included. A subclass constructor argument is never read as API data.
- `no-discord-limit-exceeded` counts the array form and rest form `normalizeArray` flattens.
- `@seedcord/eslint-utils`: `constructorData`, `trustedConstructorData`, `staticNumber`, `enclosingChainTop`, `lastCall`, `calleeProperty`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new lint rule that checks button builders for missing required props based on button style.
  * Expanded linting to catch more button prop conflicts, including Premium and URL-style rules.

* **Bug Fixes**
  * Improved detection for builder limits and select-menu min/max checks, including values set in constructors.
  * Updated validation to handle both chained calls and constructor data more accurately.

* **Documentation**
  * Refreshed rule docs and examples to match the new lint behavior and supported patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->