### PR TITLE
feat: config.store rate-limiter backend + Store seam

### DIFF
--- a/.changeset/config-store.md
+++ b/.changeset/config-store.md
@@ -1,0 +1,7 @@
+---
+'@seedcord/types': patch
+'@seedcord/rate-limiter': patch
+'@seedcord/gateway': patch
+---
+
+Add optional `config.store` to supply a durable rate-limiter backend, replacing the in-memory default.

--- a/packages/core/tests/gates/catalog/Cooldown.test.ts
+++ b/packages/core/tests/gates/catalog/Cooldown.test.ts
@@ -207,19 +207,7 @@ describe('Cooldown', () => {
         expect(String(peek.mock.calls[0]?.[0])).toContain(expected);
     });
 
-    it('lets two requests racing the same key both pass before either commits', async () => {
-        const rl = new MemoryRateLimiter();
-        const gate = Cooldown(60);
-        const ctxA = cdCtx(rl);
-        const ctxB = cdCtx(rl);
-
-        // both checks run before either commit charges, the charge-in-commit trade-off admits both
-        await expect(Promise.all([runGates([gate], ctxA), runGates([gate], ctxB)])).resolves.toBeDefined();
-
-        await expect(runGates([gate], cdCtx(rl))).rejects.toBeInstanceOf(OnCooldown);
-    });
-
-    // flips when the limiter gains an atomic reserve, the peek/charge split admits both rn
+    // flips when the limiter gets an atomic reserve, the peek/charge split admits both rn
     it.fails('admits exactly one of two requests racing the same key', async () => {
         const rl = new MemoryRateLimiter();
         const gate = Cooldown(60);

--- a/packages/gateway/src/Seedcord.ts
+++ b/packages/gateway/src/Seedcord.ts
@@ -81,7 +81,7 @@ export class Seedcord extends Pluggable implements Core {
         this.hmrManager.init();
         this.bus = new Bus(this);
         this.bot = new Bot(this);
-        this.rateLimiter = new MemoryRateLimiter();
+        this.rateLimiter = config.store ?? new MemoryRateLimiter();
         this.healthCheck = new HealthCheck(this.shutdown, config.healthCheck);
 
         this.registerStartupTasks();

--- a/packages/gateway/tests/store.test.ts
+++ b/packages/gateway/tests/store.test.ts
@@ -1,0 +1,27 @@
+import { MemoryRateLimiter } from '@seedcord/rate-limiter';
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { Seedcord } from '@src/Seedcord';
+
+import { testConfig } from './utils/test-config';
+
+import './utils/mock-client';
+import './utils/mock-env';
+
+describe('config.store', () => {
+    beforeEach(() => {
+        // @ts-expect-error reset the Seedcord singleton between tests
+        Seedcord.reset();
+    });
+
+    it('backs core.rateLimiter with the provided store', () => {
+        const store = new MemoryRateLimiter();
+        const bot = new Seedcord({ ...testConfig(), store });
+        expect(bot.rateLimiter).toBe(store);
+    });
+
+    it('falls back to an in-memory store when none is given', () => {
+        const bot = new Seedcord(testConfig());
+        expect(bot.rateLimiter).toBeInstanceOf(MemoryRateLimiter);
+    });
+});

--- a/packages/rate-limiter/src/MemoryRateLimiter.ts
+++ b/packages/rate-limiter/src/MemoryRateLimiter.ts
@@ -1,4 +1,5 @@
-import type { EpochMs, IRateLimiter, RateLimitResult, RateLimitWindow } from '@seedcord/types';
+import type { EpochMs, RateLimitResult, RateLimitWindow } from '@seedcord/types';
+import type { Store, StoreKind } from '@seedcord/types/internal';
 
 const SWEEP_GAP_MS = 60_000;
 
@@ -19,7 +20,12 @@ function openResult(remaining: number): RateLimitResult {
  * Each key holds its live uses' expiry times. State is per-process and lost on restart. Expired keys
  * are dropped on the first access at least a minute after the previous sweep.
  */
-export class MemoryRateLimiter implements IRateLimiter {
+export class MemoryRateLimiter implements Store<'charge'> {
+    /** @internal */
+    public readonly kind: StoreKind = 'memory';
+    /** @internal */
+    public readonly caps: ReadonlySet<'charge'> = new Set(['charge']);
+
     private readonly map = new Map<string, number[]>();
     private lastSweep = Date.now();
 

--- a/packages/rate-limiter/tests/memory-rate-limiter.test.ts
+++ b/packages/rate-limiter/tests/memory-rate-limiter.test.ts
@@ -12,6 +12,12 @@ describe('MemoryRateLimiter', () => {
         expectTypeOf(new MemoryRateLimiter()).toExtend<IRateLimiter>();
     });
 
+    it('has kind memory and the charge cap', () => {
+        const limiter = new MemoryRateLimiter();
+        expect(limiter.kind).toBe('memory');
+        expect(limiter.caps.has('charge')).toBe(true);
+    });
+
     it('reports not limited on the first charge of a fresh key', async () => {
         const limiter = new MemoryRateLimiter();
 

--- a/packages/types/src/Interfaces/Config.ts
+++ b/packages/types/src/Interfaces/Config.ts
@@ -1,6 +1,7 @@
 import type { CustomIdMatcher } from './CustomId';
 import type { EmojiConfig } from './EmojiMap';
 import type { ErrorsConfig } from './Errors';
+import type { Store } from './Store';
 import type { BotColor } from '../Types/Colors';
 
 // interactions, commands, services, bus subscribers
@@ -154,4 +155,10 @@ export interface Config {
      * User ids the `OwnerOnly` gate treats as bot owners.
      */
     ownerIds?: string[];
+
+    /**
+     * The in-memory default resets on restart and is per-isolate on serverless. Pass a durable store
+     * to keep framework state across restarts and isolates.
+     */
+    store?: Store<'charge'>;
 }

--- a/packages/types/src/Interfaces/Store.ts
+++ b/packages/types/src/Interfaces/Store.ts
@@ -1,0 +1,31 @@
+import type { IRateLimiter } from './RateLimiter';
+import type { EpochMs } from '../Types/Epoch';
+
+export type Capability = 'charge' | 'claim' | 'cas' | 'timer';
+
+export type StoreKind = 'memory' | 'sqlite' | 'd1' | 'turso' | 'durable-object' | 'redis';
+
+interface StoreBase<Caps extends Capability> {
+    readonly kind: StoreKind;
+    readonly caps: ReadonlySet<Caps>;
+}
+
+interface ClaimOps {
+    claim(key: string, ttlMs: number): Promise<boolean>;
+}
+
+interface CasOps {
+    get(key: string): Promise<{ value: string | null; version: number }>;
+    cas(key: string, version: number, value: string | null): Promise<boolean>;
+}
+
+interface TimerOps {
+    timer(key: string, fireAt: EpochMs): Promise<void>;
+}
+
+// each cap adds its verbs, so timer on a Store<'charge'> is a compile error for example
+export type Store<Caps extends Capability = never> = StoreBase<Caps> &
+    ('charge' extends Caps ? IRateLimiter : unknown) &
+    ('claim' extends Caps ? ClaimOps : unknown) &
+    ('cas' extends Caps ? CasOps : unknown) &
+    ('timer' extends Caps ? TimerOps : unknown);

--- a/packages/types/src/internal.index.ts
+++ b/packages/types/src/internal.index.ts
@@ -2,3 +2,4 @@ export * from './brand';
 export type * from './Hmr';
 export { wrapHot } from './Hmr';
 export type * from './Interfaces/SeedcordInstance';
+export type * from './Interfaces/Store';


### PR DESCRIPTION
- **config.store:** supply a rate-limiter backend to survive restarts and share across serverless isolates. The in-memory default is unchanged, and `core.rateLimiter` derives from it.
- **Store seam (internal):** `Store<Caps>` in `@seedcord/types/internal` is the capability-gated contract for the framework's atomic state. v1 wires only `charge` (the rate limiter), `claim`/`cas`/`timer` are reserved for later features. `kind` and `caps` are typed to the declared capabilities, so a backend advertising a cap it did not declare is a compile error.
- **MemoryRateLimiter** implements `Store<'charge'>` with `@internal` `kind`/`caps`.
- **Cooldown test:** dropped the redundant race test, kept the `it.fails` tripwire for the future atomic reserve.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a durable store for rate limiting, with a default in-memory fallback.
  * Expanded public store types to describe supported backends and capabilities.

* **Bug Fixes**
  * Improved concurrent rate-limit handling so racing requests no longer both pass.

* **Tests**
  * Added coverage for custom store selection, default behavior, and in-memory store capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->