### PR TITLE
feat: decouple default subscribers from djs, redesign WebhookLog

### DIFF
--- a/.changeset/decorator-rules-origin-matching.md
+++ b/.changeset/decorator-rules-origin-matching.md
@@ -1,0 +1,5 @@
+---
+'@seedcord/eslint-plugin': minor
+---
+
+The decorator rules `event-handler-missing-register-event`, `middleware-missing-register-decorator`, `command-builder-missing-register-command`, and `interaction-handler-missing-route` match decorators by origin, the same way `subscriber-missing-decorators` does. An aliased or relative import counts, and a same-named decorator from another package no longer passes.

--- a/.changeset/errors-webhook-codes.md
+++ b/.changeset/errors-webhook-codes.md
@@ -1,0 +1,5 @@
+---
+'@seedcord/errors': minor
+---
+
+**BREAKING:** `ConfigUnknownExceptionWebhookMissing`, `ConfigUnknownExceptionWebhookInvalid`, `ConfigHandledExceptionWebhookMissing`, and `ConfigHandledExceptionWebhookInvalid` are removed. `ConfigWebhookUrlInvalid` covers a malformed webhook url for any reporter, `ConfigWebhookNotFound` covers a webhook Discord answers 404 or 401 for at boot, `DecoratorWebhookUrlMissing` covers a `WebhookLog` subclass without `@WebhookUrl`, and `ConfigEmojiUnresolved` renumbers to 1005.

--- a/.changeset/subscriber-missing-decorators-rule.md
+++ b/.changeset/subscriber-missing-decorators-rule.md
@@ -2,4 +2,4 @@
 '@seedcord/eslint-plugin': minor
 ---
 
-New rule `subscriber-missing-decorators`, on in the recommended preset. A concrete `Subscriber` subclass without `@Subscribe` is never registered by the bus, and a `WebhookLog` reporter without `@WebhookUrl` throws at boot.
+New rule `subscriber-missing-decorators`, on in the recommended preset. A concrete `Subscriber` subclass without `@Subscribe` is never registered by the bus, and a `WebhookLog` reporter without `@WebhookUrl` throws at boot. The decorators match by origin, an aliased import counts and a same-named decorator from another package never satisfies the rule.

--- a/.changeset/subscriber-missing-decorators-rule.md
+++ b/.changeset/subscriber-missing-decorators-rule.md
@@ -1,0 +1,5 @@
+---
+'@seedcord/eslint-plugin': minor
+---
+
+New rule `subscriber-missing-decorators`, on in the recommended preset. A concrete `Subscriber` subclass without `@Subscribe` is never registered by the bus, and a `WebhookLog` reporter without `@WebhookUrl` throws at boot.

--- a/.changeset/subscribers-surface-trim.md
+++ b/.changeset/subscribers-surface-trim.md
@@ -1,0 +1,5 @@
+---
+'@seedcord/gateway': minor
+---
+
+**BREAKING:** `AllSubscriptions` is no longer exported. Type a payload with `SubscriptionData<K>` and add keys by augmenting `Subscriptions`.

--- a/.changeset/unknown-exception-scalar-payload.md
+++ b/.changeset/unknown-exception-scalar-payload.md
@@ -1,0 +1,5 @@
+---
+'@seedcord/gateway': minor
+---
+
+**BREAKING:** the `unknownException` payload carries plain `guild` and `user` objects (`{ id, name }` and `{ id, username }`), each key omitted when absent. A subscriber that read other discord.js fields off the payload now fetches them through the client.

--- a/.changeset/utils-timestamp-from-snowflake.md
+++ b/.changeset/utils-timestamp-from-snowflake.md
@@ -1,0 +1,5 @@
+---
+'@seedcord/utils': minor
+---
+
+New `timestampFromSnowflake(snowflake)` returns the epoch milliseconds encoded in a Discord snowflake.

--- a/.changeset/webhook-log-redesign.md
+++ b/.changeset/webhook-log-redesign.md
@@ -1,0 +1,11 @@
+---
+'@seedcord/gateway': minor
+---
+
+`WebhookLog` now runs the webhook ceremony. A reporter declares its url's env var with the new `@WebhookUrl` decorator and implements `report()` returning `{ username?, components, files? }`. The base resolves and validates the url, reuses one sender per url, posts through `@discordjs/rest`, and logs send failures. `username` defaults to the class name.
+
+The webhook urls are optional. An unset var disables that reporter with a boot warning. A set but malformed value throws at boot. `UNKNOWN_EXCEPTION_WEBHOOK_URL` and `HANDLED_EXCEPTION_WEBHOOK_URL` keep their names.
+
+At boot each configured webhook is probed with a GET on the token-bearing webhook route, without a bot token and without sending a message. A webhook that does not exist on Discord stops the boot. An unreachable Discord logs a warning and the boot continues.
+
+**BREAKING:** a `WebhookLog` subclass implements `report()` and carries `@WebhookUrl`. The abstract `webhook` field is removed.

--- a/.changeset/webhook-url-metadata-key.md
+++ b/.changeset/webhook-url-metadata-key.md
@@ -1,0 +1,5 @@
+---
+'@seedcord/core': patch
+---
+
+Adds support for the gateway `@WebhookUrl` decorator.

--- a/knip.json
+++ b/knip.json
@@ -30,26 +30,29 @@
         "packages/eslint-config": {
             "ignoreDependencies": [
                 "@types/eslint-plugin-security",
-                "@typescript-eslint/eslint-plugin",
                 "@typescript-eslint/parser",
                 "eslint-config-prettier",
-                "eslint-import-resolver-typescript",
                 "eslint-plugin-better-tailwindcss",
-                "eslint-plugin-import-x",
                 "eslint-plugin-mdx",
                 "eslint-plugin-prettier",
                 "eslint-plugin-security",
                 "eslint-plugin-tailwind-canonical-classes",
                 "eslint-plugin-tsdoc",
                 "eslint-plugin-unicorn",
-                "lodash.merge",
-                "prettier",
-                "typescript-eslint"
+                "lodash.merge"
             ]
         },
-        "packages/eslint-config-base": {},
-        "packages/eslint-plugin": {},
-        "packages/eslint-plugin-discordjs": {},
+        "packages/eslint-config-base": {
+            "ignoreDependencies": ["@typescript-eslint/parser"]
+        },
+        "packages/eslint-plugin": {
+            "ignore": ["tests/fixtures/**"],
+            "ignoreDependencies": ["discord.js"]
+        },
+        "packages/eslint-plugin-discordjs": {
+            "ignore": ["tests/fixtures/**"],
+            "ignoreDependencies": ["discord.js"]
+        },
         "packages/eslint-utils": {},
         "packages/plugins": {},
         "packages/rate-limiter": {},

--- a/mock/.env.example
+++ b/mock/.env.example
@@ -1,5 +1,5 @@
 # Discord Bot Token from the Dev Dashboard
-BOT_TOKEN=your_bot_token_here
+DISCORD_BOT_TOKEN=your_bot_token_here
 
 # MongoDB URI for connecting to the database
 MONGO_URI=local_mongodb_or_remote_mongodb_uri_here
@@ -7,9 +7,7 @@ DB_NAME=database_name_to_use_in_cluster
 
 # Webhook URL for reporting unknown exceptions
 UNKNOWN_EXCEPTION_WEBHOOK_URL=your_webhook_url_here
+HANDLED_EXCEPTION_WEBHOOK_URL=your_webhook_url_here
 
 # Environment (development, staging, production)
 ENV=development
-
-# Bot color, health-check port/path/host, shutdown toggle, and developer username now live in the
-# Seedcord config: new Seedcord({ botColor, healthCheck, shutdownEnabled, notifications }).

--- a/packages/core/src/internal.index.ts
+++ b/packages/core/src/internal.index.ts
@@ -20,7 +20,8 @@ export {
     InteractionRouteKeys,
     InteractionRoutes,
     MiddlewareMetadataKey,
-    SubscribeMetadataKey
+    SubscribeMetadataKey,
+    WebhookUrlMetadataKey
 } from '@src/metadataKeys';
 
 export { NoticeCard } from '@stops/NoticeCard';

--- a/packages/core/src/metadataKeys.ts
+++ b/packages/core/src/metadataKeys.ts
@@ -37,3 +37,5 @@ export const CommandMetadataKey = Symbol('seedcord:command:metadata');
 export const GatedMetadataKey = Symbol('seedcord:gated:metadata');
 
 export const SubscribeMetadataKey = Symbol('seedcord:subscribe:metadata');
+
+export const WebhookUrlMetadataKey = Symbol('seedcord:webhookUrl:metadata');

--- a/packages/docs-generator/tests/mock/class.ts
+++ b/packages/docs-generator/tests/mock/class.ts
@@ -84,7 +84,7 @@ export class MockClass<TypeT, TypeU extends number> extends BaseClass {
             return param * 2;
         }
         void this.privateMethod(param);
-        return MockClass.privateStaticProp;
+        return MockClass.privateStaticProp; // eslint-disable-line @typescript-eslint/no-deprecated -- deprecated on purpose, the fixture tests deprecation rendering
     }
 
     /**

--- a/packages/docs-generator/tests/mock/index.ts
+++ b/packages/docs-generator/tests/mock/index.ts
@@ -7,8 +7,10 @@
  * @packageDocumentation
  */
 
+// eslint-disable-next-line @typescript-eslint/no-deprecated -- deprecated on purpose, the fixture tests deprecation rendering
 export { BaseClass, MockClass } from './class';
 export { MockEnum } from './enum';
+// eslint-disable-next-line @typescript-eslint/no-deprecated -- deprecated on purpose, the fixture tests deprecation rendering
 export { mockFunction, mockFunctionWithRest, asyncMockFunction, LogDecorator } from './function';
 export type { MockInterface, RecursiveInterface, IndexableInterface, ExtendedInterface } from './interface';
 export type {

--- a/packages/errors/src/ErrorCodes.ts
+++ b/packages/errors/src/ErrorCodes.ts
@@ -8,16 +8,12 @@ export enum SeedcordErrorCode {
     ConfigMissingDiscordToken = 1001,
     /** DISCORD_BOT_TOKEN is present but fails validation. */
     ConfigIncorrectDiscordToken = 1004,
-    /** UNKNOWN_EXCEPTION_WEBHOOK_URL is missing when configuring the reporter. */
-    ConfigUnknownExceptionWebhookMissing = 1002,
-    /** UNKNOWN_EXCEPTION_WEBHOOK_URL is present but fails URL validation. */
-    ConfigUnknownExceptionWebhookInvalid = 1003,
-    /** HANDLED_EXCEPTION_WEBHOOK_URL is missing when configuring the reporter. */
-    ConfigHandledExceptionWebhookMissing = 1005,
-    /** HANDLED_EXCEPTION_WEBHOOK_URL is present but fails URL validation. */
-    ConfigHandledExceptionWebhookInvalid = 1006,
     /** One or more configured emojis could not be resolved at startup. */
-    ConfigEmojiUnresolved = 1007,
+    ConfigEmojiUnresolved = 1005,
+    /** A webhook reporter's env var is set but fails webhook URL validation. */
+    ConfigWebhookUrlInvalid = 1006,
+    /** A configured webhook does not exist on Discord (deleted, or a wrong id or token). */
+    ConfigWebhookNotFound = 1007,
 
     /** Attempted to add lifecycle tasks after startup already completed. */
     LifecycleAddAfterCompletion = 1101,
@@ -55,6 +51,8 @@ export enum SeedcordErrorCode {
     DecoratorCommandGuildWithoutGuilds = 1305,
     /** Middleware priority provided by the decorator was not a finite number. */
     DecoratorInvalidMiddlewarePriority = 1306,
+    /** A WebhookLog subclass is missing its `@WebhookUrl` decorator. */
+    DecoratorWebhookUrlMissing = 1307,
 
     /** Two interaction handlers registered the same route within a scope. */
     InteractionDuplicateRoute = 1401,

--- a/packages/errors/src/ErrorMessages.ts
+++ b/packages/errors/src/ErrorMessages.ts
@@ -4,12 +4,10 @@ import { SeedcordErrorCode } from './ErrorCodes';
 const messages = {
     [SeedcordErrorCode.ConfigMissingDiscordToken]: () => 'Missing DISCORD_BOT_TOKEN environment variable.',
     [SeedcordErrorCode.ConfigIncorrectDiscordToken]: () => 'Invalid DISCORD_BOT_TOKEN value.',
-    [SeedcordErrorCode.ConfigUnknownExceptionWebhookMissing]: () =>
-        'Missing UNKNOWN_EXCEPTION_WEBHOOK_URL environment variable.',
-    [SeedcordErrorCode.ConfigUnknownExceptionWebhookInvalid]: () => 'Invalid UNKNOWN_EXCEPTION_WEBHOOK_URL value.',
-    [SeedcordErrorCode.ConfigHandledExceptionWebhookMissing]: () =>
-        'Missing HANDLED_EXCEPTION_WEBHOOK_URL environment variable.',
-    [SeedcordErrorCode.ConfigHandledExceptionWebhookInvalid]: () => 'Invalid HANDLED_EXCEPTION_WEBHOOK_URL value.',
+    [SeedcordErrorCode.ConfigWebhookUrlInvalid]: (envKey: string) =>
+        `${envKey} is not a well-formed Discord webhook url.`,
+    [SeedcordErrorCode.ConfigWebhookNotFound]: (envKey: string) =>
+        `The webhook behind ${envKey} does not exist on Discord.`,
     [SeedcordErrorCode.ConfigEmojiUnresolved]: (count: number, failures: string) =>
         `Could not resolve ${count} configured emoji${count === 1 ? '' : 's'} at startup.\n${failures}`,
 
@@ -46,6 +44,8 @@ const messages = {
     [SeedcordErrorCode.DecoratorCommandGuildWithoutGuilds]: () =>
         'RegisterCommand("guild") requires a non-empty guilds array.',
     [SeedcordErrorCode.DecoratorInvalidMiddlewarePriority]: () => 'Middleware priority must be a finite number.',
+    [SeedcordErrorCode.DecoratorWebhookUrlMissing]: (className: string) =>
+        `${className} extends WebhookLog and needs a @WebhookUrl decorator naming its env var.`,
 
     [SeedcordErrorCode.InteractionDuplicateRoute]: (route: string, firstClass: string, secondClass: string) =>
         `Two interaction handlers resolve to the same route \`${route}\`. Registered by ${firstClass} and ${secondClass}. Rename one.`,

--- a/packages/eslint-plugin-discordjs/tests/typed-rule-tester.ts
+++ b/packages/eslint-plugin-discordjs/tests/typed-rule-tester.ts
@@ -8,11 +8,6 @@ RuleTester.describe = describe;
 RuleTester.it = it;
 RuleTester.itOnly = it.only;
 
-// a plain RuleTester (no type information) for the AST-only rules
-export function createRuleTester(): RuleTester {
-    return new RuleTester();
-}
-
 export function createTypedRuleTester(): RuleTester {
     return new RuleTester({
         languageOptions: {

--- a/packages/eslint-plugin/docs/rules/command-builder-missing-register-command.md
+++ b/packages/eslint-plugin/docs/rules/command-builder-missing-register-command.md
@@ -6,6 +6,8 @@ A class that extends `BuilderComponent<'command'>` or `BuilderComponent<'context
 
 Only the `'command'` and `'context_menu'` literal type arguments are targeted. Nested `'group'` and `'subcommand'` builders, other component types, a non-literal type argument, and `abstract` bases are all skipped, and the base must come from `seedcord` or a `@seedcord/*` package.
 
+The decorator matches by origin. A seedcord, relative, or tsconfig-alias import counts, an aliased name counts, and a same-named decorator from another package never does.
+
 ## Incorrect
 
 ```ts
@@ -17,7 +19,7 @@ export class PingCommand extends BuilderComponent<'command'> {}
 ## Correct
 
 ```ts
-import { BuilderComponent } from '@seedcord/core';
+import { BuilderComponent, RegisterCommand } from '@seedcord/core';
 
 @RegisterCommand('global')
 export class PingCommand extends BuilderComponent<'command'> {}

--- a/packages/eslint-plugin/docs/rules/event-handler-missing-register-event.md
+++ b/packages/eslint-plugin/docs/rules/event-handler-missing-register-event.md
@@ -6,6 +6,8 @@ A class that extends `EventHandler` registers only when it carries `@RegisterEve
 
 The base class must be imported from `seedcord` or a `@seedcord/*` package, and an `abstract` intermediate base is skipped.
 
+The decorator matches by origin. A seedcord, relative, or tsconfig-alias import counts, an aliased name counts, and a same-named decorator from another package never does.
+
 ## Incorrect
 
 ```ts
@@ -17,7 +19,7 @@ export class PingPong extends EventHandler<Events.MessageCreate> {}
 ## Correct
 
 ```ts
-import { EventHandler } from 'seedcord';
+import { EventHandler, RegisterEvent } from 'seedcord';
 
 @RegisterEvent([Events.MessageCreate])
 export class PingPong extends EventHandler<Events.MessageCreate> {}

--- a/packages/eslint-plugin/docs/rules/interaction-handler-missing-route.md
+++ b/packages/eslint-plugin/docs/rules/interaction-handler-missing-route.md
@@ -6,6 +6,8 @@ A class that extends `SlashHandler`, `ButtonHandler`, `ModalHandler`, `SelectMen
 
 The base class must be imported from `seedcord` or a `@seedcord/*` package. A same-named class from another module is not flagged, and an `abstract` intermediate base is skipped.
 
+The route decorators match by origin. A seedcord, relative, or tsconfig-alias import counts, an aliased name counts, and a same-named decorator from another package never does.
+
 ## Incorrect
 
 ```ts
@@ -19,7 +21,7 @@ export class BanHandler extends SlashHandler<'ban'> {
 ## Correct
 
 ```ts
-import { SlashHandler } from 'seedcord';
+import { SlashHandler, SlashRoute } from 'seedcord';
 
 @SlashRoute('ban')
 export class BanHandler extends SlashHandler<'ban'> {

--- a/packages/eslint-plugin/docs/rules/middleware-missing-register-decorator.md
+++ b/packages/eslint-plugin/docs/rules/middleware-missing-register-decorator.md
@@ -6,6 +6,8 @@ A class that extends `InteractionMiddleware` or `EventMiddleware` registers only
 
 The base class must be imported from `seedcord` or a `@seedcord/*` package, and an `abstract` intermediate base is skipped.
 
+The decorator matches by origin. A seedcord, relative, or tsconfig-alias import counts, an aliased name counts, and a same-named decorator from another package never does.
+
 ## Incorrect
 
 ```ts
@@ -17,7 +19,7 @@ export class LogMiddleware extends EventMiddleware {}
 ## Correct
 
 ```ts
-import { EventMiddleware } from 'seedcord';
+import { EventMiddleware, Middleware } from 'seedcord';
 
 @Middleware(MiddlewareType.Event, 0)
 export class LogMiddleware extends EventMiddleware {}

--- a/packages/eslint-plugin/docs/rules/subscriber-missing-decorators.md
+++ b/packages/eslint-plugin/docs/rules/subscriber-missing-decorators.md
@@ -6,6 +6,8 @@ A class that extends `Subscriber` registers only when it carries `@Subscribe`, a
 
 The base class must be imported from `seedcord` or a `@seedcord/*` package, and an `abstract` intermediate base is skipped.
 
+The decorators match by origin. A seedcord, relative, or tsconfig-alias import counts, an aliased name counts, and a same-named decorator from another package never does.
+
 ## Incorrect
 
 ```ts

--- a/packages/eslint-plugin/docs/rules/subscriber-missing-decorators.md
+++ b/packages/eslint-plugin/docs/rules/subscriber-missing-decorators.md
@@ -1,0 +1,26 @@
+# subscriber-missing-decorators
+
+Require `@Subscribe` on every concrete subscriber and `@WebhookUrl` on every webhook reporter.
+
+A class that extends `Subscriber` registers only when it carries `@Subscribe`, and the bus never runs an undecorated one. A class that extends `WebhookLog` additionally needs `@WebhookUrl` naming its url env var, and registration throws at boot without it.
+
+The base class must be imported from `seedcord` or a `@seedcord/*` package, and an `abstract` intermediate base is skipped.
+
+## Incorrect
+
+```ts
+import { WebhookLog, Subscribe } from 'seedcord';
+
+@Subscribe('memberBanned')
+export class BanLog extends WebhookLog<'memberBanned'> {}
+```
+
+## Correct
+
+```ts
+import { WebhookLog, Subscribe, WebhookUrl } from 'seedcord';
+
+@Subscribe('memberBanned')
+@WebhookUrl('BAN_LOG_WEBHOOK_URL')
+export class BanLog extends WebhookLog<'memberBanned'> {}
+```

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -6,6 +6,7 @@ import interactionHandlerMissingRoute from './rules/interaction-handler-missing-
 import middlewareMissingRegisterDecorator from './rules/middleware-missing-register-decorator';
 import noDjsBuilderImport from './rules/no-djs-builder-import';
 import noRawClientEvents from './rules/no-raw-client-events';
+import subscriberMissingDecorators from './rules/subscriber-missing-decorators';
 import useCustomIdCodec from './rules/use-custom-id-codec';
 
 import type { TSESLint } from '@typescript-eslint/utils';
@@ -17,6 +18,7 @@ const rules = {
     'middleware-missing-register-decorator': middlewareMissingRegisterDecorator,
     'no-djs-builder-import': noDjsBuilderImport,
     'no-raw-client-events': noRawClientEvents,
+    'subscriber-missing-decorators': subscriberMissingDecorators,
     'use-custom-id-codec': useCustomIdCodec
 } satisfies Record<string, TSESLint.RuleModule<string, readonly unknown[]>>;
 

--- a/packages/eslint-plugin/src/rules/command-builder-missing-register-command.ts
+++ b/packages/eslint-plugin/src/rules/command-builder-missing-register-command.ts
@@ -1,8 +1,8 @@
 import {
     classInstanceType,
+    createDecoratorMatcher,
     extendsSeedcordType,
-    forEachSeedcordImport,
-    hasDecoratorNamed
+    forEachSeedcordImport
 } from '@seedcord/eslint-utils';
 import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
 
@@ -18,7 +18,7 @@ const KIND_LABEL = {
 
 type CommandKind = keyof typeof KIND_LABEL;
 
-const REGISTER_COMMAND = new Set(['RegisterCommand']);
+const REGISTER_COMMAND = 'RegisterCommand';
 const BUILDER_COMPONENT = 'BuilderComponent';
 
 function isCommandKind(value: string): value is CommandKind {
@@ -65,12 +65,14 @@ export default createRule({
         const checker = services.program.getTypeChecker();
         const builderComponentNames = new Set<string>();
         const intermediateKinds = new Map<string, CommandKind>();
+        const decorators = createDecoratorMatcher(services, checker, [REGISTER_COMMAND]);
 
         return {
             ImportDeclaration(node) {
                 forEachSeedcordImport(node, (imported, local) => {
                     if (imported === BUILDER_COMPONENT) builderComponentNames.add(local);
                 });
+                decorators.collectImports(node);
             },
             ClassDeclaration(node) {
                 if (node.superClass?.type !== AST_NODE_TYPES.Identifier) return;
@@ -89,7 +91,7 @@ export default createRule({
                     if (node.id) intermediateKinds.set(node.id.name, kind);
                     return;
                 }
-                if (hasDecoratorNamed(node, REGISTER_COMMAND)) return;
+                if (decorators.hasDecorator(node, REGISTER_COMMAND)) return;
 
                 context.report({
                     node: node.id ?? node,

--- a/packages/eslint-plugin/src/rules/event-handler-missing-register-event.ts
+++ b/packages/eslint-plugin/src/rules/event-handler-missing-register-event.ts
@@ -1,14 +1,14 @@
 import {
     classInstanceType,
+    createDecoratorMatcher,
     extendsSeedcordType,
-    forEachSeedcordImport,
-    hasDecoratorNamed
+    forEachSeedcordImport
 } from '@seedcord/eslint-utils';
 import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
 
 import { createRule } from '../createRule';
 
-const REGISTER_EVENT = new Set(['RegisterEvent']);
+const REGISTER_EVENT = 'RegisterEvent';
 const EVENT_HANDLER = 'EventHandler';
 
 export default createRule({
@@ -29,12 +29,14 @@ export default createRule({
         const services = ESLintUtils.getParserServices(context);
         const checker = services.program.getTypeChecker();
         const bases = new Set<string>();
+        const decorators = createDecoratorMatcher(services, checker, [REGISTER_EVENT]);
 
         return {
             ImportDeclaration(node) {
                 forEachSeedcordImport(node, (imported, local) => {
                     if (imported === EVENT_HANDLER) bases.add(local);
                 });
+                decorators.collectImports(node);
             },
             ClassDeclaration(node) {
                 if (node.superClass?.type !== AST_NODE_TYPES.Identifier) return;
@@ -50,7 +52,7 @@ export default createRule({
                     if (node.id) bases.add(node.id.name);
                     return;
                 }
-                if (hasDecoratorNamed(node, REGISTER_EVENT)) return;
+                if (decorators.hasDecorator(node, REGISTER_EVENT)) return;
 
                 context.report({ node: node.id ?? node, messageId: 'missingRegister' });
             }

--- a/packages/eslint-plugin/src/rules/interaction-handler-missing-route.ts
+++ b/packages/eslint-plugin/src/rules/interaction-handler-missing-route.ts
@@ -1,8 +1,8 @@
 import {
     classInstanceType,
+    createDecoratorMatcher,
     extendsSeedcordType,
-    forEachSeedcordImport,
-    hasDecoratorNamed
+    forEachSeedcordImport
 } from '@seedcord/eslint-utils';
 import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
 
@@ -43,12 +43,14 @@ export default createRule({
         const services = ESLintUtils.getParserServices(context);
         const checker = services.program.getTypeChecker();
         const bases = new Map<string, HandlerBase>();
+        const decorators = createDecoratorMatcher(services, checker, Object.values(BASE_TO_DECORATOR));
 
         return {
             ImportDeclaration(node) {
                 forEachSeedcordImport(node, (imported, local) => {
                     if (isHandlerBase(imported)) bases.set(local, imported);
                 });
+                decorators.collectImports(node);
             },
             ClassDeclaration(node) {
                 if (node.superClass?.type !== AST_NODE_TYPES.Identifier) return;
@@ -67,7 +69,7 @@ export default createRule({
                     return;
                 }
                 // only the decorator matching this handler's base registers it. a wrong-type route still fails
-                if (hasDecoratorNamed(node, new Set([BASE_TO_DECORATOR[base]]))) return;
+                if (decorators.hasDecorator(node, BASE_TO_DECORATOR[base])) return;
 
                 context.report({
                     node: node.id ?? node,

--- a/packages/eslint-plugin/src/rules/middleware-missing-register-decorator.ts
+++ b/packages/eslint-plugin/src/rules/middleware-missing-register-decorator.ts
@@ -1,15 +1,15 @@
 import {
     classInstanceType,
+    createDecoratorMatcher,
     extendsSeedcordType,
-    forEachSeedcordImport,
-    hasDecoratorNamed
+    forEachSeedcordImport
 } from '@seedcord/eslint-utils';
 import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
 
 import { createRule } from '../createRule';
 
 const MIDDLEWARE_BASES = new Set(['InteractionMiddleware', 'EventMiddleware']);
-const MIDDLEWARE_DECORATOR = new Set(['Middleware']);
+const MIDDLEWARE_DECORATOR = 'Middleware';
 
 export default createRule({
     name: 'middleware-missing-register-decorator',
@@ -28,12 +28,14 @@ export default createRule({
         const services = ESLintUtils.getParserServices(context);
         const checker = services.program.getTypeChecker();
         const bases = new Set<string>();
+        const decorators = createDecoratorMatcher(services, checker, [MIDDLEWARE_DECORATOR]);
 
         return {
             ImportDeclaration(node) {
                 forEachSeedcordImport(node, (imported, local) => {
                     if (MIDDLEWARE_BASES.has(imported)) bases.add(local);
                 });
+                decorators.collectImports(node);
             },
             ClassDeclaration(node) {
                 if (node.superClass?.type !== AST_NODE_TYPES.Identifier) return;
@@ -49,7 +51,7 @@ export default createRule({
                     if (node.id) bases.add(node.id.name);
                     return;
                 }
-                if (hasDecoratorNamed(node, MIDDLEWARE_DECORATOR)) return;
+                if (decorators.hasDecorator(node, MIDDLEWARE_DECORATOR)) return;
 
                 context.report({ node: node.id ?? node, messageId: 'missingMiddleware' });
             }

--- a/packages/eslint-plugin/src/rules/subscriber-missing-decorators.ts
+++ b/packages/eslint-plugin/src/rules/subscriber-missing-decorators.ts
@@ -1,0 +1,93 @@
+import {
+    classInstanceType,
+    extendsSeedcordType,
+    forEachSeedcordImport,
+    hasDecoratorNamed
+} from '@seedcord/eslint-utils';
+import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
+
+import { createRule } from '../createRule';
+
+import type { TSESTree } from '@typescript-eslint/utils';
+
+const SUBSCRIBE = new Set(['Subscribe']);
+const WEBHOOK_URL = new Set(['WebhookUrl']);
+const SUBSCRIBER = 'Subscriber';
+const WEBHOOK_LOG = 'WebhookLog';
+
+interface Kind {
+    isSubscriber: boolean;
+    isWebhook: boolean;
+}
+
+export default createRule({
+    name: 'subscriber-missing-decorators',
+    meta: {
+        type: 'problem',
+        docs: {
+            description: 'Require @Subscribe on every concrete subscriber and @WebhookUrl on every webhook reporter.'
+        },
+        messages: {
+            missingSubscribe: 'This subscriber has no @Subscribe decorator, so the bus never registers it.',
+            missingWebhookUrl:
+                'This WebhookLog has no @WebhookUrl decorator naming its url env var, so registration throws at boot.'
+        },
+        schema: []
+    },
+    defaultOptions: [],
+    create(context) {
+        const services = ESLintUtils.getParserServices(context);
+        const checker = services.program.getTypeChecker();
+        const subscriberBases = new Set<string>();
+        const webhookBases = new Set<string>();
+
+        function classify(node: TSESTree.ClassDeclaration, superName: string): Kind {
+            // every webhook base is also a subscriber base
+            if (webhookBases.has(superName)) return { isSubscriber: true, isWebhook: true };
+            let isSubscriber = subscriberBases.has(superName);
+            let isWebhook = false;
+            const classType = classInstanceType(node, services, checker);
+            if (classType) {
+                isSubscriber ||= extendsSeedcordType(checker, classType, SUBSCRIBER);
+                isWebhook = extendsSeedcordType(checker, classType, WEBHOOK_LOG);
+            }
+            return { isSubscriber, isWebhook };
+        }
+
+        // same-file bases, cross-file chains resolve through the type checker
+        function trackAbstractBase(node: TSESTree.ClassDeclaration, kind: Kind): void {
+            if (!node.id) return;
+            subscriberBases.add(node.id.name);
+            if (kind.isWebhook) webhookBases.add(node.id.name);
+        }
+
+        return {
+            ImportDeclaration(node) {
+                forEachSeedcordImport(node, (imported, local) => {
+                    if (imported === SUBSCRIBER) subscriberBases.add(local);
+                    if (imported === WEBHOOK_LOG) {
+                        subscriberBases.add(local);
+                        webhookBases.add(local);
+                    }
+                });
+            },
+            ClassDeclaration(node) {
+                if (node.superClass?.type !== AST_NODE_TYPES.Identifier) return;
+
+                const kind = classify(node, node.superClass.name);
+                if (!kind.isSubscriber && !kind.isWebhook) return;
+                if (node.abstract) {
+                    trackAbstractBase(node, kind);
+                    return;
+                }
+
+                if (!hasDecoratorNamed(node, SUBSCRIBE)) {
+                    context.report({ node: node.id ?? node, messageId: 'missingSubscribe' });
+                }
+                if (kind.isWebhook && !hasDecoratorNamed(node, WEBHOOK_URL)) {
+                    context.report({ node: node.id ?? node, messageId: 'missingWebhookUrl' });
+                }
+            }
+        };
+    }
+});

--- a/packages/eslint-plugin/src/rules/subscriber-missing-decorators.ts
+++ b/packages/eslint-plugin/src/rules/subscriber-missing-decorators.ts
@@ -1,8 +1,8 @@
 import {
     classInstanceType,
+    createDecoratorMatcher,
     extendsSeedcordType,
-    forEachSeedcordImport,
-    hasDecoratorNamed
+    forEachSeedcordImport
 } from '@seedcord/eslint-utils';
 import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
 
@@ -10,8 +10,8 @@ import { createRule } from '../createRule';
 
 import type { TSESTree } from '@typescript-eslint/utils';
 
-const SUBSCRIBE = new Set(['Subscribe']);
-const WEBHOOK_URL = new Set(['WebhookUrl']);
+const SUBSCRIBE = 'Subscribe';
+const WEBHOOK_URL = 'WebhookUrl';
 const SUBSCRIBER = 'Subscriber';
 const WEBHOOK_LOG = 'WebhookLog';
 
@@ -40,6 +40,7 @@ export default createRule({
         const checker = services.program.getTypeChecker();
         const subscriberBases = new Set<string>();
         const webhookBases = new Set<string>();
+        const decorators = createDecoratorMatcher(services, checker, [SUBSCRIBE, WEBHOOK_URL]);
 
         function classify(node: TSESTree.ClassDeclaration, superName: string): Kind {
             // every webhook base is also a subscriber base
@@ -70,6 +71,7 @@ export default createRule({
                         webhookBases.add(local);
                     }
                 });
+                decorators.collectImports(node);
             },
             ClassDeclaration(node) {
                 if (node.superClass?.type !== AST_NODE_TYPES.Identifier) return;
@@ -81,10 +83,10 @@ export default createRule({
                     return;
                 }
 
-                if (!hasDecoratorNamed(node, SUBSCRIBE)) {
+                if (!decorators.hasDecorator(node, SUBSCRIBE)) {
                     context.report({ node: node.id ?? node, messageId: 'missingSubscribe' });
                 }
-                if (kind.isWebhook && !hasDecoratorNamed(node, WEBHOOK_URL)) {
+                if (kind.isWebhook && !decorators.hasDecorator(node, WEBHOOK_URL)) {
                     context.report({ node: node.id ?? node, messageId: 'missingWebhookUrl' });
                 }
             }

--- a/packages/eslint-plugin/tests/fixtures/project-bases.ts
+++ b/packages/eslint-plugin/tests/fixtures/project-bases.ts
@@ -19,6 +19,18 @@ export abstract class EventMiddleware {
     public abstract handle(): void;
 }
 
+export abstract class Subscriber<KeyOfSubscribers extends string> {
+    declare public readonly key: KeyOfSubscribers;
+}
+
+export abstract class WebhookLog<KeyOfSubscribers extends string> extends Subscriber<KeyOfSubscribers> {
+    public abstract report(): unknown;
+}
+
+export abstract class BaseSub extends Subscriber<'unknownException'> {}
+
+export abstract class BaseReporter extends WebhookLog<'unknownException'> {}
+
 export abstract class BaseMw extends EventMiddleware {}
 
 export abstract class BaseCommand extends BuilderComponent<'command'> {

--- a/packages/eslint-plugin/tests/rules/command-builder-missing-register-command.test.ts
+++ b/packages/eslint-plugin/tests/rules/command-builder-missing-register-command.test.ts
@@ -9,24 +9,37 @@ ruleTester.run('command-builder-missing-register-command', rule, {
     valid: [
         // registered commands, the real mock shape
         dedent`
-            import { BuilderComponent } from '@seedcord/core';
+            import { BuilderComponent, RegisterCommand } from '@seedcord/core';
             @RegisterCommand('global')
             export class ProbeCommand extends BuilderComponent<'command'> {}
         `,
         dedent`
-            import { BuilderComponent } from '@seedcord/core';
+            import { BuilderComponent, RegisterCommand } from '@seedcord/core';
             @RegisterCommand('global')
             export class ViewProfileCommand extends BuilderComponent<'context_menu'> {}
         `,
         dedent`
-            import { BuilderComponent } from '@seedcord/core';
+            import { BuilderComponent, RegisterCommand } from '@seedcord/core';
             @RegisterCommand('guild', ['123456789'])
             export class AdminCommand extends BuilderComponent<'command'> {}
         `,
         // a bare @RegisterCommand identifier (no parens) still registers
         dedent`
-            import { BuilderComponent } from '@seedcord/core';
+            import { BuilderComponent, RegisterCommand } from '@seedcord/core';
             @RegisterCommand
+            export class ProbeCommand extends BuilderComponent<'command'> {}
+        `,
+        // an aliased decorator import still counts
+        dedent`
+            import { BuilderComponent, RegisterCommand as RC } from '@seedcord/core';
+            @RC('global')
+            export class ProbeCommand extends BuilderComponent<'command'> {}
+        `,
+        // a relative decorator import counts, the framework and user barrels resolve this way
+        dedent`
+            import { BuilderComponent } from '@seedcord/core';
+            import { RegisterCommand } from './decorators/RegisterCommand';
+            @RegisterCommand('global')
             export class ProbeCommand extends BuilderComponent<'command'> {}
         `,
         // non-command builders are not deployable, never flagged
@@ -83,6 +96,16 @@ ruleTester.run('command-builder-missing-register-command', rule, {
             code: dedent`
                 import { BuilderComponent } from '@seedcord/core';
                 @LogUsage()
+                export class ProbeCommand extends BuilderComponent<'command'> {}
+            `,
+            errors: [{ messageId: 'missingRegister', data: { label: 'slash command' } }]
+        },
+        {
+            // a same-named decorator from another module satisfies nothing
+            code: dedent`
+                import { BuilderComponent } from '@seedcord/core';
+                import { RegisterCommand } from 'some-other-lib';
+                @RegisterCommand('global')
                 export class ProbeCommand extends BuilderComponent<'command'> {}
             `,
             errors: [{ messageId: 'missingRegister', data: { label: 'slash command' } }]

--- a/packages/eslint-plugin/tests/rules/event-handler-missing-register-event.test.ts
+++ b/packages/eslint-plugin/tests/rules/event-handler-missing-register-event.test.ts
@@ -9,14 +9,27 @@ ruleTester.run('event-handler-missing-register-event', rule, {
     valid: [
         // decorated event handlers, the real mock shape
         dedent`
-            import { EventHandler } from 'seedcord';
+            import { EventHandler, RegisterEvent } from 'seedcord';
             @RegisterEvent([Events.MessageCreate])
             export class PingPong extends EventHandler<Events.MessageCreate> {}
         `,
         dedent`
-            import { EventHandler } from 'seedcord';
+            import { EventHandler, RegisterEvent } from 'seedcord';
             @RegisterEvent([Events.MessageCreate, { frequency: 'once' }], [Events.MessageUpdate])
             export class PingPong extends EventHandler<Events.MessageCreate | Events.MessageUpdate> {}
+        `,
+        // an aliased decorator import still counts
+        dedent`
+            import { EventHandler, RegisterEvent as RE } from 'seedcord';
+            @RE([Events.MessageCreate])
+            export class PingPong extends EventHandler<Events.MessageCreate> {}
+        `,
+        // a relative decorator import counts, the framework and user barrels resolve this way
+        dedent`
+            import { EventHandler } from 'seedcord';
+            import { RegisterEvent } from './decorators/RegisterEvent';
+            @RegisterEvent([Events.MessageCreate])
+            export class PingPong extends EventHandler<Events.MessageCreate> {}
         `,
         // abstract base is not a concrete handler
         dedent`
@@ -44,6 +57,16 @@ ruleTester.run('event-handler-missing-register-event', rule, {
             code: dedent`
                 import { EventHandler } from 'seedcord';
                 @LogUsage()
+                export class PingPong extends EventHandler<Events.MessageCreate> {}
+            `,
+            errors: [{ messageId: 'missingRegister' }]
+        },
+        {
+            // a same-named decorator from another module satisfies nothing
+            code: dedent`
+                import { EventHandler } from 'seedcord';
+                import { RegisterEvent } from 'some-other-lib';
+                @RegisterEvent([Events.MessageCreate])
                 export class PingPong extends EventHandler<Events.MessageCreate> {}
             `,
             errors: [{ messageId: 'missingRegister' }]

--- a/packages/eslint-plugin/tests/rules/interaction-handler-missing-route.test.ts
+++ b/packages/eslint-plugin/tests/rules/interaction-handler-missing-route.test.ts
@@ -9,34 +9,47 @@ ruleTester.run('interaction-handler-missing-route', rule, {
     valid: [
         // decorated handlers, the real mock shape
         dedent`
-            import { SlashHandler } from 'seedcord';
+            import { SlashHandler, SlashRoute } from 'seedcord';
             @SlashRoute('probe')
             export class Probe extends SlashHandler<'probe'> {
                 async execute() {}
             }
         `,
         dedent`
-            import { ButtonHandler } from 'seedcord';
+            import { ButtonHandler, ButtonRoute } from 'seedcord';
             @ButtonRoute(Board)
             export class Nav extends ButtonHandler<[typeof Board]> {}
         `,
         dedent`
-            import { ContextMenuHandler } from 'seedcord';
+            import { ContextMenuHandler, ContextMenuRoute } from 'seedcord';
             @ContextMenuRoute(ApplicationCommandType.User, 'View Profile')
             export class ViewProfile extends ContextMenuHandler<ApplicationCommandType.User> {}
         `,
         // a route decorator stacked under an unrelated one still counts
         dedent`
-            import { ButtonHandler } from 'seedcord';
+            import { ButtonHandler, ButtonRoute } from 'seedcord';
             @LogUsage()
             @ButtonRoute(Board)
             export class Nav extends ButtonHandler<[typeof Board]> {}
         `,
         // aliased import still resolves to the seedcord base
         dedent`
-            import { SlashHandler as SH } from 'seedcord';
+            import { SlashHandler as SH, SlashRoute } from 'seedcord';
             @SlashRoute('probe')
             export class Probe extends SH<'probe'> {}
+        `,
+        // an aliased route decorator still counts
+        dedent`
+            import { SlashHandler, SlashRoute as SR } from 'seedcord';
+            @SR('probe')
+            export class Probe extends SlashHandler<'probe'> {}
+        `,
+        // a relative decorator import counts, the framework and user barrels resolve this way
+        dedent`
+            import { SlashHandler } from 'seedcord';
+            import { SlashRoute } from './decorators/SlashRoute';
+            @SlashRoute('probe')
+            export class Probe extends SlashHandler<'probe'> {}
         `,
         // abstract intermediate base is not a concrete handler
         dedent`
@@ -50,19 +63,19 @@ ruleTester.run('interaction-handler-missing-route', rule, {
         `,
         // select menu handler with its route
         dedent`
-            import { SelectMenuHandler } from 'seedcord';
+            import { SelectMenuHandler, SelectMenuRoute } from 'seedcord';
             @SelectMenuRoute(Menu)
             export class Picker extends SelectMenuHandler<[typeof Menu]> {}
         `,
         // autocomplete handler with its route
         dedent`
-            import { AutocompleteHandler } from 'seedcord';
+            import { AutocompleteHandler, AutocompleteRoute } from 'seedcord';
             @AutocompleteRoute('search')
             export class Search extends AutocompleteHandler<'search'> {}
         `,
         // modal handler with its route
         dedent`
-            import { ModalHandler } from 'seedcord';
+            import { ModalHandler, ModalRoute } from 'seedcord';
             @ModalRoute(Feedback)
             export class FeedbackModal extends ModalHandler<[typeof Feedback]> {}
         `,
@@ -82,11 +95,21 @@ ruleTester.run('interaction-handler-missing-route', rule, {
         {
             // the wrong route decorator does not register a slash handler
             code: dedent`
-                import { SlashHandler } from 'seedcord';
+                import { SlashHandler, ButtonRoute } from 'seedcord';
                 @ButtonRoute('x')
                 export class Mismatch extends SlashHandler<'ban'> {
                     async execute() {}
                 }
+            `,
+            errors: [{ messageId: 'missingRoute', data: { base: 'SlashHandler', decorator: 'SlashRoute' } }]
+        },
+        {
+            // a same-named route decorator from another module satisfies nothing
+            code: dedent`
+                import { SlashHandler } from 'seedcord';
+                import { SlashRoute } from 'some-other-lib';
+                @SlashRoute('ban')
+                export class BanHandler extends SlashHandler<'ban'> {}
             `,
             errors: [{ messageId: 'missingRoute', data: { base: 'SlashHandler', decorator: 'SlashRoute' } }]
         },

--- a/packages/eslint-plugin/tests/rules/middleware-missing-register-decorator.test.ts
+++ b/packages/eslint-plugin/tests/rules/middleware-missing-register-decorator.test.ts
@@ -9,19 +9,32 @@ ruleTester.run('middleware-missing-register-decorator', rule, {
     valid: [
         // decorated middleware, the real shape
         dedent`
-            import { EventMiddleware } from 'seedcord';
+            import { EventMiddleware, Middleware } from 'seedcord';
             @Middleware(MiddlewareType.Event, 0)
             export class LogMw extends EventMiddleware {}
         `,
         dedent`
-            import { InteractionMiddleware } from 'seedcord';
+            import { InteractionMiddleware, Middleware } from 'seedcord';
             @Middleware(MiddlewareType.Interaction, 0)
             export class AuthMw extends InteractionMiddleware<Repliables> {}
         `,
         dedent`
-            import { EventMiddleware } from 'seedcord';
+            import { EventMiddleware, Middleware } from 'seedcord';
             @Middleware(MiddlewareType.Event, 5, { events: [Events.MessageCreate] })
             export class MsgMw extends EventMiddleware<Events.MessageCreate> {}
+        `,
+        // an aliased decorator import still counts
+        dedent`
+            import { EventMiddleware, Middleware as Mw } from 'seedcord';
+            @Mw(MiddlewareType.Event, 0)
+            export class LogMw extends EventMiddleware {}
+        `,
+        // a relative decorator import counts, the framework and user barrels resolve this way
+        dedent`
+            import { EventMiddleware } from 'seedcord';
+            import { Middleware } from './decorators/Middleware';
+            @Middleware(MiddlewareType.Event, 0)
+            export class LogMw extends EventMiddleware {}
         `,
         // abstract base is not a concrete middleware
         dedent`
@@ -57,6 +70,16 @@ ruleTester.run('middleware-missing-register-decorator', rule, {
                 import { EventMiddleware } from 'seedcord';
                 @LogUsage()
                 export class LogMw extends EventMiddleware<Events.MessageCreate> {}
+            `,
+            errors: [{ messageId: 'missingMiddleware' }]
+        },
+        {
+            // a same-named decorator from another module satisfies nothing
+            code: dedent`
+                import { EventMiddleware } from 'seedcord';
+                import { Middleware } from 'some-other-lib';
+                @Middleware(MiddlewareType.Event, 0)
+                export class LogMw extends EventMiddleware {}
             `,
             errors: [{ messageId: 'missingMiddleware' }]
         },

--- a/packages/eslint-plugin/tests/rules/subscriber-missing-decorators.test.ts
+++ b/packages/eslint-plugin/tests/rules/subscriber-missing-decorators.test.ts
@@ -12,6 +12,19 @@ ruleTester.run('subscriber-missing-decorators', rule, {
             @Subscribe('unknownException')
             export class LogSub extends Subscriber<'unknownException'> {}
         `,
+        // an aliased decorator import still counts
+        dedent`
+            import { Subscriber, Subscribe as Sub } from 'seedcord';
+            @Sub('unknownException')
+            export class LogSub extends Subscriber<'unknownException'> {}
+        `,
+        // a relative decorator import counts, the framework and user barrels resolve this way
+        dedent`
+            import { Subscriber } from 'seedcord';
+            import { Subscribe } from './decorators/Subscribe';
+            @Subscribe('unknownException')
+            export class LogSub extends Subscriber<'unknownException'> {}
+        `,
         dedent`
             import { WebhookLog, Subscribe, WebhookUrl } from 'seedcord';
             @Subscribe('memberBanned')
@@ -61,6 +74,27 @@ ruleTester.run('subscriber-missing-decorators', rule, {
             errors: [{ messageId: 'missingSubscribe' }]
         },
         {
+            // a same-named decorator from another module satisfies nothing
+            code: dedent`
+                import { Subscriber } from 'seedcord';
+                import { Subscribe } from 'some-other-lib';
+                @Subscribe('unknownException')
+                export class LogSub extends Subscriber<'unknownException'> {}
+            `,
+            errors: [{ messageId: 'missingSubscribe' }]
+        },
+        {
+            // both decorators from another module, both reports fire
+            code: dedent`
+                import { WebhookLog } from 'seedcord';
+                import { Subscribe, WebhookUrl } from 'some-other-lib';
+                @Subscribe('memberBanned')
+                @WebhookUrl('BAN_LOG_WEBHOOK_URL')
+                export class BanLog extends WebhookLog<'memberBanned'> {}
+            `,
+            errors: [{ messageId: 'missingSubscribe' }, { messageId: 'missingWebhookUrl' }]
+        },
+        {
             // a concrete subclass of a same-file abstract subscriber base
             code: dedent`
                 import { Subscriber } from 'seedcord';
@@ -72,6 +106,7 @@ ruleTester.run('subscriber-missing-decorators', rule, {
         {
             // a concrete subclass of a cross-file abstract reporter base
             code: dedent`
+                import { Subscribe } from 'seedcord';
                 import { BaseReporter } from './project-bases';
                 @Subscribe('unknownException')
                 export class BanLog extends BaseReporter {}

--- a/packages/eslint-plugin/tests/rules/subscriber-missing-decorators.test.ts
+++ b/packages/eslint-plugin/tests/rules/subscriber-missing-decorators.test.ts
@@ -1,0 +1,106 @@
+import dedent from 'dedent';
+
+import rule from '../../src/rules/subscriber-missing-decorators';
+import { createTypedRuleTester } from '../typed-rule-tester';
+
+const ruleTester = createTypedRuleTester();
+
+ruleTester.run('subscriber-missing-decorators', rule, {
+    valid: [
+        dedent`
+            import { Subscriber, Subscribe } from 'seedcord';
+            @Subscribe('unknownException')
+            export class LogSub extends Subscriber<'unknownException'> {}
+        `,
+        dedent`
+            import { WebhookLog, Subscribe, WebhookUrl } from 'seedcord';
+            @Subscribe('memberBanned')
+            @WebhookUrl('BAN_LOG_WEBHOOK_URL')
+            export class BanLog extends WebhookLog<'memberBanned'> {}
+        `,
+        // abstract intermediates only seed the base set
+        dedent`
+            import { WebhookLog } from 'seedcord';
+            export abstract class BaseLog extends WebhookLog<'memberBanned'> {}
+        `,
+        dedent`
+            import { Subscriber, Subscribe } from 'seedcord';
+            abstract class BaseSub extends Subscriber<'unknownException'> {}
+            @Subscribe('unknownException')
+            export class LogSub extends BaseSub {}
+        `,
+        // a same-named base from a non-seedcord module
+        dedent`
+            import { Subscriber } from './local';
+            export class Foo extends Subscriber {}
+        `,
+        `export class Plain {}`
+    ],
+    invalid: [
+        {
+            code: dedent`
+                import { Subscriber } from 'seedcord';
+                export class LogSub extends Subscriber<'unknownException'> {}
+            `,
+            errors: [{ messageId: 'missingSubscribe' }]
+        },
+        {
+            code: dedent`
+                import { WebhookLog, Subscribe } from 'seedcord';
+                @Subscribe('memberBanned')
+                export class BanLog extends WebhookLog<'memberBanned'> {}
+            `,
+            errors: [{ messageId: 'missingWebhookUrl' }]
+        },
+        {
+            // aliased seedcord import
+            code: dedent`
+                import { Subscriber as Sub } from '@seedcord/core';
+                export class Foo extends Sub<'unknownException'> {}
+            `,
+            errors: [{ messageId: 'missingSubscribe' }]
+        },
+        {
+            // a concrete subclass of a same-file abstract subscriber base
+            code: dedent`
+                import { Subscriber } from 'seedcord';
+                abstract class BaseSub extends Subscriber<'unknownException'> {}
+                export class LogSub extends BaseSub {}
+            `,
+            errors: [{ messageId: 'missingSubscribe' }]
+        },
+        {
+            // a concrete subclass of a cross-file abstract reporter base
+            code: dedent`
+                import { BaseReporter } from './project-bases';
+                @Subscribe('unknownException')
+                export class BanLog extends BaseReporter {}
+            `,
+            errors: [{ messageId: 'missingWebhookUrl' }]
+        },
+        {
+            // an anonymous default export is still a concrete subscriber
+            code: dedent`
+                import { BaseSub } from './project-bases';
+                export default class extends BaseSub {}
+            `,
+            errors: [{ messageId: 'missingSubscribe' }]
+        },
+        {
+            code: dedent`
+                import { WebhookLog } from 'seedcord';
+                export class BanLog extends WebhookLog<'memberBanned'> {}
+            `,
+            errors: [{ messageId: 'missingSubscribe' }, { messageId: 'missingWebhookUrl' }]
+        },
+        {
+            code: dedent`
+                import { WebhookLog, Subscribe } from 'seedcord';
+                export abstract class BaseLog extends WebhookLog<'memberBanned'> {}
+                @Subscribe('memberBanned')
+                export class BanLog extends BaseLog {}
+            `,
+            errors: [{ messageId: 'missingWebhookUrl' }]
+        }
+    ]
+});

--- a/packages/eslint-utils/src/typeUtils.ts
+++ b/packages/eslint-utils/src/typeUtils.ts
@@ -1,10 +1,72 @@
 import { AST_NODE_TYPES } from '@typescript-eslint/utils';
-import { TypeFlags } from 'typescript';
+import { SymbolFlags, TypeFlags } from 'typescript';
 
 import { constructorData, unwrapAssertions } from './utils';
 
 import type { ParserServicesWithTypeInformation, TSESTree } from '@typescript-eslint/utils';
 import type * as ts from 'typescript';
+
+function decoratorIdentifier(decorator: TSESTree.Decorator): TSESTree.Identifier | undefined {
+    const expr = decorator.expression;
+    if (expr.type === AST_NODE_TYPES.CallExpression && expr.callee.type === AST_NODE_TYPES.Identifier) {
+        return expr.callee;
+    }
+    if (expr.type === AST_NODE_TYPES.Identifier) return expr;
+    return undefined;
+}
+
+// matches class decorators to seedcord decorator names by import origin
+export interface DecoratorMatcher {
+    collectImports(node: TSESTree.ImportDeclaration): void;
+    hasDecorator(node: TSESTree.ClassDeclaration, originalName: string): boolean;
+}
+
+export function createDecoratorMatcher(
+    services: ParserServicesWithTypeInformation,
+    checker: ts.TypeChecker,
+    originalNames: readonly string[]
+): DecoratorMatcher {
+    const wanted = new Set(originalNames);
+    const locals = new Map<string, Set<string>>();
+
+    // a tsconfig-alias import is shaped like a scoped package, only the resolved declaration file tells the two apart
+    function resolvesTo(id: TSESTree.Identifier, originalName: string): boolean {
+        const symbol = checker.getSymbolAtLocation(services.esTreeNodeToTSNodeMap.get(id));
+        if (!symbol) return false;
+        const target = symbol.flags & SymbolFlags.Alias ? checker.getAliasedSymbol(symbol) : symbol;
+        if (target.getName() !== originalName) return false;
+        const file = target.declarations?.[0]?.getSourceFile().fileName ?? '';
+        if (!file.includes('node_modules')) return true;
+        return /node_modules[\\/](@seedcord[\\/]|seedcord[\\/])/.test(file);
+    }
+
+    return {
+        collectImports(node) {
+            const source = node.source.value;
+            if (typeof source !== 'string') return;
+            if (source !== 'seedcord' && !source.startsWith('@seedcord/') && !source.startsWith('.')) return;
+            for (const spec of node.specifiers) {
+                if (spec.type !== AST_NODE_TYPES.ImportSpecifier) continue;
+                if (spec.imported.type !== AST_NODE_TYPES.Identifier) continue;
+                if (!wanted.has(spec.imported.name)) continue;
+                let set = locals.get(spec.imported.name);
+                if (!set) {
+                    set = new Set();
+                    locals.set(spec.imported.name, set);
+                }
+                set.add(spec.local.name);
+            }
+        },
+        hasDecorator(node, originalName) {
+            return node.decorators.some((decorator) => {
+                const id = decoratorIdentifier(decorator);
+                if (!id) return false;
+                if (locals.get(originalName)?.has(id.name)) return true;
+                return resolvesTo(id, originalName);
+            });
+        }
+    };
+}
 
 // the symbol is declared inside the discord.js or @discordjs packages, so a same-named local class is excluded
 export function isFromDiscordJs(symbol: ts.Symbol | undefined): boolean {

--- a/packages/eslint-utils/src/utils.ts
+++ b/packages/eslint-utils/src/utils.ts
@@ -6,22 +6,6 @@ function isSeedcordSource(source: string): boolean {
     return source === 'seedcord' || source.startsWith('@seedcord/');
 }
 
-function decoratorName(decorator: TSESTree.Decorator): string | undefined {
-    const expr = decorator.expression;
-    if (expr.type === AST_NODE_TYPES.CallExpression && expr.callee.type === AST_NODE_TYPES.Identifier) {
-        return expr.callee.name;
-    }
-    if (expr.type === AST_NODE_TYPES.Identifier) return expr.name;
-    return undefined;
-}
-
-export function hasDecoratorNamed(node: TSESTree.ClassDeclaration, names: ReadonlySet<string>): boolean {
-    return node.decorators.some((decorator) => {
-        const name = decoratorName(decorator);
-        return name !== undefined && names.has(name);
-    });
-}
-
 export function forEachSeedcordImport(
     node: TSESTree.ImportDeclaration,
     fn: (imported: string, local: string) => void

--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -49,6 +49,7 @@
     },
     "dependencies": {
         "@discordjs/builders": "catalog:deps",
+        "@discordjs/rest": "catalog:deps",
         "@seedcord/core": "workspace:*",
         "@seedcord/errors": "workspace:*",
         "@seedcord/event-emitter": "workspace:*",
@@ -58,6 +59,7 @@
         "@seedcord/types": "workspace:*",
         "@seedcord/utils": "workspace:*",
         "chalk": "catalog:deps",
+        "discord-api-types": "catalog:deps",
         "envapt": "catalog:deps"
     },
     "devDependencies": {

--- a/packages/gateway/src/bot/notices/index.ts
+++ b/packages/gateway/src/bot/notices/index.ts
@@ -7,7 +7,7 @@ import type { PermSubject } from './utils';
 import type { ReplyResponse } from '@seedcord/types';
 import type { Role } from 'discord.js';
 
-export { NeedsAny, NotAllowed, NotInDm, NotInGuild, NotOwner, OnCooldown } from '@seedcord/core/internal';
+export { NotInGuild } from '@seedcord/core/internal';
 
 // ----- catalog gate refusals -----
 

--- a/packages/gateway/src/miscellaneous/extractErrorResponse.ts
+++ b/packages/gateway/src/miscellaneous/extractErrorResponse.ts
@@ -11,25 +11,16 @@ import { FaultThrottle } from '@miscellaneous/FaultThrottle';
 import type { Repliables } from '@handlers/BaseHandler';
 import type { Core } from '@interfaces/Core';
 import type { RenderContext, ReplyResponse, Nullable } from '@seedcord/types';
-import type { EventFaultSource, InteractionFaultSource } from '@subscribers/types/Subscriptions';
+import type { AllSubscriptions, EventFaultSource, InteractionFaultSource } from '@subscribers/types/Subscriptions';
 import type { Guild, User } from 'discord.js';
 import type { UUID } from 'node:crypto';
 
 const logger = new Logger('ErrorsHandling');
 
-/**
- * The single throttle for every fault publish, so a recurring fault reports once per window across both
- * the interaction and event paths. Exported so tests reset it between cases.
- *
- * @internal
- */
+// one throttle across both report paths, so a recurring fault reports once per window. exported so
+// tests reset the shared window state.
 export const faultThrottle = new FaultThrottle();
 
-/**
- * A fault that came from a client event. The event boundary derives the actor and channel best-effort.
- *
- * @internal
- */
 interface EventOrigin {
     name: string;
     handler: string;
@@ -37,12 +28,6 @@ interface EventOrigin {
     channelId: string | null;
 }
 
-/**
- * Where an error came from. `interaction` sets the interaction `handledException` source, `event` sets
- * the event source. guild/user back the `unknownException` payload on every path.
- *
- * @internal
- */
 export interface ErrorOrigin {
     interaction?: Repliables;
     event?: EventOrigin;
@@ -53,7 +38,6 @@ export interface ErrorOrigin {
     metadata?: unknown;
 }
 
-/** @internal */
 export interface ExtractedErrorResponse {
     uuid: UUID;
     response: ReplyResponse;
@@ -66,8 +50,6 @@ export interface ExtractedErrorResponse {
  * publishes `handledException` on the interaction path. A raw, non-denial throw publishes
  * `unknownException` and renders the configured `defaultError` (or a generic {@link Fault}). One uuid is
  * threaded into both the reply and the bus payload.
- *
- * @internal
  */
 export function extractErrorResponse(error: Error, core: Core, origin: ErrorOrigin): ExtractedErrorResponse {
     const uuid = crypto.randomUUID();
@@ -87,7 +69,7 @@ export function extractErrorResponse(error: Error, core: Core, origin: ErrorOrig
     return { uuid, response };
 }
 
-// the throttle protocol both report paths share: report once per window per key, stamp only on a report
+// stamp only after a publish, so a throttled fault stays reportable next window
 function withThrottle(origin: ErrorOrigin, error: Error, publish: () => void): void {
     const key = faultKey(origin, error);
     if (!faultThrottle.shouldReport(key)) {
@@ -111,8 +93,7 @@ function reportFault(denial: Notice, core: Core, origin: ErrorOrigin, uuid: UUID
             core.bus.publish('unknownException', {
                 uuid,
                 error: denial,
-                guild: origin.guild,
-                user: origin.user,
+                ...scalarActors(origin),
                 metadata: metadataFor(origin)
             });
         }
@@ -128,11 +109,18 @@ function reportRawFault(error: Error, core: Core, origin: ErrorOrigin, uuid: UUI
         core.bus.publish('unknownException', {
             uuid,
             error,
-            guild: origin.guild,
-            user: origin.user,
+            ...scalarActors(origin),
             metadata: metadataFor(origin)
         });
     });
+}
+
+// the bus payload must stay djs-free, so map to plain scalars
+function scalarActors(origin: ErrorOrigin): Pick<AllSubscriptions['unknownException'], 'guild' | 'user'> {
+    return {
+        guild: origin.guild ? { id: origin.guild.id, name: origin.guild.name } : undefined,
+        user: origin.user ? { id: origin.user.id, username: origin.user.username } : undefined
+    };
 }
 
 function metadataFor(origin: ErrorOrigin): unknown {

--- a/packages/gateway/src/miscellaneous/flagsFor.ts
+++ b/packages/gateway/src/miscellaneous/flagsFor.ts
@@ -1,14 +1,7 @@
-import { MessageFlags } from 'discord.js';
+import { MessageFlags } from 'discord-api-types/v10';
 
-/**
- * Builds the `flags` bitfield for a framework reply. Every framework reply is ComponentsV2, so the
- * IsComponentsV2 flag is always set.
- *
- * @param ephemeral - Whether the reply is ephemeral.
- * @returns The OR'd `MessageFlags` value as a plain number.
- *
- * @internal
- */
+// IsComponentsV2 is unconditional, every framework reply is ComponentsV2
+/** @internal */
 export function flagsFor(ephemeral: boolean): number {
     let flags = MessageFlags.IsComponentsV2;
     if (ephemeral) flags |= MessageFlags.Ephemeral;

--- a/packages/gateway/src/subscribers/Bus.ts
+++ b/packages/gateway/src/subscribers/Bus.ts
@@ -2,7 +2,7 @@ import { HmrModuleHandler } from '@seedcord/core/hmr';
 import { SubscribeMetadataKey } from '@seedcord/core/internal';
 import { SeedcordErrorCode } from '@seedcord/errors';
 import { SeedcordError } from '@seedcord/errors/internal';
-import { Logger } from '@seedcord/logger';
+import { Logger, paint } from '@seedcord/logger';
 import { traverseDirectory } from '@seedcord/utils/node';
 import chalk from 'chalk';
 import { Envapter } from 'envapt';
@@ -94,7 +94,8 @@ export class Bus extends Plugin<SubscriptionTuples> {
             [...this.webhookProbes].map(async ([url, envKey]) => {
                 const result = await WebhookLog.senderFor(url).verify();
                 if (result === 'missing') throw new SeedcordError(SeedcordErrorCode.ConfigWebhookNotFound, [envKey]);
-                if (result === 'unreachable') this.logger.warn(`could not verify the webhook behind ${envKey}`);
+                if (result === 'unreachable')
+                    this.logger.warn(`could not verify the webhook behind ${paint.sky.bold(envKey)}`);
             })
         );
     }
@@ -128,7 +129,7 @@ export class Bus extends Plugin<SubscriptionTuples> {
             const envKey = WebhookLog.envKeyOf(handler);
             const url = WebhookLog.urlOf(envKey);
             if (url === null) {
-                this.logger.warn(`${handler.name} disabled, ${envKey} is not set`);
+                this.logger.warn(`${chalk.bold(handler.name)} disabled, ${paint.sky.bold(envKey)} is not set`);
                 return;
             }
             this.webhookProbes.set(url, envKey);

--- a/packages/gateway/src/subscribers/Bus.ts
+++ b/packages/gateway/src/subscribers/Bus.ts
@@ -40,8 +40,8 @@ export class Bus extends Plugin<SubscriptionTuples> {
     private isInitialized = false;
     private readonly subscribersMap = new Map<SubscriptionKey, RegisteredSubscriberHandlerEntry[]>();
     private readonly executedOnceHandlers = new Set<SubscriberConstructor>();
-    // url -> env key, read once at boot by verifyWebhooks, an hmr unregister leaves entries behind harmlessly
-    private readonly webhookProbes = new Map<string, string>();
+    // url -> env keys, read once at boot by verifyWebhooks, an hmr unregister leaves no-op entries which is fine
+    private readonly webhookProbes = new Map<string, string[]>();
     private readonly hmrHandler?: HmrModuleHandler<SubscriberConstructor, void, SubscriberArtifact>;
 
     constructor(protected core: Core) {
@@ -92,14 +92,14 @@ export class Bus extends Plugin<SubscriptionTuples> {
     public async verifyWebhooks(): Promise<void> {
         const missing: string[] = [];
         await Promise.all(
-            [...this.webhookProbes].map(async ([url, envKey]) => {
+            [...this.webhookProbes].map(async ([url, envKeys]) => {
                 const result = await WebhookLog.senderFor(url).verify();
-                if (result === 'missing') missing.push(envKey);
+                if (result === 'missing') missing.push(...envKeys);
                 else if (result === 'unreachable')
-                    this.logger.warn(`could not verify the webhook behind ${paint.sky.bold(envKey)}`);
+                    this.logger.warn(`could not verify webhook at ${paint.sky.bold(envKeys.join(', '))}`);
             })
         );
-        // one boot reports every dead webhook
+        // initial boot reports all missing webhooks
         if (missing.length > 0) throw new SeedcordError(SeedcordErrorCode.ConfigWebhookNotFound, [missing.join(', ')]);
     }
 
@@ -135,7 +135,9 @@ export class Bus extends Plugin<SubscriptionTuples> {
                 this.logger.warn(`${chalk.bold(handler.name)} disabled, ${paint.sky.bold(envKey)} is not set`);
                 return;
             }
-            this.webhookProbes.set(url, envKey);
+            const envKeys = this.webhookProbes.get(url) ?? [];
+            if (!envKeys.includes(envKey)) envKeys.push(envKey);
+            this.webhookProbes.set(url, envKeys);
         }
 
         const options = Reflect.getMetadata(SubscribeMetadataKey, handler) as SubscribeMetadataEntry;
@@ -158,7 +160,7 @@ export class Bus extends Plugin<SubscriptionTuples> {
                 handlers.splice(index, 1);
             }
         }
-        // spent follows the ctor identity, so leaving executedOnceHandlers alone keeps a rollback-restored subscriber spent
+        // ctor identity determines state, so ignoring executedOnceHandlers on rollback preserves state for restored subscribers
     }
 
     private isSubscriber(obj: unknown): obj is SubscriberConstructor {

--- a/packages/gateway/src/subscribers/Bus.ts
+++ b/packages/gateway/src/subscribers/Bus.ts
@@ -1,5 +1,7 @@
 import { HmrModuleHandler } from '@seedcord/core/hmr';
 import { SubscribeMetadataKey } from '@seedcord/core/internal';
+import { SeedcordErrorCode } from '@seedcord/errors';
+import { SeedcordError } from '@seedcord/errors/internal';
 import { Logger } from '@seedcord/logger';
 import { traverseDirectory } from '@seedcord/utils/node';
 import chalk from 'chalk';
@@ -7,6 +9,7 @@ import { Envapter } from 'envapt';
 
 import { Plugin } from '@interfaces/Plugin';
 
+import { WebhookLog } from './bases/WebhookLog';
 import { HandledException } from './default/HandledException';
 import { UnknownException } from './default/UnknownException';
 import { Subscriber } from './Subscriber';
@@ -17,8 +20,7 @@ import type { Core } from '@interfaces/Core';
 import type { EventFrequency } from '@miscellaneous/types';
 import type { HmrUpdateEvent } from '@seedcord/types';
 
-// `data: never` so a concrete subscriber (which takes one subscription's payload) is assignable here
-// for storage. The per-key map restores the precise payload type at dispatch.
+// `data: never` so a concrete subscriber stays assignable for storage. the per-key map restores the payload type at dispatch.
 type SubscriberConstructor = new (data: never, core: Core) => Subscriber<SubscriptionKey>;
 interface RegisteredSubscriberHandlerEntry {
     ctor: SubscriberConstructor;
@@ -28,12 +30,8 @@ interface RegisteredSubscriberHandlerEntry {
 type SubscriberArtifact = SubscriptionKey[];
 
 /**
- * Manages application subscribers and event handling
- *
- * Provides a centralized system for registering and executing custom subscribers
- * throughout the application lifecycle. Bus subscribers are loaded from configured directories
- * and can be triggered programmatically or by framework events. Accessed via `core.bus`. Do not
- * construct it directly.
+ * Registers and dispatches subscribers. Subscribers load from the configured directories and run
+ * on a programmatic or framework-event publish. Accessed via `core.bus`. Do not construct it directly.
  */
 export class Bus extends Plugin<SubscriptionTuples> {
     public readonly logger = new Logger('Subscribers');
@@ -42,6 +40,8 @@ export class Bus extends Plugin<SubscriptionTuples> {
     private isInitialized = false;
     private readonly subscribersMap = new Map<SubscriptionKey, RegisteredSubscriberHandlerEntry[]>();
     private readonly executedOnceHandlers = new Set<SubscriberConstructor>();
+    // url -> env key, read once at boot by verifyWebhooks, an hmr unregister leaves entries behind harmlessly
+    private readonly webhookProbes = new Map<string, string>();
     private readonly hmrHandler?: HmrModuleHandler<SubscriberConstructor, void, SubscriberArtifact>;
 
     constructor(protected core: Core) {
@@ -74,10 +74,6 @@ export class Bus extends Plugin<SubscriptionTuples> {
         this.registerSubscriber(UnknownException);
         this.registerSubscriber(HandledException);
 
-        // require both webhook urls at boot so a missing one stops the boot, never silently dropping fault
-        // reports when the first exception fires.
-        Envapter.require('UNKNOWN_EXCEPTION_WEBHOOK_URL', 'HANDLED_EXCEPTION_WEBHOOK_URL');
-
         const subscribersDir = this.core.config.subscribers.path;
         if (subscribersDir) {
             this.logger.info(chalk.bold(subscribersDir));
@@ -88,9 +84,22 @@ export class Bus extends Plugin<SubscriptionTuples> {
             );
             this.logger.utils.list([`${chalk.bold.magenta(totalSubscribers)} subscribers`], chalk.bold.green('Loaded'));
         }
+
+        if (!Envapter.isTest) await this.verifyWebhooks();
     }
 
-    /** @internal For use in dev mode */
+    /** @internal Exposed for tests. */
+    public async verifyWebhooks(): Promise<void> {
+        await Promise.all(
+            [...this.webhookProbes].map(async ([url, envKey]) => {
+                const result = await WebhookLog.senderFor(url).verify();
+                if (result === 'missing') throw new SeedcordError(SeedcordErrorCode.ConfigWebhookNotFound, [envKey]);
+                if (result === 'unreachable') this.logger.warn(`could not verify the webhook behind ${envKey}`);
+            })
+        );
+    }
+
+    /** @internal */
     public override async onHmr(event: HmrUpdateEvent): Promise<void> {
         if (this.hmrHandler) {
             await this.hmrHandler.handle(event);
@@ -115,6 +124,16 @@ export class Bus extends Plugin<SubscriptionTuples> {
     }
 
     private registerSubscriber(handler: SubscriberConstructor): void {
+        if (handler.prototype instanceof WebhookLog) {
+            const envKey = WebhookLog.envKeyOf(handler);
+            const url = WebhookLog.urlOf(envKey);
+            if (url === null) {
+                this.logger.warn(`${handler.name} disabled, ${envKey} is not set`);
+                return;
+            }
+            this.webhookProbes.set(url, envKey);
+        }
+
         const options = Reflect.getMetadata(SubscribeMetadataKey, handler) as SubscribeMetadataEntry;
 
         let handlers = this.subscribersMap.get(options.subscriber);
@@ -177,8 +196,8 @@ export class Bus extends Plugin<SubscriptionTuples> {
             }
 
             try {
-                // Mark before awaiting so a re-entrant publish of the same event can't run a
-                // 'once' subscriber twice while the first invocation is still pending.
+                // mark before awaiting, so a re-entrant publish can't run a 'once' subscriber twice
+                // while the first invocation is still pending
                 if (entry.frequency === 'once') {
                     this.executedOnceHandlers.add(entry.ctor);
                 }

--- a/packages/gateway/src/subscribers/Bus.ts
+++ b/packages/gateway/src/subscribers/Bus.ts
@@ -90,14 +90,17 @@ export class Bus extends Plugin<SubscriptionTuples> {
 
     /** @internal Exposed for tests. */
     public async verifyWebhooks(): Promise<void> {
+        const missing: string[] = [];
         await Promise.all(
             [...this.webhookProbes].map(async ([url, envKey]) => {
                 const result = await WebhookLog.senderFor(url).verify();
-                if (result === 'missing') throw new SeedcordError(SeedcordErrorCode.ConfigWebhookNotFound, [envKey]);
-                if (result === 'unreachable')
+                if (result === 'missing') missing.push(envKey);
+                else if (result === 'unreachable')
                     this.logger.warn(`could not verify the webhook behind ${paint.sky.bold(envKey)}`);
             })
         );
+        // one boot reports every dead webhook
+        if (missing.length > 0) throw new SeedcordError(SeedcordErrorCode.ConfigWebhookNotFound, [missing.join(', ')]);
     }
 
     /** @internal */

--- a/packages/gateway/src/subscribers/bases/WebhookLog.ts
+++ b/packages/gateway/src/subscribers/bases/WebhookLog.ts
@@ -1,22 +1,86 @@
-import { Subscriber } from '../Subscriber';
+import { WebhookUrlMetadataKey } from '@seedcord/core/internal';
+import { SeedcordErrorCode } from '@seedcord/errors';
+import { SeedcordError } from '@seedcord/errors/internal';
+import { Envapter } from 'envapt';
 
-import type { SubscriptionKey, AllSubscriptions } from '../types/Subscriptions';
-import type { Core } from '@interfaces/Core';
-import type { WebhookClient } from 'discord.js';
+import { flagsFor } from '@miscellaneous/flagsFor';
+
+import { Subscriber } from '../Subscriber';
+import { isDiscordWebhookUrl } from './webhookHelpers';
+import { WebhookSender } from './WebhookSender';
+
+import type { WebhookFile } from './WebhookSender';
+import type { SubscriptionKey } from '../types/Subscriptions';
+import type { APIMessageTopLevelComponent } from 'discord-api-types/v10';
 
 /**
- * Abstract webhook logging handler for subscriber events.
+ * The content a reporter returns from {@link WebhookLog.report}.
+ */
+export interface WebhookReport {
+    /** Shown as the webhook message author. Defaults to the reporter's class name. */
+    username?: string;
+    components: readonly { toJSON(): APIMessageTopLevelComponent }[];
+    files?: readonly WebhookFile[] | undefined;
+}
+
+/**
+ * Base class for subscribers that deliver their event to a Discord webhook.
  *
- * Extends Subscriber to provide webhook-based logging capabilities.
- * Implementations must define the webhook client to send messages to by implementing the webhook property.
+ * Declare the url's environment variable with `@WebhookUrl` and implement {@link report}. Url
+ * resolution, validation, sender reuse, and sending run in the base. When the variable is unset
+ * the reporter is skipped at registration with a boot warning.
  *
- * @typeParam KeyOfSubscribers - The specific subscriber type this handler processes
+ * @typeParam KeyOfSubscribers - The subscription key this reporter receives
  */
 export abstract class WebhookLog<KeyOfSubscribers extends SubscriptionKey> extends Subscriber<KeyOfSubscribers> {
-    /** The Discord webhook client for sending log messages */
-    abstract webhook: WebhookClient;
+    private static readonly senders = new Map<string, WebhookSender>();
 
-    constructor(data: AllSubscriptions[KeyOfSubscribers], core: Core) {
-        super(data, core);
+    /** Builds the message for one published event. */
+    abstract report(): WebhookReport | Promise<WebhookReport>;
+
+    async execute(): Promise<void> {
+        const url = WebhookLog.urlOf(WebhookLog.envKeyOf(this.constructor));
+        if (url === null) {
+            // unreachable through the Bus, registration already skips url-less reporters
+            this.logger.warn(`${this.constructor.name} has no webhook url set, dropping the report`);
+            return;
+        }
+
+        const { username, components, files } = await this.report();
+        try {
+            await WebhookLog.senderFor(url).send({
+                flags: flagsFor(false),
+                username: username ?? this.constructor.name,
+                components,
+                files
+            });
+        } catch (error) {
+            this.logger.error('Failed to send webhook report', error);
+        }
+    }
+
+    /** @internal */
+    static senderFor(url: string): WebhookSender {
+        let sender = WebhookLog.senders.get(url);
+        if (!sender) {
+            sender = new WebhookSender(url);
+            WebhookLog.senders.set(url, sender);
+        }
+        return sender;
+    }
+
+    /** @internal */
+    static envKeyOf(ctor: NewableFunction): string {
+        const envKey = Reflect.getMetadata(WebhookUrlMetadataKey, ctor) as string | undefined;
+        if (!envKey) throw new SeedcordError(SeedcordErrorCode.DecoratorWebhookUrlMissing, [ctor.name]);
+        return envKey;
+    }
+
+    /** @internal Returns null when the env var is unset, throws when set but malformed. */
+    static urlOf(envKey: string): string | null {
+        const raw = Envapter.get(envKey)?.trim();
+        if (raw === undefined || raw === '') return null;
+        if (!isDiscordWebhookUrl(raw)) throw new SeedcordError(SeedcordErrorCode.ConfigWebhookUrlInvalid, [envKey]);
+        return raw;
     }
 }

--- a/packages/gateway/src/subscribers/bases/WebhookLog.ts
+++ b/packages/gateway/src/subscribers/bases/WebhookLog.ts
@@ -1,6 +1,7 @@
 import { WebhookUrlMetadataKey } from '@seedcord/core/internal';
 import { SeedcordErrorCode } from '@seedcord/errors';
 import { SeedcordError } from '@seedcord/errors/internal';
+import chalk from 'chalk';
 import { Envapter } from 'envapt';
 
 import { flagsFor } from '@miscellaneous/flagsFor';
@@ -42,7 +43,7 @@ export abstract class WebhookLog<KeyOfSubscribers extends SubscriptionKey> exten
         const url = WebhookLog.urlOf(WebhookLog.envKeyOf(this.constructor));
         if (url === null) {
             // unreachable through the Bus, registration already skips url-less reporters
-            this.logger.warn(`${this.constructor.name} has no webhook url set, dropping the report`);
+            this.logger.warn(`${chalk.bold(this.constructor.name)} has no webhook url set, this reporter is disabled`);
             return;
         }
 

--- a/packages/gateway/src/subscribers/bases/WebhookSender.ts
+++ b/packages/gateway/src/subscribers/bases/WebhookSender.ts
@@ -1,0 +1,80 @@
+import { DiscordAPIError, REST } from '@discordjs/rest';
+import { SeedcordErrorCode } from '@seedcord/errors';
+import { SeedcordError } from '@seedcord/errors/internal';
+import { Routes } from 'discord-api-types/v10';
+
+import type { APIMessageTopLevelComponent } from 'discord-api-types/v10';
+
+const HTTP_NOT_FOUND = 404;
+const HTTP_UNAUTHORIZED = 401;
+
+/**
+ * A file attached to a webhook report.
+ */
+export interface WebhookFile {
+    name: string;
+    description: string;
+    data: Buffer;
+}
+
+/**
+ * The payload {@link WebhookSender.send} posts.
+ */
+export interface WebhookSendOptions {
+    flags: number;
+    username: string;
+    components: readonly { toJSON(): APIMessageTopLevelComponent }[];
+    files?: readonly WebhookFile[] | undefined;
+}
+
+/**
+ * Sends component messages to a Discord webhook through `@discordjs/rest`.
+ *
+ * @throws A `SeedcordError` when the url does not carry a webhook id and token.
+ */
+export class WebhookSender {
+    private readonly rest = new REST();
+    private readonly route: `/${string}`;
+
+    constructor(url: string) {
+        const match = /\/webhooks\/(\d+)\/([\w$-]+)$/.exec(url);
+        // the url is a secret, the error message never carries it
+        if (!match?.[1] || !match[2]) throw new SeedcordError(SeedcordErrorCode.ConfigWebhookUrlInvalid, ['The url']);
+        this.route = Routes.webhook(match[1], match[2]);
+    }
+
+    /**
+     * Fetches the webhook object, sending no message. Returns `missing` on a 404 or 401 from
+     * Discord and `unreachable` on any other failure.
+     */
+    async verify(): Promise<'ok' | 'missing' | 'unreachable'> {
+        try {
+            await this.rest.get(this.route, { auth: false });
+            return 'ok';
+        } catch (error) {
+            const gone =
+                error instanceof DiscordAPIError &&
+                (error.status === HTTP_NOT_FOUND || error.status === HTTP_UNAUTHORIZED);
+            return gone ? 'missing' : 'unreachable';
+        }
+    }
+
+    async send(options: WebhookSendOptions): Promise<void> {
+        const { flags, username, components, files } = options;
+        await this.rest.post(this.route, {
+            auth: false,
+            // with_components=true makes discord accept a components-v2 payload, wait=true makes it
+            // return payload errors in the response
+            query: new URLSearchParams({ with_components: 'true', wait: 'true' }),
+            body: {
+                flags,
+                username,
+                components: components.map((component) => component.toJSON()),
+                ...(files?.length && {
+                    attachments: files.map((file, id) => ({ id, filename: file.name, description: file.description }))
+                })
+            },
+            ...(files?.length && { files: files.map((file) => ({ name: file.name, data: file.data })) })
+        });
+    }
+}

--- a/packages/gateway/src/subscribers/bases/webhookHelpers.ts
+++ b/packages/gateway/src/subscribers/bases/webhookHelpers.ts
@@ -1,35 +1,22 @@
 import { BuilderComponent } from '@seedcord/core';
 import { filterCirculars } from '@seedcord/utils';
-import { AttachmentBuilder, SeparatorSpacingSize } from 'discord.js';
+import { SeparatorSpacingSize } from 'discord-api-types/v10';
+
+import type { WebhookFile } from './WebhookSender';
 
 const DISCORD_WEBHOOK_REGEX = new RegExp(
     String.raw`^https?:\/\/(?:canary\.|ptb\.)?discord(?:app)?\.com\/api\/webhooks\/\d+\/[\w$-]+$`
 );
 
-/**
- * Whether a string is a well-formed Discord webhook URL.
- *
- * @internal
- */
 export function isDiscordWebhookUrl(value: string): boolean {
     return URL.canParse(value) && DISCORD_WEBHOOK_REGEX.test(value);
 }
 
-/**
- * Serializes a value to a JSON attachment, made circular-safe first.
- *
- * @internal
- */
-export function jsonAttachment(name: string, description: string, data: unknown): AttachmentBuilder {
+export function jsonAttachment(name: string, description: string, data: unknown): WebhookFile {
     const content = filterCirculars(data);
-    return new AttachmentBuilder(Buffer.from(JSON.stringify(content, undefined, 2), 'utf8'), { name, description });
+    return { name, description, data: Buffer.from(JSON.stringify(content, undefined, 2), 'utf8') };
 }
 
-/**
- * The small divider the default webhook reporters place between sections.
- *
- * @internal
- */
 export class WebhookSeparator extends BuilderComponent<'separator'> {
     constructor() {
         super('separator');

--- a/packages/gateway/src/subscribers/decorators/WebhookUrl.ts
+++ b/packages/gateway/src/subscribers/decorators/WebhookUrl.ts
@@ -1,0 +1,30 @@
+import { WebhookUrlMetadataKey } from '@seedcord/core/internal';
+
+import type { WebhookLog } from '../bases/WebhookLog';
+import type { SubscriptionKey } from '../types/Subscriptions';
+import type { Constructor } from 'type-fest';
+
+/**
+ * Declares the environment variable a {@link WebhookLog} reporter reads its webhook url from.
+ *
+ * An unset variable disables the reporter with a boot warning. A set but malformed value throws
+ * at boot.
+ *
+ * @param envKey - The environment variable name holding the webhook url
+ * @decorator
+ * @example
+ * ```ts
+ * \@Subscribe('memberBanned')
+ * \@WebhookUrl('BAN_LOG_WEBHOOK_URL')
+ * class BanLog extends WebhookLog<'memberBanned'> {
+ *   report() {
+ *     return { components: [new BanCard(this.data).component] };
+ *   }
+ * }
+ * ```
+ */
+export function WebhookUrl(envKey: string) {
+    return function <HandlerCtor extends Constructor<WebhookLog<SubscriptionKey>>>(constructor: HandlerCtor): void {
+        Reflect.defineMetadata(WebhookUrlMetadataKey, envKey, constructor);
+    };
+}

--- a/packages/gateway/src/subscribers/default/HandledException.ts
+++ b/packages/gateway/src/subscribers/default/HandledException.ts
@@ -1,69 +1,31 @@
 import { BuilderComponent } from '@seedcord/core';
-import { SeedcordErrorCode } from '@seedcord/errors';
-import { SeedcordError } from '@seedcord/errors/internal';
-import { WebhookClient } from 'discord.js';
-import { Envapt } from 'envapt/legacy';
 
-import { flagsFor } from '@miscellaneous/flagsFor';
-
-import { isDiscordWebhookUrl, jsonAttachment, WebhookSeparator } from '../bases/webhookHelpers';
+import { jsonAttachment, WebhookSeparator } from '../bases/webhookHelpers';
 import { WebhookLog } from '../bases/WebhookLog';
 import { Subscribe } from '../decorators/Subscribe';
+import { WebhookUrl } from '../decorators/WebhookUrl';
 
+import type { WebhookReport } from '../bases/WebhookLog';
 import type { AllSubscriptions, FaultSource } from '../types/Subscriptions';
 import type { Notice } from '@seedcord/core';
 
-function webhookUrlValidator(raw: unknown): string {
-    if (raw !== null && typeof raw !== 'string') {
-        throw new SeedcordError(SeedcordErrorCode.ConfigHandledExceptionWebhookInvalid);
-    }
-
-    const value = raw?.trim() ?? '';
-    if (value === '') {
-        throw new SeedcordError(SeedcordErrorCode.ConfigHandledExceptionWebhookMissing);
-    }
-
-    if (!isDiscordWebhookUrl(value)) {
-        throw new SeedcordError(SeedcordErrorCode.ConfigHandledExceptionWebhookInvalid);
-    }
-
-    return value;
-}
-
 /**
- * Default subscriber that delivers a reported `Notice` (`report: true`) to a webhook with the denial,
- * the fault source, the threaded uuid, the cause stack, and the raw source as a JSON attachment. The
- * controller boundary throttles identical faults before they reach the bus.
+ * Default subscriber that delivers a reported `Notice` (`report: true`) to a webhook with the
+ * denial, the fault source, the threaded uuid, the cause stack, and the raw source as a JSON
+ * attachment. The controller boundary throttles identical faults before they reach the bus.
  *
- * Requires the HANDLED_EXCEPTION_WEBHOOK_URL environment variable, the same rule UNKNOWN_EXCEPTION_WEBHOOK_URL enforces.
- *
- * @throws A **SeedcordError** if HANDLED_EXCEPTION_WEBHOOK_URL is not set or is invalid
+ * Reads its webhook url from HANDLED_EXCEPTION_WEBHOOK_URL. Unset, the reporter is disabled with
+ * a boot warning.
  */
 @Subscribe('handledException')
+@WebhookUrl('HANDLED_EXCEPTION_WEBHOOK_URL')
 export class HandledException extends WebhookLog<'handledException'> {
-    @Envapt('HANDLED_EXCEPTION_WEBHOOK_URL', {
-        converter: (raw) => webhookUrlValidator(raw)
-    })
-    declare static readonly handledExceptionWebhookUrl: string;
-
-    webhook = new WebhookClient({
-        url: HandledException.handledExceptionWebhookUrl
-    });
-
-    async execute(): Promise<void> {
-        const { source } = this.data;
-
-        try {
-            await this.webhook.send({
-                flags: flagsFor(false),
-                withComponents: true,
-                username: 'Handled Exception',
-                components: [new HandledExceptionContainer(this.data).component],
-                files: [jsonAttachment('source.json', 'The raw source the fault came from', source.raw)]
-            });
-        } catch (error) {
-            this.logger.error('Failed to send handled exception webhook', error);
-        }
+    report(): WebhookReport {
+        return {
+            username: 'Handled Exception',
+            components: [new HandledExceptionContainer(this.data).component],
+            files: [jsonAttachment('source.json', 'The raw source the fault came from', this.data.source.raw)]
+        };
     }
 }
 
@@ -85,13 +47,7 @@ class HandledExceptionContainer extends BuilderComponent<'container'> {
     }
 }
 
-/**
- * The summary block of a fault report, narrowed per source kind so an interaction fault shows its
- * command and customId while an event fault shows its event name and handler.
- *
- * @internal
- */
-export function faultSummary(denial: Notice, source: FaultSource): string {
+function faultSummary(denial: Notice, source: FaultSource): string {
     const head = `### A handled fault was reported: \`${denial.name}\`\n**Message:** ${denial.message}\n`;
     if (source.kind === 'event') {
         return (
@@ -113,13 +69,8 @@ export function faultSummary(denial: Notice, source: FaultSource): string {
     );
 }
 
-/**
- * The text shown for a denial's cause in the report. Tolerates a non-serializable cause (a bigint or a
- * circular object) so building the report never throws.
- *
- * @internal
- */
-export function causeStack(denial: Notice): string {
+// every cause shape returns a string, building the report never throws on a bigint or circular cause
+function causeStack(denial: Notice): string {
     const { cause } = denial;
     if (Error.isError(cause)) return cause.stack ?? cause.message;
     if (typeof cause === 'string') return cause;

--- a/packages/gateway/src/subscribers/default/UnknownException.ts
+++ b/packages/gateway/src/subscribers/default/UnknownException.ts
@@ -1,75 +1,35 @@
+import { DiscordAPIError } from '@discordjs/rest';
 import { BuilderComponent } from '@seedcord/core';
-import { SeedcordErrorCode } from '@seedcord/errors';
-import { SeedcordError } from '@seedcord/errors/internal';
-import { WebhookClient, DiscordAPIError, SnowflakeUtil } from 'discord.js';
-import { Envapt } from 'envapt/legacy';
+import { timestampFromSnowflake } from '@seedcord/utils';
 
-import { flagsFor } from '@miscellaneous/flagsFor';
-
-import { isDiscordWebhookUrl, jsonAttachment, WebhookSeparator } from '../bases/webhookHelpers';
+import { jsonAttachment, WebhookSeparator } from '../bases/webhookHelpers';
 import { WebhookLog } from '../bases/WebhookLog';
 import { Subscribe } from '../decorators/Subscribe';
+import { WebhookUrl } from '../decorators/WebhookUrl';
 
+import type { WebhookReport } from '../bases/WebhookLog';
 import type { AllSubscriptions } from '../types/Subscriptions';
 
-function webhookUrlValidator(raw: unknown): string {
-    if (raw !== null && typeof raw !== 'string') {
-        throw new SeedcordError(SeedcordErrorCode.ConfigUnknownExceptionWebhookInvalid);
-    }
-
-    const value = raw?.trim() ?? '';
-    if (value === '') {
-        throw new SeedcordError(SeedcordErrorCode.ConfigUnknownExceptionWebhookMissing);
-    }
-
-    if (!isDiscordWebhookUrl(value)) {
-        throw new SeedcordError(SeedcordErrorCode.ConfigUnknownExceptionWebhookInvalid);
-    }
-
-    return value;
-}
-
 /**
- * Default subscriber to log unhandled exceptions via webhook. It provides basic information about the error:
- * - Error stack trace
- * - Guild ID and name (if applicable)
- * - User ID and username (if applicable)
- * - A unique UUID for tracking
- * - Timestamps comparing interaction time and error log time (if applicable)
- * - Metadata associated with the error (if provided)
+ * Default subscriber that reports an unhandled exception to a webhook: the stack trace, the guild
+ * and user, a tracking uuid, interaction timestamps when available, and the error metadata as a
+ * JSON attachment.
  *
- * Developers need to set the UNKNOWN_EXCEPTION_WEBHOOK_URL environment variable in their .env file otherwise this subscriber will throw an error during initialization.
- *
- * @throws A **SeedcordError** if UNKNOWN_EXCEPTION_WEBHOOK_URL is not set or is invalid
+ * Reads its webhook url from UNKNOWN_EXCEPTION_WEBHOOK_URL. Unset, the reporter is disabled with
+ * a boot warning.
  */
 @Subscribe('unknownException')
+@WebhookUrl('UNKNOWN_EXCEPTION_WEBHOOK_URL')
 export class UnknownException extends WebhookLog<'unknownException'> {
-    @Envapt('UNKNOWN_EXCEPTION_WEBHOOK_URL', {
-        converter: (raw) => webhookUrlValidator(raw)
-    })
-    declare static readonly unknownExceptionWebhookUrl: string;
-
-    webhook = new WebhookClient({
-        url: UnknownException.unknownExceptionWebhookUrl
-    });
-
-    async execute(): Promise<void> {
+    report(): WebhookReport {
         const { metadata } = this.data;
-        const metadataFile = metadata
-            ? jsonAttachment('metadata.json', 'Metadata associated with the error', metadata)
-            : null;
-
-        try {
-            await this.webhook.send({
-                flags: flagsFor(false),
-                withComponents: true,
-                username: 'Unknown Exception',
-                components: [new UnhandledErrorContainer(this.data).component],
-                files: metadataFile ? [metadataFile] : []
-            });
-        } catch (error) {
-            this.logger.error('Failed to send unknown exception webhook', error);
-        }
+        return {
+            username: 'Unknown Exception',
+            components: [new UnhandledErrorContainer(this.data).component],
+            files: metadata
+                ? [jsonAttachment('metadata.json', 'Metadata associated with the error', metadata)]
+                : undefined
+        };
     }
 }
 
@@ -101,11 +61,10 @@ class UnhandledErrorContainer extends BuilderComponent<'container'> {
 
         const now = Date.now();
 
-        // Extract the snowflake ID from `/interactions/{ID}/`
         const snowflake = error.url.match(/\/interactions\/(\d+)\//)?.[1];
         if (!snowflake) return undefined;
 
-        const interactionTs = Number(SnowflakeUtil.deconstruct(snowflake).timestamp);
+        const interactionTs = timestampFromSnowflake(snowflake);
 
         const diff = now - interactionTs;
         const seconds = Math.floor(diff / 1000);

--- a/packages/gateway/src/subscribers/index.ts
+++ b/packages/gateway/src/subscribers/index.ts
@@ -1,17 +1,9 @@
-// The class users will extend to create subscriber handlers
 export { Subscriber } from './Subscriber';
 
-// Decorators
 export { Subscribe, type SubscribeOptions } from './decorators/Subscribe';
+export { WebhookUrl } from './decorators/WebhookUrl';
 
-// Abstracts and Bases
-export { WebhookLog } from './bases/WebhookLog';
+export { WebhookLog, type WebhookReport } from './bases/WebhookLog';
+export type { WebhookFile } from './bases/WebhookSender';
 
-// Types
-export type {
-    Subscriptions,
-    SubscriptionData,
-    SubscriptionKey,
-    AllSubscriptions,
-    FaultSource
-} from './types/Subscriptions';
+export type { Subscriptions, SubscriptionData, SubscriptionKey, FaultSource } from './types/Subscriptions';

--- a/packages/gateway/src/subscribers/types/Subscriptions.ts
+++ b/packages/gateway/src/subscribers/types/Subscriptions.ts
@@ -1,10 +1,8 @@
 import type { Notice } from '@seedcord/core';
-import type { Nullable } from '@seedcord/types';
-import type { Guild, User } from 'discord.js';
 import type { UUID } from 'node:crypto';
 
 /**
- * Where a reported fault came from. A union over `kind`.
+ * Where a reported fault came from.
  */
 export type FaultSource = InteractionFaultSource | EventFaultSource;
 
@@ -13,19 +11,16 @@ export type FaultSource = InteractionFaultSource | EventFaultSource;
  */
 export interface InteractionFaultSource {
     kind: 'interaction';
-    /** Which interaction kind produced the fault. */
     interactionKind: 'slash' | 'context-menu' | 'button' | 'select' | 'modal';
     /** Slash or context-menu command name, null for component and modal interactions. */
     command: string | null;
     /** Component or modal customId, null for slash and context-menu interactions. */
     customId: string | null;
-    /** User who triggered the interaction. */
     userId: string;
     /** Guild the interaction came from, null in DMs. */
     guildId: string | null;
     /** Channel the interaction came from, null when unavailable. */
     channelId: string | null;
-    /** The interaction's own id. */
     interactionId: string;
     /** The raw interaction, made JSON-safe at serialization with filterCirculars. */
     raw: unknown;
@@ -39,26 +34,21 @@ export interface EventFaultSource {
     kind: 'event';
     eventName: string;
     handler: string;
-    /** Actor derived from the event args, null when none is present. */
     userId: string | null;
-    /** Guild derived from the event args, null outside a guild. */
+    /** Null outside a guild. */
     guildId: string | null;
-    /** Channel derived from the event args, null when none is present. */
     channelId: string | null;
     /** The raw event args, made JSON-safe at serialization with filterCirculars. */
     raw: unknown;
 }
 
-/**
- * Default subscribers that are always available in the framework.
- */
 interface DefaultSubscriptions {
     /** Triggered when an unhandled exception (a raw non-Notice throw) occurs */
     unknownException: {
         uuid: UUID;
         error: Error;
-        guild: Nullable<Guild>;
-        user: Nullable<User>;
+        guild?: { id: string; name: string } | undefined;
+        user?: { id: string; username: string } | undefined;
         metadata?: unknown;
     };
     /** Triggered when a reported Notice (`report: true`) is caught */
@@ -70,45 +60,34 @@ interface DefaultSubscriptions {
 }
 
 /**
- * Custom subscribers defined by the application.
- *
- * This interface can be augmented via declaration merging to add
- * type-safe custom subscriber definitions for emitting custom subscribers anywhere in the application.
+ * Custom subscribers defined by the application. Augment it via declaration merging to type your
+ * own subscriber payloads.
  *
  * @example
  * ```typescript
  * declare module '@seedcord/gateway' {
  *   interface Subscriptions {
- *     'userJoin': { user: User; guild: Guild };
- *     'levelUp': { user: User; level: number; guild: Guild };
+ *     'userJoin': { userId: string; guildId: string };
+ *     'levelUp': { userId: string; level: number };
  *   }
  * }
  * ```
  */
 export interface Subscriptions {}
 
-/**
- * Combined subscribers interface containing both default and custom subscribers.
- */
 export interface AllSubscriptions extends DefaultSubscriptions, Subscriptions {}
 
-/**
- * Helper type to extract all available subscriber event names.
- */
+/** All subscriber event names available to publish and augment. */
 export type SubscriptionKey = keyof AllSubscriptions;
 
 /**
- * Helper type to get parameters for a specific subscriber event.
+ * The payload type for a subscriber event.
  *
  * @typeParam KeyOfSubscribers - The subscriber event name
  */
 export type SubscriptionData<KeyOfSubscribers extends SubscriptionKey> = AllSubscriptions[KeyOfSubscribers];
 
-/**
- * Event map for Bus, compatible with TypedEventEmitter.
- *
- * @internal
- */
+// event map for Bus, compatible with TypedEventEmitter
 export type SubscriptionTuples = {
     [K in SubscriptionKey]: [AllSubscriptions[K]];
 };

--- a/packages/gateway/tests/miscellaneous/extractErrorResponse.test.ts
+++ b/packages/gateway/tests/miscellaneous/extractErrorResponse.test.ts
@@ -1,7 +1,7 @@
 import { Fault, CustomId } from '@seedcord/core';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
-import { extractErrorResponse, faultThrottle } from '@miscellaneous/extractErrorResponse';
+import { extractErrorResponse } from '@miscellaneous/extractErrorResponse';
 
 import { cardJson } from '../utils/cardText';
 import { TestNotice } from '../utils/TestNotice';
@@ -48,11 +48,8 @@ function buttonInteraction(customId: string): Repliables {
     } as unknown as Repliables;
 }
 
+// the module-level throttle persists across tests, so every origin below carries a unique fault key
 describe('extractErrorResponse', () => {
-    beforeEach(() => {
-        faultThrottle.clear();
-    });
-
     it('publishes handledException for a reporting denial with the uuid the reply shows', () => {
         const publish = vi.fn();
         const denial = new Fault({ cause: new Error('write failed') });
@@ -75,9 +72,26 @@ describe('extractErrorResponse', () => {
 
     it('publishes unknownException for a raw, non-denial throw', () => {
         const publish = vi.fn();
-        const result = extractErrorResponse(new Error('a bug'), mockCore(publish), { guild: null, user: null });
+        const result = extractErrorResponse(new Error('a bug'), mockCore(publish), {
+            route: 'raw-probe',
+            guild: null,
+            user: null
+        });
 
         expect(publish).toHaveBeenCalledWith('unknownException', expect.objectContaining({ uuid: result.uuid }));
+    });
+
+    it('publishes scalar guild and user fields, never the discord.js objects', () => {
+        const publish = vi.fn();
+        // justified: the fixtures carry the fields the scalar mapping reads plus djs baggage it must drop
+        const guild = { id: 'g1', name: 'Guild One', members: {} } as unknown as import('discord.js').Guild;
+        const user = { id: 'u1', username: 'uname', client: {} } as unknown as import('discord.js').User;
+
+        extractErrorResponse(new Error('a bug'), mockCore(publish), { route: 'scalar-probe', guild, user });
+
+        const [, payload] = publish.mock.calls[0] as [string, AllSubscriptions['unknownException']];
+        expect(payload.guild).toEqual({ id: 'g1', name: 'Guild One' });
+        expect(payload.user).toEqual({ id: 'u1', username: 'uname' });
     });
 
     it('publishes nothing for a non-reporting denial', () => {
@@ -121,8 +135,8 @@ describe('extractErrorResponse', () => {
     });
 
     it('stamps the throttle on publish, not on webhook send success', () => {
-        // the bus is fire-and-forget, so the second fault is suppressed by the first's publish-time stamp
-        // even though no subscriber send has been observed to succeed (separate spy stands in for a retry).
+        // the stamp lands at publish time, so the first fault suppresses the retry (separate spy)
+        // with no subscriber send observed
         const origin = { interaction: slashInteraction('stamp-probe'), guild: null, user: null };
 
         const firstPublish = vi.fn();

--- a/packages/gateway/tests/subscribers/Bus.once-reentrancy.test.ts
+++ b/packages/gateway/tests/subscribers/Bus.once-reentrancy.test.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto';
 import { describe, it, expect } from 'vitest';
 
 import { Bus } from '../../src/subscribers/Bus';
+import { Subscribe } from '../../src/subscribers/decorators/Subscribe';
 import { Subscriber } from '../../src/subscribers/Subscriber';
 import '../utils/mock-env';
 
@@ -27,6 +28,7 @@ describe("Bus 'once' re-entrancy", () => {
         };
 
         let runs = 0;
+        @Subscribe('unknownException')
         class ReentrantOnce extends Subscriber<'unknownException'> {
             public execute(): Promise<void> {
                 runs += 1;

--- a/packages/gateway/tests/subscribers/Bus.once-reentrancy.test.ts
+++ b/packages/gateway/tests/subscribers/Bus.once-reentrancy.test.ts
@@ -16,23 +16,21 @@ interface PrivateBus {
 
 describe("Bus 'once' re-entrancy", () => {
     it('runs a once subscriber a single time even if it re-publishes the same event', async () => {
-        // justified: minimal Core stub; Bus only reads config.subscribers.path at construction.
+        // justified: minimal Core stub, Bus only reads config.subscribers.path at construction.
         const core = { config: { subscribers: { path: null } } } as unknown as Core;
         const bus = new Bus(core);
         (core as { bus: Bus }).bus = bus;
 
         const payload: AllSubscriptions['unknownException'] = {
             uuid: randomUUID(),
-            error: new Error('boom'),
-            guild: null,
-            user: null
+            error: new Error('boom')
         };
 
         let runs = 0;
         class ReentrantOnce extends Subscriber<'unknownException'> {
             public execute(): Promise<void> {
                 runs += 1;
-                // Re-publish while still "executing": the old fire-then-mark order ran this twice.
+                // re-publish while still executing, the old fire-then-mark order ran this twice
                 if (runs === 1) this.core.bus.publish('unknownException', payload);
                 return Promise.resolve();
             }

--- a/packages/gateway/tests/subscribers/Bus.registration.test.ts
+++ b/packages/gateway/tests/subscribers/Bus.registration.test.ts
@@ -10,6 +10,8 @@ import '../utils/mock-client';
 
 const restMocks = vi.hoisted(() => {
     process.env.MALFORMED_REPORTER_WEBHOOK_URL = 'https://example.com/not-a-webhook';
+    process.env.DUPLICATE_A_WEBHOOK_URL = 'https://discord.com/api/webhooks/9/shared-tok';
+    process.env.DUPLICATE_B_WEBHOOK_URL = 'https://discord.com/api/webhooks/9/shared-tok';
     // hard-assign the default reporter urls, a shell exporting garbage would change the suite
     process.env.UNKNOWN_EXCEPTION_WEBHOOK_URL = 'https://discord.com/api/webhooks/1/aaa';
     process.env.HANDLED_EXCEPTION_WEBHOOK_URL = 'https://discord.com/api/webhooks/2/bbb';
@@ -107,6 +109,40 @@ describe('Bus webhook reporter registration', () => {
         await expect(seedcord.bus.verifyWebhooks()).rejects.toThrow(
             /UNKNOWN_EXCEPTION_WEBHOOK_URL.+HANDLED_EXCEPTION_WEBHOOK_URL/
         );
+    });
+
+    it('names every env key behind one dead url at verify', async () => {
+        await testEnv.createFile(
+            'subscribers/SharedUrlReporters.ts',
+            `
+            import { WebhookLog, WebhookUrl, Subscribe } from '${seedcordPath}';
+
+            @Subscribe('unknownException')
+            @WebhookUrl('DUPLICATE_A_WEBHOOK_URL')
+            export class ReporterA extends WebhookLog<'unknownException'> {
+                public report() {
+                    return { components: [] };
+                }
+            }
+
+            @Subscribe('unknownException')
+            @WebhookUrl('DUPLICATE_B_WEBHOOK_URL')
+            export class ReporterB extends WebhookLog<'unknownException'> {
+                public report() {
+                    return { components: [] };
+                }
+            }
+            `
+        );
+
+        seedcord = new Seedcord(testConfig({ subscribers: testEnv.resolvePath('subscribers') }));
+        await seedcord.bus.init();
+
+        const { DiscordAPIError } = await import('@discordjs/rest');
+        restMocks.getMock.mockRejectedValue(
+            new DiscordAPIError({ message: 'Unknown Webhook', code: 10_015 }, 10_015, 404, 'GET', 'url', {})
+        );
+        await expect(seedcord.bus.verifyWebhooks()).rejects.toThrow(/DUPLICATE_A_WEBHOOK_URL.+DUPLICATE_B_WEBHOOK_URL/);
     });
 
     it('warns and continues when discord is unreachable at verify', async () => {

--- a/packages/gateway/tests/subscribers/Bus.registration.test.ts
+++ b/packages/gateway/tests/subscribers/Bus.registration.test.ts
@@ -44,6 +44,8 @@ describe('Bus webhook reporter registration', () => {
     afterEach(async () => {
         await testEnv.teardown();
         vi.clearAllMocks();
+        // clearAllMocks keeps implementations, a rejecting getMock must never leak into the next test
+        restMocks.getMock.mockReset().mockResolvedValue({});
     });
 
     it('warns and skips a reporter whose env var is unset', async () => {
@@ -101,8 +103,10 @@ describe('Bus webhook reporter registration', () => {
         restMocks.getMock.mockRejectedValue(
             new DiscordAPIError({ message: 'Unknown Webhook', code: 10_015 }, 10_015, 404, 'GET', 'url', {})
         );
-        await expect(seedcord.bus.verifyWebhooks()).rejects.toThrow(/does not exist/);
-        restMocks.getMock.mockReset().mockResolvedValue({});
+        // one boot reports every dead webhook, both default urls are mocked dead here
+        await expect(seedcord.bus.verifyWebhooks()).rejects.toThrow(
+            /UNKNOWN_EXCEPTION_WEBHOOK_URL.+HANDLED_EXCEPTION_WEBHOOK_URL/
+        );
     });
 
     it('warns and continues when discord is unreachable at verify', async () => {
@@ -113,7 +117,6 @@ describe('Bus webhook reporter registration', () => {
         const warnSpy = vi.spyOn(seedcord.bus.logger, 'warn');
         await expect(seedcord.bus.verifyWebhooks()).resolves.toBeUndefined();
         expect(warnSpy).toHaveBeenCalled();
-        restMocks.getMock.mockReset().mockResolvedValue({});
     });
 
     it('throws at boot for a WebhookLog subclass without @WebhookUrl', async () => {

--- a/packages/gateway/tests/subscribers/Bus.registration.test.ts
+++ b/packages/gateway/tests/subscribers/Bus.registration.test.ts
@@ -1,0 +1,137 @@
+import path from 'node:path';
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import { Seedcord } from '../../src/Seedcord';
+import { testConfig } from '../utils/test-config';
+import { TestEnvironment } from '../utils/test-env';
+
+import '../utils/mock-client';
+
+const restMocks = vi.hoisted(() => {
+    process.env.MALFORMED_REPORTER_WEBHOOK_URL = 'https://example.com/not-a-webhook';
+    // hard-assign the default reporter urls, a shell exporting garbage would change the suite
+    process.env.UNKNOWN_EXCEPTION_WEBHOOK_URL = 'https://discord.com/api/webhooks/1/aaa';
+    process.env.HANDLED_EXCEPTION_WEBHOOK_URL = 'https://discord.com/api/webhooks/2/bbb';
+    return { getMock: vi.fn().mockResolvedValue({}), postMock: vi.fn().mockResolvedValue(undefined) };
+});
+
+vi.mock('@discordjs/rest', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('@discordjs/rest')>()),
+    REST: class {
+        get = restMocks.getMock;
+        post = restMocks.postMock;
+    }
+}));
+
+const seedcordPath = path.resolve(__dirname, '../../src/index').replaceAll('\\', '/');
+
+interface PrivateBus {
+    subscribersMap: Map<string, { ctor: unknown }[]>;
+}
+
+describe('Bus webhook reporter registration', () => {
+    let testEnv: TestEnvironment;
+    let seedcord: Seedcord;
+
+    beforeEach(async () => {
+        // @ts-expect-error: Accessing private method for testing
+        Seedcord.reset();
+        testEnv = new TestEnvironment('webhook-registration-test-');
+        await testEnv.setup();
+    });
+
+    afterEach(async () => {
+        await testEnv.teardown();
+        vi.clearAllMocks();
+    });
+
+    it('warns and skips a reporter whose env var is unset', async () => {
+        await testEnv.createFile(
+            'subscribers/QuietReporter.ts',
+            `
+            import { WebhookLog, WebhookUrl, Subscribe } from '${seedcordPath}';
+
+            @Subscribe('unknownException')
+            @WebhookUrl('UNSET_REPORTER_WEBHOOK_URL')
+            export class QuietReporter extends WebhookLog<'unknownException'> {
+                public report() {
+                    return { components: [] };
+                }
+            }
+            `
+        );
+
+        seedcord = new Seedcord(testConfig({ subscribers: testEnv.resolvePath('subscribers') }));
+        const warnSpy = vi.spyOn(seedcord.bus.logger, 'warn');
+        await seedcord.bus.init();
+
+        // justified: PrivateBus exposes the private subscribersMap for assertion
+        const bus = seedcord.bus as unknown as PrivateBus;
+        // the default UnknownException only, the url-less reporter is skipped
+        expect(bus.subscribersMap.get('unknownException')).toHaveLength(1);
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('UNSET_REPORTER_WEBHOOK_URL'));
+    });
+
+    it('throws at boot when a reporter env var is set but malformed', async () => {
+        await testEnv.createFile(
+            'subscribers/BadUrlReporter.ts',
+            `
+            import { WebhookLog, WebhookUrl, Subscribe } from '${seedcordPath}';
+
+            @Subscribe('unknownException')
+            @WebhookUrl('MALFORMED_REPORTER_WEBHOOK_URL')
+            export class BadUrlReporter extends WebhookLog<'unknownException'> {
+                public report() {
+                    return { components: [] };
+                }
+            }
+            `
+        );
+
+        seedcord = new Seedcord(testConfig({ subscribers: testEnv.resolvePath('subscribers') }));
+        await expect(seedcord.bus.init()).rejects.toThrow('MALFORMED_REPORTER_WEBHOOK_URL');
+    });
+
+    it('throws at verify when a configured webhook does not exist on discord', async () => {
+        seedcord = new Seedcord(testConfig({}));
+        await seedcord.bus.init();
+
+        const { DiscordAPIError } = await import('@discordjs/rest');
+        restMocks.getMock.mockRejectedValue(
+            new DiscordAPIError({ message: 'Unknown Webhook', code: 10_015 }, 10_015, 404, 'GET', 'url', {})
+        );
+        await expect(seedcord.bus.verifyWebhooks()).rejects.toThrow(/does not exist/);
+        restMocks.getMock.mockReset().mockResolvedValue({});
+    });
+
+    it('warns and continues when discord is unreachable at verify', async () => {
+        seedcord = new Seedcord(testConfig({}));
+        await seedcord.bus.init();
+
+        restMocks.getMock.mockRejectedValue(new TypeError('fetch failed'));
+        const warnSpy = vi.spyOn(seedcord.bus.logger, 'warn');
+        await expect(seedcord.bus.verifyWebhooks()).resolves.toBeUndefined();
+        expect(warnSpy).toHaveBeenCalled();
+        restMocks.getMock.mockReset().mockResolvedValue({});
+    });
+
+    it('throws at boot for a WebhookLog subclass without @WebhookUrl', async () => {
+        await testEnv.createFile(
+            'subscribers/UndeclaredReporter.ts',
+            `
+            import { WebhookLog, Subscribe } from '${seedcordPath}';
+
+            @Subscribe('unknownException')
+            export class UndeclaredReporter extends WebhookLog<'unknownException'> {
+                public report() {
+                    return { components: [] };
+                }
+            }
+            `
+        );
+
+        seedcord = new Seedcord(testConfig({ subscribers: testEnv.resolvePath('subscribers') }));
+        await expect(seedcord.bus.init()).rejects.toThrow('UndeclaredReporter');
+    });
+});

--- a/packages/gateway/tests/subscribers/HandledException.test.ts
+++ b/packages/gateway/tests/subscribers/HandledException.test.ts
@@ -1,12 +1,15 @@
 import '../utils/mock-env';
 
+import { randomUUID } from 'node:crypto';
+
 import { Notice } from '@seedcord/core';
 import { describe, expect, it } from 'vitest';
 
-import { causeStack, faultSummary } from '@subscribers/default/HandledException';
+import { HandledException } from '@subscribers/default/HandledException';
 
+import type { Core } from '@interfaces/Core';
 import type { ReplyResponse } from '@seedcord/types';
-import type { EventFaultSource, InteractionFaultSource } from '@subscribers/types/Subscriptions';
+import type { EventFaultSource, FaultSource, InteractionFaultSource } from '@subscribers/types/Subscriptions';
 
 class TestFault extends Notice {
     constructor(message = 'boom', cause?: unknown) {
@@ -39,41 +42,46 @@ const eventSource: EventFaultSource = {
     raw: []
 };
 
-describe('faultSummary', () => {
+// justified: the Subscriber base only stores core
+const core = {} as unknown as Core;
+
+function reportText(denial: Notice, source: FaultSource): string {
+    const report = new HandledException({ denial, uuid: randomUUID(), source }, core).report();
+    return JSON.stringify(report.components.map((component) => component.toJSON()));
+}
+
+describe('HandledException.report', () => {
     it('renders the command and customId for an interaction source', () => {
-        const summary = faultSummary(new TestFault(), interactionSource);
-        expect(summary).toContain('**Command:** ban');
-        expect(summary).toContain('**Interaction ID:** `i1`');
-        expect(summary).not.toContain('**Event:**');
+        const text = reportText(new TestFault(), interactionSource);
+        expect(text).toContain('**Command:** ban');
+        expect(text).toContain('**Interaction ID:** `i1`');
+        expect(text).not.toContain('**Event:**');
     });
 
     it('renders the event name and handler for an event source, with nullable fallbacks', () => {
-        const summary = faultSummary(new TestFault(), eventSource);
-        expect(summary).toContain('**Event:** messageCreate');
-        expect(summary).toContain('**Handler:** Starboard');
-        expect(summary).toContain('**User ID:** `n/a`');
-        expect(summary).toContain('**Channel ID:** `n/a`');
-        expect(summary).not.toContain('**Interaction ID:**');
-    });
-});
-
-describe('causeStack', () => {
-    it('uses an Error cause stack', () => {
-        const cause = new Error('driver down');
-        expect(causeStack(new TestFault('x', cause))).toBe(cause.stack);
+        const text = reportText(new TestFault(), eventSource);
+        expect(text).toContain('**Event:** messageCreate');
+        expect(text).toContain('**Handler:** Starboard');
+        expect(text).toContain('**User ID:** `n/a`');
+        expect(text).toContain('**Channel ID:** `n/a`');
+        expect(text).not.toContain('**Interaction ID:**');
     });
 
-    it('returns a string cause as-is', () => {
-        expect(causeStack(new TestFault('x', 'plain reason'))).toBe('plain reason');
+    it('shows an Error cause stack', () => {
+        expect(reportText(new TestFault('x', new Error('driver down')), interactionSource)).toContain('driver down');
+    });
+
+    it('shows a string cause as-is', () => {
+        expect(reportText(new TestFault('x', 'plain reason'), interactionSource)).toContain('plain reason');
     });
 
     it('does not throw on a bigint cause', () => {
-        expect(causeStack(new TestFault('x', 10n))).toBe('10');
+        expect(reportText(new TestFault('x', 10_987_654_321n), interactionSource)).toContain('10987654321');
     });
 
     it('does not throw on a circular-object cause', () => {
         const circular: Record<string, unknown> = {};
         circular.self = circular;
-        expect(() => causeStack(new TestFault('x', circular))).not.toThrow();
+        expect(() => reportText(new TestFault('x', circular), interactionSource)).not.toThrow();
     });
 });

--- a/packages/gateway/tests/subscribers/WebhookLog.test.ts
+++ b/packages/gateway/tests/subscribers/WebhookLog.test.ts
@@ -3,6 +3,7 @@ import { ComponentType } from 'discord-api-types/v10';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 
 import { WebhookLog } from '@subscribers/bases/WebhookLog';
+import { Subscribe } from '@subscribers/decorators/Subscribe';
 import { WebhookUrl } from '@subscribers/decorators/WebhookUrl';
 
 import type { Core } from '@interfaces/Core';
@@ -38,6 +39,7 @@ beforeEach(() => {
 
 describe('WebhookLog', () => {
     it('sends the report to the url from the decorated env key', async () => {
+        @Subscribe('unknownException')
         @WebhookUrl('REPORTER_WEBHOOK_URL')
         class CustomReporter extends WebhookLog<'unknownException'> {
             report(): WebhookReport {
@@ -53,6 +55,7 @@ describe('WebhookLog', () => {
     });
 
     it('defaults the username to the class name', async () => {
+        @Subscribe('unknownException')
         @WebhookUrl('REPORTER_WEBHOOK_URL')
         class NamedReporter extends WebhookLog<'unknownException'> {
             report(): WebhookReport {
@@ -67,6 +70,7 @@ describe('WebhookLog', () => {
     });
 
     it('reuses one sender per url across instances', async () => {
+        @Subscribe('unknownException')
         @WebhookUrl('REPORTER_REUSE_WEBHOOK_URL')
         class RepeatReporter extends WebhookLog<'unknownException'> {
             report(): WebhookReport {
@@ -84,6 +88,7 @@ describe('WebhookLog', () => {
     });
 
     it('logs a send failure and resolves', async () => {
+        @Subscribe('unknownException')
         @WebhookUrl('REPORTER_WEBHOOK_URL')
         class FailingReporter extends WebhookLog<'unknownException'> {
             report(): WebhookReport {
@@ -100,6 +105,7 @@ describe('WebhookLog', () => {
     });
 
     it('warns and drops the report when the env var is unset', async () => {
+        @Subscribe('unknownException')
         @WebhookUrl('NEVER_SET_WEBHOOK_URL')
         class UnsetReporter extends WebhookLog<'unknownException'> {
             report(): WebhookReport {
@@ -116,6 +122,8 @@ describe('WebhookLog', () => {
     });
 
     it('throws at execute when the decorator is missing', async () => {
+        @Subscribe('unknownException')
+        // eslint-disable-next-line @seedcord/subscriber-missing-decorators -- the missing @WebhookUrl is the case under test
         class UndeclaredReporter extends WebhookLog<'unknownException'> {
             report(): WebhookReport {
                 return { components: [] };

--- a/packages/gateway/tests/subscribers/WebhookLog.test.ts
+++ b/packages/gateway/tests/subscribers/WebhookLog.test.ts
@@ -1,0 +1,127 @@
+import { Logger } from '@seedcord/logger';
+import { ComponentType } from 'discord-api-types/v10';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import { WebhookLog } from '@subscribers/bases/WebhookLog';
+import { WebhookUrl } from '@subscribers/decorators/WebhookUrl';
+
+import type { Core } from '@interfaces/Core';
+import type { WebhookReport } from '@subscribers/bases/WebhookLog';
+import type { AllSubscriptions } from '@subscribers/types/Subscriptions';
+import type { APIMessageTopLevelComponent } from 'discord-api-types/v10';
+
+const hoisted = vi.hoisted(() => {
+    process.env.REPORTER_WEBHOOK_URL = 'https://discord.com/api/webhooks/77/tok-en';
+    process.env.REPORTER_REUSE_WEBHOOK_URL = 'https://discord.com/api/webhooks/88/reuse-tok';
+    return { postMock: vi.fn(), restConstructions: { count: 0 } };
+});
+
+vi.mock('@discordjs/rest', () => ({
+    REST: class {
+        post = hoisted.postMock;
+        constructor() {
+            hoisted.restConstructions.count += 1;
+        }
+    }
+}));
+
+// justified: report() under test ignores the payload
+const data = {} as unknown as AllSubscriptions['unknownException'];
+// justified: the Subscriber base only stores core
+const core = {} as unknown as Core;
+
+const component = { toJSON: (): APIMessageTopLevelComponent => ({ type: ComponentType.Container, components: [] }) };
+
+beforeEach(() => {
+    hoisted.postMock.mockReset().mockResolvedValue(undefined);
+});
+
+describe('WebhookLog', () => {
+    it('sends the report to the url from the decorated env key', async () => {
+        @WebhookUrl('REPORTER_WEBHOOK_URL')
+        class CustomReporter extends WebhookLog<'unknownException'> {
+            report(): WebhookReport {
+                return { username: 'Custom', components: [component] };
+            }
+        }
+
+        await new CustomReporter(data, core).execute();
+
+        const [route, options] = hoisted.postMock.mock.calls[0] as [string, { body: { username: string } }];
+        expect(route).toBe('/webhooks/77/tok-en');
+        expect(options.body.username).toBe('Custom');
+    });
+
+    it('defaults the username to the class name', async () => {
+        @WebhookUrl('REPORTER_WEBHOOK_URL')
+        class NamedReporter extends WebhookLog<'unknownException'> {
+            report(): WebhookReport {
+                return { components: [component] };
+            }
+        }
+
+        await new NamedReporter(data, core).execute();
+
+        const [, options] = hoisted.postMock.mock.calls[0] as [string, { body: { username: string } }];
+        expect(options.body.username).toBe('NamedReporter');
+    });
+
+    it('reuses one sender per url across instances', async () => {
+        @WebhookUrl('REPORTER_REUSE_WEBHOOK_URL')
+        class RepeatReporter extends WebhookLog<'unknownException'> {
+            report(): WebhookReport {
+                return { components: [] };
+            }
+        }
+
+        const before = hoisted.restConstructions.count;
+        await new RepeatReporter(data, core).execute();
+        expect(hoisted.restConstructions.count - before).toBe(1);
+        await new RepeatReporter(data, core).execute();
+
+        expect(hoisted.postMock).toHaveBeenCalledTimes(2);
+        expect(hoisted.restConstructions.count - before).toBe(1);
+    });
+
+    it('logs a send failure and resolves', async () => {
+        @WebhookUrl('REPORTER_WEBHOOK_URL')
+        class FailingReporter extends WebhookLog<'unknownException'> {
+            report(): WebhookReport {
+                return { components: [] };
+            }
+        }
+
+        hoisted.postMock.mockRejectedValueOnce(new Error('down'));
+        const errorSpy = vi.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+
+        await expect(new FailingReporter(data, core).execute()).resolves.toBeUndefined();
+        expect(errorSpy).toHaveBeenCalled();
+        errorSpy.mockRestore();
+    });
+
+    it('warns and drops the report when the env var is unset', async () => {
+        @WebhookUrl('NEVER_SET_WEBHOOK_URL')
+        class UnsetReporter extends WebhookLog<'unknownException'> {
+            report(): WebhookReport {
+                return { components: [] };
+            }
+        }
+
+        const warnSpy = vi.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+
+        await expect(new UnsetReporter(data, core).execute()).resolves.toBeUndefined();
+        expect(hoisted.postMock).not.toHaveBeenCalled();
+        expect(warnSpy).toHaveBeenCalled();
+        warnSpy.mockRestore();
+    });
+
+    it('throws at execute when the decorator is missing', async () => {
+        class UndeclaredReporter extends WebhookLog<'unknownException'> {
+            report(): WebhookReport {
+                return { components: [] };
+            }
+        }
+
+        await expect(new UndeclaredReporter(data, core).execute()).rejects.toThrow();
+    });
+});

--- a/packages/gateway/tests/subscribers/WebhookSender.test.ts
+++ b/packages/gateway/tests/subscribers/WebhookSender.test.ts
@@ -1,0 +1,97 @@
+import { ComponentType } from 'discord-api-types/v10';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import { WebhookSender } from '@subscribers/bases/WebhookSender';
+
+import type { APIMessageTopLevelComponent } from 'discord-api-types/v10';
+
+const mocks = vi.hoisted(() => ({
+    postMock: vi.fn().mockResolvedValue(undefined),
+    getMock: vi.fn().mockResolvedValue({})
+}));
+const { postMock, getMock } = mocks;
+
+vi.mock('@discordjs/rest', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('@discordjs/rest')>()),
+    REST: class {
+        post = mocks.postMock;
+        get = mocks.getMock;
+    }
+}));
+
+beforeEach(() => {
+    postMock.mockClear();
+    getMock.mockReset().mockResolvedValue({});
+});
+
+describe('WebhookSender', () => {
+    it('throws on a url without a webhook id and token', () => {
+        expect(() => new WebhookSender('https://example.com/not-a-webhook')).toThrow();
+    });
+
+    it('posts components and file metadata to the webhook route without auth', async () => {
+        const sender = new WebhookSender('https://discord.com/api/webhooks/123/abc-XY');
+        await sender.send({
+            flags: 32_768,
+            username: 'Unknown Exception',
+            components: [
+                { toJSON: (): APIMessageTopLevelComponent => ({ type: ComponentType.Container, components: [] }) }
+            ],
+            files: [{ name: 'metadata.json', description: 'error metadata', data: Buffer.from('{}') }]
+        });
+
+        expect(postMock).toHaveBeenCalledTimes(1);
+        const [route, options] = postMock.mock.calls[0] as [string, Record<string, unknown>];
+        expect(route).toBe('/webhooks/123/abc-XY');
+        expect(options.auth).toBe(false);
+        expect(String(options.query)).toContain('with_components=true');
+        expect(options.body).toEqual({
+            flags: 32_768,
+            username: 'Unknown Exception',
+            components: [{ type: ComponentType.Container, components: [] }],
+            attachments: [{ id: 0, filename: 'metadata.json', description: 'error metadata' }]
+        });
+        expect(options.files).toEqual([{ name: 'metadata.json', data: Buffer.from('{}') }]);
+    });
+
+    it('omits attachments and files when no files are given', async () => {
+        const sender = new WebhookSender('https://discord.com/api/webhooks/123/abc-XY');
+        await sender.send({ flags: 32_768, username: 'Handled Exception', components: [] });
+
+        const [, options] = postMock.mock.calls[0] as [string, Record<string, unknown>];
+        expect(options.body).toEqual({ flags: 32_768, username: 'Handled Exception', components: [] });
+        expect(options.files).toBeUndefined();
+    });
+});
+
+describe('WebhookSender.verify', () => {
+    const sender = (): WebhookSender => new WebhookSender('https://discord.com/api/webhooks/123/abc-XY');
+
+    it('resolves ok when the webhook answers', async () => {
+        await expect(sender().verify()).resolves.toBe('ok');
+        const [route, options] = getMock.mock.calls[0] as [string, Record<string, unknown>];
+        expect(route).toBe('/webhooks/123/abc-XY');
+        expect(options.auth).toBe(false);
+    });
+
+    it('resolves missing on a 404 from discord', async () => {
+        const { DiscordAPIError } = await import('@discordjs/rest');
+        getMock.mockRejectedValueOnce(
+            new DiscordAPIError({ message: 'Unknown Webhook', code: 10_015 }, 10_015, 404, 'GET', 'url', {})
+        );
+        await expect(sender().verify()).resolves.toBe('missing');
+    });
+
+    it('resolves missing on a 401 from discord', async () => {
+        const { DiscordAPIError } = await import('@discordjs/rest');
+        getMock.mockRejectedValueOnce(
+            new DiscordAPIError({ message: 'Invalid Webhook Token', code: 50_027 }, 50_027, 401, 'GET', 'url', {})
+        );
+        await expect(sender().verify()).resolves.toBe('missing');
+    });
+
+    it('resolves unreachable on a network failure', async () => {
+        getMock.mockRejectedValueOnce(new TypeError('fetch failed'));
+        await expect(sender().verify()).resolves.toBe('unreachable');
+    });
+});

--- a/packages/seedcord/package.json
+++ b/packages/seedcord/package.json
@@ -54,7 +54,7 @@
     "dependencies": {
         "@clack/prompts": "^1.6.0",
         "@commander-js/extra-typings": "^15.0.0",
-        "@discordjs/rest": "^2.6.1",
+        "@discordjs/rest": "catalog:deps",
         "@seedcord/core": "workspace:*",
         "@seedcord/errors": "workspace:*",
         "@seedcord/event-emitter": "workspace:*",

--- a/packages/utils/src/numbers/index.ts
+++ b/packages/utils/src/numbers/index.ts
@@ -5,4 +5,5 @@ export * from './parseDuration';
 export * from './percentage';
 export * from './round';
 export * from './roundToDenomination';
+export * from './timestampFromSnowflake';
 export * from './toEpochSeconds';

--- a/packages/utils/src/numbers/timestampFromSnowflake.ts
+++ b/packages/utils/src/numbers/timestampFromSnowflake.ts
@@ -3,6 +3,11 @@ import type { EpochMs } from '@seedcord/types';
 const DISCORD_EPOCH_MS = 1_420_070_400_000n; // 2015-01-01
 const TIMESTAMP_SHIFT = 22n; // the top 42 bits of a snowflake carry the timestamp
 
+/**
+ * Milliseconds since the unix epoch encoded in a Discord snowflake.
+ *
+ * @throws A `SyntaxError` when the input is a non-numeric string.
+ */
 export function timestampFromSnowflake(snowflake: string): EpochMs {
     return Number((BigInt(snowflake) >> TIMESTAMP_SHIFT) + DISCORD_EPOCH_MS) as EpochMs;
 }

--- a/packages/utils/src/numbers/timestampFromSnowflake.ts
+++ b/packages/utils/src/numbers/timestampFromSnowflake.ts
@@ -1,0 +1,8 @@
+import type { EpochMs } from '@seedcord/types';
+
+const DISCORD_EPOCH_MS = 1_420_070_400_000n; // 2015-01-01
+const TIMESTAMP_SHIFT = 22n; // the top 42 bits of a snowflake carry the timestamp
+
+export function timestampFromSnowflake(snowflake: string): EpochMs {
+    return Number((BigInt(snowflake) >> TIMESTAMP_SHIFT) + DISCORD_EPOCH_MS) as EpochMs;
+}

--- a/packages/utils/tests/numbers/timestampFromSnowflake.test.ts
+++ b/packages/utils/tests/numbers/timestampFromSnowflake.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { timestampFromSnowflake } from '../../src/numbers/timestampFromSnowflake';
+
+describe('timestampFromSnowflake', () => {
+    it('decodes the discord docs example snowflake', () => {
+        expect(timestampFromSnowflake('175928847299117063')).toBe(1_462_015_105_796);
+    });
+
+    it('decodes a snowflake minted at the discord epoch', () => {
+        expect(timestampFromSnowflake('0')).toBe(1_420_070_400_000);
+    });
+
+    it('throws on a non-numeric string', () => {
+        expect(() => timestampFromSnowflake('not-a-snowflake')).toThrow(SyntaxError);
+    });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,9 @@ catalogs:
     '@discordjs/builders':
       specifier: ^1.14.1
       version: 1.14.1
+    '@discordjs/rest':
+      specifier: ^2.6.1
+      version: 2.6.1
     '@tailwindcss/postcss':
       specifier: ^4.3.1
       version: 4.3.1
@@ -850,6 +853,9 @@ importers:
       '@discordjs/builders':
         specifier: catalog:deps
         version: 1.14.1
+      '@discordjs/rest':
+        specifier: catalog:deps
+        version: 2.6.1
       '@seedcord/core':
         specifier: workspace:*
         version: link:../core
@@ -877,6 +883,9 @@ importers:
       chalk:
         specifier: catalog:deps
         version: 5.6.2
+      discord-api-types:
+        specifier: ^0.38.49
+        version: 0.38.49
       envapt:
         specifier: catalog:deps
         version: 8.0.0
@@ -1026,7 +1035,7 @@ importers:
         specifier: ^15.0.0
         version: 15.0.0(commander@15.0.0)
       '@discordjs/rest':
-        specifier: ^2.6.1
+        specifier: catalog:deps
         version: 2.6.1
       '@seedcord/core':
         specifier: workspace:*

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,6 +26,7 @@ allowBuilds:
 catalogs:
     deps:
         '@discordjs/builders': ^1.14.1
+        '@discordjs/rest': ^2.6.1
         '@tailwindcss/postcss': ^4.3.1
         '@types/node': ^25.9.3
         chalk: ^5.6.2


### PR DESCRIPTION
- Subscriber files contain no imports from discord.js. Reporters send through `@discordjs/rest` (`WebhookSender`), snowflake timestamps use the new `timestampFromSnowflake` in `@seedcord/utils`, and `flagsFor` plus the separator consume `discord-api-types/v10`.
- `WebhookLog` handles the webhook flow. A reporter requires `@Subscribe(key)` + `@WebhookUrl('ENV_KEY')` + a `report()` method returning `{ username?, components, files? }`. The base validates the URL at initialization, maintains one sender per URL, sets `username` to the class name by default, and tracks send failures.
- Webhook URLs are optional. An unset environment variable disables that reporter with an initialization warning. A malformed value raises an error at initialization, and a `WebhookLog` subclass without `@WebhookUrl` raises an error at registration. The initialization-time requirement of `UNKNOWN_EXCEPTION_WEBHOOK_URL` and `HANDLED_EXCEPTION_WEBHOOK_URL` is removed; the names remain unchanged.
- Each configured webhook receives a token-authorized GET probe at initialization (no message is sent). An invalid webhook halts initialization with `ConfigWebhookNotFound`, an unreachable Discord service emits a warning and initialization continues. The probe is skipped in the test environment.
- **BREAKING** the `unknownException` payload includes `guild?: { id, name }` and `user?: { id, username }`, with each key omitted when absent.
- **BREAKING** a `WebhookLog` subclass implements `report()` and includes `@WebhookUrl`. The abstract `webhook` field is removed.
- **BREAKING** `@seedcord/errors` replaces the four per-reporter webhook codes with `ConfigWebhookUrlInvalid` and `DecoratorWebhookUrlMissing`, and renumbers the Config block.
- `@discordjs/rest` moves to the workspace catalog, `@seedcord/gateway` adds it and `discord-api-types` as direct dependencies.
- New `@seedcord/eslint-plugin` rule `subscriber-missing-decorators`, enabled in the recommended preset. A concrete `Subscriber` without `@Subscribe` and a `WebhookLog` without `@WebhookUrl` are lint errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added webhook reporting via `@WebhookUrl`, including URL validation, startup probing, attachment support, and webhook sender reuse.
  * Added `subscriber-missing-decorators` ESLint rule for missing `@Subscribe` / `@WebhookUrl`.
  * Added `timestampFromSnowflake` utility.

* **Breaking Changes**
  * Webhook reporters now implement `report()` and must use `@WebhookUrl`; missing/malformed configuration fails at boot.
  * Removed `AllSubscriptions`.
  * Updated `unknownException` payload `guild`/`user` to scalar projections.

* **Bug Fixes**
  * Improved webhook verification and error-code/message handling for invalid/missing/unreachable cases.

* **Documentation**
  * Updated docs for the new decorator rule and origin-based decorator matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->