### PR TITLE
feat: guide mdx kit

### DIFF
--- a/apps/docs/src/app/globals.css
+++ b/apps/docs/src/app/globals.css
@@ -24,7 +24,7 @@
     }
 }
 
-/* need to make sure both are using 'inline' otherwise the logo shifts when switching modes */
+/* both stay inline or the logo shifts when the theme flips */
 .readme-img-light {
     display: inline;
 }
@@ -38,10 +38,9 @@
     display: inline;
 }
 
-/* Cross-package/external indicator, emitted by decorateProseLinks (prose) and the SeeAlso /
- * inheritedFrom anchors. code-block links open in a new tab without this glyph. nowrap keeps the
- * glyph on the link's last line. */
+/* decorateProseLinks, SeeAlso, and the inheritedFrom anchors set this class on a cross-package or external link */
 a.cross-ref {
+    /* keeps the glyph on the link's last line */
     white-space: nowrap;
 }
 

--- a/apps/docs/src/app/globals.css
+++ b/apps/docs/src/app/globals.css
@@ -2,15 +2,8 @@
 @import '../styles/tokens.css';
 @import '../styles/utilities.css';
 
-/* one knob for all docs rounding. chips need to be 2px tighter */
 :root {
-    --radius-surface: 0.375rem;
     --nav-h: 4.5rem; /* fallback until the navbar measures its own height */
-}
-@theme {
-    --radius-sm: calc(var(--radius-surface) - 0.125rem);
-    --radius-md: var(--radius-surface);
-    --radius-lg: var(--radius-surface);
 }
 
 @layer base {

--- a/apps/docs/src/components/docs/ReadmeBlock.tsx
+++ b/apps/docs/src/components/docs/ReadmeBlock.tsx
@@ -10,7 +10,7 @@ const readmeProseClassName = cn(
     tw`[&_h4]:mt-4 [&_h4]:mb-2 [&_h4]:text-base [&_h4]:font-semibold [&_h4]:text-(--text)`,
     tw`[&_p]:my-3 [&_p]:leading-relaxed`,
     tw`[&_strong]:font-semibold [&_strong]:text-(--text)`,
-    tw`[&_a]:text-(--rind) [&_a]:underline [&_a]:underline-offset-2 [&_a:hover]:opacity-80`,
+    tw`[&_a]:text-(--link) [&_a]:underline [&_a]:underline-offset-2 [&_a]:transition-opacity [&_a]:duration-150 [&_a:hover]:opacity-80`,
     tw`[&_ul]:my-3 [&_ul]:list-disc [&_ul]:space-y-1 [&_ul]:pl-6`,
     tw`[&_ol]:my-3 [&_ol]:list-decimal [&_ol]:space-y-1 [&_ol]:pl-6`,
     tw`[&_li]:leading-relaxed`,

--- a/apps/docs/src/components/header/Navbar.tsx
+++ b/apps/docs/src/components/header/Navbar.tsx
@@ -52,7 +52,6 @@ export function Navbar(): ReactElement {
             actions={
                 <>
                     <SearchIconButton label={SEARCH_LABEL} onOpen={openSearch} />
-                    <ThemeToggle />
                     {/* the burger panel's footer repeats these two */}
                     <span className={cn(showMobileNavButton ? 'hidden lg:flex' : 'flex', 'items-center gap-2')}>
                         <HeaderSettingsPopover />
@@ -68,6 +67,8 @@ export function Navbar(): ReactElement {
                             </Link>
                         </Button>
                     </span>
+                    {/* moving this into the span above loses it on mobile */}
+                    <ThemeToggle />
                     {showMobileNavButton ? (
                         <MobileNavButton
                             open={isMobileNavOpen}

--- a/apps/guide/content/docs/index.mdx
+++ b/apps/guide/content/docs/index.mdx
@@ -74,6 +74,19 @@ A callout takes whole blocks, so a fence sits inside one.
 
 </Callout>
 
+## Reference links
+
+A named symbol links out to the reference site, and the slug comes off the name. A gate refuses by throwing
+
+<Ref pkg="core">Notice</Ref> or <Ref pkg="core">Silence</Ref>, and anything unexpected becomes a
+<Ref pkg="core">Fault</Ref>.
+
+A multi-word name kebab-cases itself, so <Ref pkg="gateway">SlashHandler</Ref> reaches `slash-handler`. A dotted member nests, so <Ref pkg="core">Paginator.start</Ref> reaches `paginator/start`. A generic drops off the end, so
+
+<Ref pkg="core">{'Plugin<Options>'}</Ref> and <Ref pkg="core">Plugin</Ref> land on the same page.
+
+Each package is its own argument, so <Ref pkg="http">createSeedcord</Ref> and <Ref pkg="gateway">Seedcord</Ref> point at two sites of the same idea. Every one of these opens in a new tab.
+
 ## Lists
 
 Three things ship with every command:

--- a/apps/guide/content/docs/index.mdx
+++ b/apps/guide/content/docs/index.mdx
@@ -34,6 +34,39 @@ A wrong option name is a compile error, before the bot ever connects. **Acking t
 
 The handler validates the layout hash after the route loads. h4 is as deep as the guide goes, and a page writing an h1, h5, or h6 fails the build.
 
+## Callouts
+
+<Callout type="note">Codegen runs before the first command typechecks.</Callout>
+
+<Callout type="tip">Name the route once and both the builder and the handler follow it.</Callout>
+
+<Callout type="warning">Discord gives you three seconds to answer an interaction.</Callout>
+
+<Callout type="danger">Acking twice throws `ReplyIllegalAckState` and the reply never arrives.</Callout>
+
+A transport difference runs one way or both ways, and the label says which.
+
+<Callout type="transport" only="gateway">
+    `getConfirmation` holds a collector in process, which an http bot has nowhere to keep.
+</Callout>
+
+<Callout type="transport" only="http">
+    Discord signs every request, and the receiver verifies the Ed25519 header before anything else runs.
+</Callout>
+
+<Callout type="transport">`getUser` returns a live discord.js `User` on gateway and a raw `APIUser` on http.</Callout>
+
+A callout takes whole blocks, so a fence sits inside one.
+
+<Callout type="tip">
+    Both mocks ship this command already.
+
+    ```ts title="src/commands/Ping.ts"
+    await this.reply('Pong');
+    ```
+
+</Callout>
+
 ## Lists
 
 Three things ship with every command:

--- a/apps/guide/content/docs/index.mdx
+++ b/apps/guide/content/docs/index.mdx
@@ -26,6 +26,13 @@ A fence with no `title` keeps its header, since the copy button lives there.
 pnpm add @seedcord/gateway
 ```
 
+Tagging a fence `output` drops the copy button, for the lines a terminal printed back.
+
+```sh output
+✓ 12 routes written to .seedcord/manifest.ts
+✓ 3 commands deployed to the test guild
+```
+
 ### Options come off the registry
 
 A wrong option name is a compile error, before the bot ever connects. **Acking twice throws.** Discord accepts one initial response per interaction, and seedcord surfaces the second attempt as `ReplyIllegalAckState` before it reaches the API. Read the [reference site](https://docs.seedcord.org) for the full code list, or _skim_ the reply page first.

--- a/apps/guide/content/docs/index.mdx
+++ b/apps/guide/content/docs/index.mdx
@@ -3,14 +3,11 @@ title: Still being written
 description: The seedcord guide has no content yet. This page renders one of each MDX element.
 ---
 
-Every element below renders through the guide's own component map.
+Every element below renders through the guide's own component map. The prose is real seedcord material so the line lengths and the vocabulary match what a written page will look like.
 
-## A heading
+## A command needs a route
 
-A paragraph with `inline code` and [a link](https://docs.seedcord.org).
-
-- A list item
-- Another one
+The decorator writes the route through `reflect-metadata`, and codegen reads the commands directory to build the registry. A handler reads its options through `this.options` and replies through `this.reply`. Both are typed off the route you named in `@SlashRoute`, so a rename in one place breaks the build in the other.
 
 ```ts
 import { SlashHandler, SlashRoute } from '@seedcord/gateway';
@@ -22,3 +19,80 @@ export class Ping extends SlashHandler<'ping'> {
     }
 }
 ```
+
+### Options come off the registry
+
+A wrong option name is a compile error, before the bot ever connects. **Acking twice throws.** Discord accepts one initial response per interaction, and seedcord surfaces the second attempt as `ReplyIllegalAckState` before it reaches the API. Read the [reference site](https://docs.seedcord.org) for the full code list, or _skim_ the reply page first.
+
+#### Autocomplete is its own route
+
+The handler validates the layout hash after the route loads. h4 is as deep as the guide goes, and a page writing an h1, h5, or h6 fails the build.
+
+## Lists
+
+Three things ship with every command:
+
+- a route id, written once in `@SlashRoute`
+- a builder, which Discord reads at deploy
+- a handler, which runs on every invocation
+    - gates run before it
+    - middleware wraps it
+
+Deploying one takes four steps:
+
+1. write the command class
+2. run `seedcord build`
+3. run `seedcord commands deploy`
+4. wait for Discord to propagate it
+
+## Quoting something
+
+> Discord gives a bot three seconds to answer an interaction. After that the token stops working and the reply never arrives.
+
+A quote sits between two paragraphs more often than it opens a section.
+
+> A gate refuses by throwing a Notice or a Silence.
+>
+> Returning false is a compile error, because `defineGate` takes `void | Promise<void>`.
+
+## A rule between two claims
+
+Everything above applies to both transports.
+
+---
+
+What follows is gateway only, since Discord posts no message events to an http bot.
+
+## Images
+
+A page showing a Discord message takes a screenshot, and a screenshot gets the border by default. Markdown image syntax is the short way to write one.
+
+![The seedcord watermelon mark, framed](/logo.svg)
+
+A mark or a diagram on a transparent ground turns the border off through `<Image frame={false} />`. Markdown has no slot for that, so the capitalized name is the way to reach it.
+
+<Image src="/logo.svg" alt="The seedcord watermelon mark, unframed" width={280} height={280} frame={false} />
+
+The border comes in three weights. `thin`, `regular`, and `thick`, with `regular` the default.
+
+<Image src="/logo.svg" alt="A thin border" width={200} height={200} frame="thin" />
+
+<Image src="/logo.svg" alt="A thick border" width={200} height={200} frame="thick" />
+
+`align` takes `left`, `center`, and `right`, with `left` the default.
+
+<Image src="/logo.svg" alt="Aligned left" width={160} height={160} align="left" />
+
+<Image src="/logo.svg" alt="Aligned center" width={160} height={160} align="center" />
+
+<Image src="/logo.svg" alt="Aligned right" width={160} height={160} align="right" />
+
+## A table, unstyled for now
+
+The table family is the next thing built. This one is here to prove the markdown parses.
+
+| what      | where it runs       | throws              |
+| --------- | ------------------- | ------------------- |
+| `Notice`  | a gate or a handler | replies with a card |
+| `Silence` | a gate              | stops with no reply |
+| `Fault`   | anywhere            | reports to the bus  |

--- a/apps/guide/content/docs/index.mdx
+++ b/apps/guide/content/docs/index.mdx
@@ -87,12 +87,31 @@ The border comes in three weights. `thin`, `regular`, and `thick`, with `regular
 
 <Image src="/logo.svg" alt="Aligned right" width={160} height={160} align="right" />
 
-## A table, unstyled for now
+## Tables
 
-The table family is the next thing built. This one is here to prove the markdown parses.
+Three ways your code can stop:
 
-| what      | where it runs       | throws              |
-| --------- | ------------------- | ------------------- |
-| `Notice`  | a gate or a handler | replies with a card |
-| `Silence` | a gate              | stops with no reply |
-| `Fault`   | anywhere            | reports to the bus  |
+| what      | where it runs       | what the user sees   |
+| --------- | ------------------- | -------------------- |
+| `Notice`  | a gate or a handler | a card with a reason |
+| `Silence` | a gate              | nothing at all       |
+| `Fault`   | anywhere            | a generic apology    |
+
+A table wider than the column scrolls on its own. The page never scrolls sideways with it.
+
+Discord rejects a payload over any of these. It never truncates for you.
+
+| component | `custom_id` | `label` | `placeholder` | `options` | `value` | other |
+| --- | --- | --- | --- | --- | --- | --- |
+| _Button_ | 1 to 100 | 80 |  |  |  | `url` 512 |
+| _String select_ | 1 to 100 |  | 150 | 25 |  | `min_values` and `max_values` 0 to 25 |
+| Text input | 1 to 100 |  | 100 |  | 4000 | `max_length` 1 to 4000 |
+| ~~Modal~~ | 1 to 100 |  |  |  |  | `title` 45, 1 to 5 components |
+
+{/* prettier-ignore-start */}
+
+| component | `custom_id` | `label` | `placeholder` | `options` | `value` | other |
+| -- | -- | ------- | --------- | --------- | ------- | ----- |
+| **Button** | 1 to 100 | 80 | | | | `url` 512 |
+
+{/* prettier-ignore-end */}

--- a/apps/guide/content/docs/index.mdx
+++ b/apps/guide/content/docs/index.mdx
@@ -9,7 +9,7 @@ Every element below renders through the guide's own component map. The prose is 
 
 The decorator writes the route through `reflect-metadata`, and codegen reads the commands directory to build the registry. A handler reads its options through `this.options` and replies through `this.reply`. Both are typed off the route you named in `@SlashRoute`, so a rename in one place breaks the build in the other.
 
-```ts
+```ts title="src/commands/Ping.ts"
 import { SlashHandler, SlashRoute } from '@seedcord/gateway';
 
 @SlashRoute('ping')
@@ -18,6 +18,12 @@ export class Ping extends SlashHandler<'ping'> {
         await this.reply('Pong');
     }
 }
+```
+
+A fence with no `title` keeps its header, since the copy button lives there.
+
+```sh
+pnpm add @seedcord/gateway
 ```
 
 ### Options come off the registry

--- a/apps/guide/package.json
+++ b/apps/guide/package.json
@@ -31,6 +31,7 @@
         "shiki": "catalog:deps"
     },
     "devDependencies": {
+        "@mdx-js/mdx": "^3.1.1",
         "@seedcord/eslint-config": "workspace:^",
         "@seedcord/tsconfig": "workspace:^",
         "@seedcord/vitest-config": "workspace:^",

--- a/apps/guide/package.json
+++ b/apps/guide/package.json
@@ -21,6 +21,7 @@
         "test:watch": "vitest dev"
     },
     "dependencies": {
+        "@seedcord/docs-engine": "workspace:^",
         "@seedcord/ui": "workspace:^",
         "fumadocs-core": "16.14.4",
         "fumadocs-mdx": "15.2.3",

--- a/apps/guide/package.json
+++ b/apps/guide/package.json
@@ -24,6 +24,7 @@
         "@seedcord/ui": "workspace:^",
         "fumadocs-core": "16.14.4",
         "fumadocs-mdx": "15.2.3",
+        "lucide-react": "catalog:deps",
         "motion": "catalog:deps",
         "next": "catalog:deps",
         "react": "catalog:react",

--- a/apps/guide/source.config.ts
+++ b/apps/guide/source.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'fumadocs-mdx/config';
 
-import { rehypeFenceTitle } from './src/lib/rehypeFenceTitle';
+import { rehypeFenceMeta } from './src/lib/rehypeFenceMeta';
 import { remarkHeadingRange } from './src/lib/remarkHeadingRange';
 
 // eslint-disable-next-line import/no-default-export -- fumadocs-mdx reads this file's default export
@@ -11,6 +11,6 @@ export default defineConfig({
         // the img in mdxComponents.tsx needs src to stay a string
         remarkImageOptions: { useImport: false },
         remarkPlugins: [remarkHeadingRange],
-        rehypePlugins: [rehypeFenceTitle]
+        rehypePlugins: [rehypeFenceMeta]
     }
 });

--- a/apps/guide/source.config.ts
+++ b/apps/guide/source.config.ts
@@ -1,7 +1,14 @@
 import { defineConfig } from 'fumadocs-mdx/config';
 
+import { remarkHeadingRange } from './src/lib/remarkHeadingRange';
+
 // eslint-disable-next-line import/no-default-export -- fumadocs-mdx reads this file's default export
 export default defineConfig({
-    // mdxComponents.tsx highlights every fence through CodeBlock
-    mdxOptions: { rehypeCodeOptions: false }
+    mdxOptions: {
+        // mdxComponents.tsx highlights every fence through CodeBlock
+        rehypeCodeOptions: false,
+        // the img in mdxComponents.tsx needs src to stay a string
+        remarkImageOptions: { useImport: false },
+        remarkPlugins: [remarkHeadingRange]
+    }
 });

--- a/apps/guide/source.config.ts
+++ b/apps/guide/source.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'fumadocs-mdx/config';
 
+import { rehypeFenceTitle } from './src/lib/rehypeFenceTitle';
 import { remarkHeadingRange } from './src/lib/remarkHeadingRange';
 
 // eslint-disable-next-line import/no-default-export -- fumadocs-mdx reads this file's default export
@@ -9,6 +10,7 @@ export default defineConfig({
         rehypeCodeOptions: false,
         // the img in mdxComponents.tsx needs src to stay a string
         remarkImageOptions: { useImport: false },
-        remarkPlugins: [remarkHeadingRange]
+        remarkPlugins: [remarkHeadingRange],
+        rehypePlugins: [rehypeFenceTitle]
     }
 });

--- a/apps/guide/source.config.ts
+++ b/apps/guide/source.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'fumadocs-mdx/config';
 
 import { rehypeFenceMeta } from './src/lib/rehypeFenceMeta';
 import { remarkHeadingRange } from './src/lib/remarkHeadingRange';
+import { remarkNoMappedJsx } from './src/lib/remarkNoMappedJsx';
 
 // eslint-disable-next-line import/no-default-export -- fumadocs-mdx reads this file's default export
 export default defineConfig({
@@ -10,7 +11,7 @@ export default defineConfig({
         rehypeCodeOptions: false,
         // the img in mdxComponents.tsx needs src to stay a string
         remarkImageOptions: { useImport: false },
-        remarkPlugins: [remarkHeadingRange],
+        remarkPlugins: [remarkHeadingRange, remarkNoMappedJsx],
         rehypePlugins: [rehypeFenceMeta]
     }
 });

--- a/apps/guide/src/app/globals.css
+++ b/apps/guide/src/app/globals.css
@@ -6,7 +6,7 @@
     --nav-h: 4.5rem; /* fallback until the navbar measures its own height */
 }
 
-/* the tab row only renders at lg */
+/* the navbar shows its tab row from lg up */
 @media (width >= 64rem) {
     :root {
         --nav-h: 7.5rem;
@@ -27,7 +27,6 @@
         -webkit-font-smoothing: antialiased;
     }
 
-    /* without this the fixed navbar covers the heading after an anchor jump */
     :is(h1, h2, h3, h4, h5, h6)[id] {
         scroll-margin-top: calc(var(--nav-h, 0px) + 1.5rem);
     }

--- a/apps/guide/src/app/globals.css
+++ b/apps/guide/src/app/globals.css
@@ -33,8 +33,8 @@
         -webkit-font-smoothing: antialiased;
     }
 
-    /* an anchor jump lands under the fixed navbar without this */
+    /* without this the fixed navbar covers the heading after an anchor jump */
     :is(h1, h2, h3, h4, h5, h6)[id] {
-        scroll-margin-top: calc(var(--nav-h, 0px) + 3.5rem);
+        scroll-margin-top: calc(var(--nav-h, 0px) + 1.5rem);
     }
 }

--- a/apps/guide/src/app/globals.css
+++ b/apps/guide/src/app/globals.css
@@ -1,4 +1,5 @@
 @import '@seedcord/ui/styles/globals.css';
+@import '../styles/callout.css';
 
 :root {
     --content-max: 100rem;

--- a/apps/guide/src/app/globals.css
+++ b/apps/guide/src/app/globals.css
@@ -1,7 +1,6 @@
 @import '@seedcord/ui/styles/globals.css';
 
 :root {
-    --radius-surface: 0.375rem;
     --content-max: 100rem;
     --nav-h: 4.5rem; /* fallback until the navbar measures its own height */
 }
@@ -11,12 +10,6 @@
     :root {
         --nav-h: 7.5rem;
     }
-}
-
-@theme {
-    --radius-sm: calc(var(--radius-surface) - 0.125rem);
-    --radius-md: var(--radius-surface);
-    --radius-lg: var(--radius-surface);
 }
 
 @layer base {

--- a/apps/guide/src/components/Callout.tsx
+++ b/apps/guide/src/components/Callout.tsx
@@ -19,14 +19,13 @@ type Transport = keyof typeof TRANSPORT_LABELS;
 
 export interface CalloutProps {
     type: CalloutType;
-    /** Which transport the difference runs on. Leaving it off says both differ. */
+    /** Which transport the difference applies to. Leave it off to say both differ. */
     only?: Transport;
     children: ReactNode;
 }
 
 export function Callout({ type, only, children }: CalloutProps): ReactElement {
     const kind = KINDS[type];
-    // a typo would otherwise render an uncoloured card with no label
     if (kind === undefined) throw new Error(`${type} is not a callout. Write one of ${Object.keys(KINDS).join(', ')}.`);
 
     const label = only === undefined ? kind.label : TRANSPORT_LABELS[only];
@@ -37,7 +36,7 @@ export function Callout({ type, only, children }: CalloutProps): ReactElement {
                 <Icon icon={kind.icon} size={15} />
                 <span className={cn('text-[0.625rem] font-semibold tracking-widest uppercase')}>{label}</span>
             </p>
-            {/* mdx gives phrasing children when the content shares a line with the tag */}
+            {/* a one-line callout arrives as bare text with no p around it */}
             <div className={cn('mt-1.5 space-y-3 text-sm/relaxed text-(--text)')}>{children}</div>
         </Card>
     );

--- a/apps/guide/src/components/Callout.tsx
+++ b/apps/guide/src/components/Callout.tsx
@@ -28,7 +28,14 @@ export function Callout({ type, only, children }: CalloutProps): ReactElement {
     const kind = KINDS[type];
     if (kind === undefined) throw new Error(`${type} is not a callout. Write one of ${Object.keys(KINDS).join(', ')}.`);
 
+    if (only !== undefined && type !== 'transport') {
+        throw new Error(`only is for a transport callout. This one is a ${type}.`);
+    }
+
     const label = only === undefined ? kind.label : TRANSPORT_LABELS[only];
+    if (label === undefined) {
+        throw new Error(`${only} is not a transport. Write one of ${Object.keys(TRANSPORT_LABELS).join(', ')}.`);
+    }
 
     return (
         <Card as="div" size="none" data-callout={type} className={cn('border-(--cal-border) bg-(--cal-bg) px-4 py-3')}>

--- a/apps/guide/src/components/Callout.tsx
+++ b/apps/guide/src/components/Callout.tsx
@@ -1,0 +1,44 @@
+import { Card, Icon, cn } from '@seedcord/ui';
+import { ArrowLeftRight, Info, Lightbulb, OctagonAlert, TriangleAlert } from 'lucide-react';
+
+import type { IconComponent } from '@seedcord/ui';
+import type { ReactElement, ReactNode } from 'react';
+
+const KINDS = {
+    note: { label: 'Note', icon: Info },
+    tip: { label: 'Tip', icon: Lightbulb },
+    warning: { label: 'Warning', icon: TriangleAlert },
+    danger: { label: 'Danger', icon: OctagonAlert },
+    transport: { label: 'Gateway and http differ', icon: ArrowLeftRight }
+} as const satisfies Record<string, { label: string; icon: IconComponent }>;
+
+const TRANSPORT_LABELS = { gateway: 'Gateway only', http: 'Http only' } as const;
+
+type CalloutType = keyof typeof KINDS;
+type Transport = keyof typeof TRANSPORT_LABELS;
+
+export interface CalloutProps {
+    type: CalloutType;
+    /** Which transport the difference runs on. Leaving it off says both differ. */
+    only?: Transport;
+    children: ReactNode;
+}
+
+export function Callout({ type, only, children }: CalloutProps): ReactElement {
+    const kind = KINDS[type];
+    // a typo would otherwise render an uncoloured card with no label
+    if (kind === undefined) throw new Error(`${type} is not a callout. Write one of ${Object.keys(KINDS).join(', ')}.`);
+
+    const label = only === undefined ? kind.label : TRANSPORT_LABELS[only];
+
+    return (
+        <Card as="div" size="none" data-callout={type} className={cn('border-(--cal-border) bg-(--cal-bg) px-4 py-3')}>
+            <p className={cn('flex items-center gap-2 text-(--cal-text)')}>
+                <Icon icon={kind.icon} size={15} />
+                <span className={cn('text-[0.625rem] font-semibold tracking-widest uppercase')}>{label}</span>
+            </p>
+            {/* mdx gives phrasing children when the content shares a line with the tag */}
+            <div className={cn('mt-1.5 space-y-3 text-sm/relaxed text-(--text)')}>{children}</div>
+        </Card>
+    );
+}

--- a/apps/guide/src/components/Callout.tsx
+++ b/apps/guide/src/components/Callout.tsx
@@ -37,7 +37,7 @@ export function Callout({ type, only, children }: CalloutProps): ReactElement {
                 <span className={cn('text-[0.625rem] font-semibold tracking-widest uppercase')}>{label}</span>
             </p>
             {/* a one-line callout arrives as bare text with no p around it */}
-            <div className={cn('mt-1.5 space-y-3 text-sm/relaxed text-(--text)')}>{children}</div>
+            <div className={cn('mt-1.5 space-y-3 text-sm/relaxed text-(--text) [&>p]:text-sm/relaxed')}>{children}</div>
         </Card>
     );
 }

--- a/apps/guide/src/components/GuideShell.tsx
+++ b/apps/guide/src/components/GuideShell.tsx
@@ -112,10 +112,10 @@ export function GuideShell({
                 mark={<SiteSwitcher site="guide" destinations={DESTINATIONS} linkAs={Link} />}
                 actions={
                     <>
-                        <ThemeToggle />
                         <span className={cn('hidden lg:flex')}>
                             <GithubLink />
                         </span>
+                        <ThemeToggle />
                         <MobileNavButton open={navOpen} onOpen={() => setNavOpen(true)} className={cn('lg:hidden')} />
                     </>
                 }

--- a/apps/guide/src/components/Ref.tsx
+++ b/apps/guide/src/components/Ref.tsx
@@ -1,0 +1,29 @@
+import { slugifySegment } from '@seedcord/docs-engine/client';
+import { cn } from '@seedcord/ui';
+
+import { DOCS_URL } from '#lib/site';
+
+import type { ReactElement } from 'react';
+
+export interface RefProps {
+    pkg: string;
+    children: string;
+}
+
+// the reference site builds a cross-package link the same way, in resolve-helpers.ts
+export function Ref({ pkg, children }: RefProps): ReactElement {
+    const slug = children.split('.').map(slugifySegment).join('/');
+
+    return (
+        <a
+            href={`${DOCS_URL}/packages/${pkg}/latest/${slug}`}
+            target="_blank"
+            rel="noreferrer noopener"
+            className={cn(
+                'text-(--link) underline underline-offset-4 transition-opacity duration-150 hover:opacity-80'
+            )}
+        >
+            {children}
+        </a>
+    );
+}

--- a/apps/guide/src/components/Ref.tsx
+++ b/apps/guide/src/components/Ref.tsx
@@ -1,9 +1,11 @@
 import { slugifySegment } from '@seedcord/docs-engine/client';
-import { cn } from '@seedcord/ui';
+import { cn, tw } from '@seedcord/ui';
 
 import { DOCS_URL } from '#lib/site';
 
 import type { ReactElement } from 'react';
+
+export const LINK = tw`text-(--link) underline underline-offset-4 transition-opacity duration-150 hover:opacity-80`;
 
 export interface RefProps {
     pkg: string;
@@ -12,16 +14,15 @@ export interface RefProps {
 
 // the reference site builds a cross-package link the same way, in resolve-helpers.ts
 export function Ref({ pkg, children }: RefProps): ReactElement {
-    const slug = children.split('.').map(slugifySegment).join('/');
+    // resolve-helpers.ts splits a qualified name on the same pair
+    const slug = children.split(/[.#]/).filter(Boolean).map(slugifySegment).join('/');
 
     return (
         <a
             href={`${DOCS_URL}/packages/${pkg}/latest/${slug}`}
             target="_blank"
             rel="noreferrer noopener"
-            className={cn(
-                'text-(--link) underline underline-offset-4 transition-opacity duration-150 hover:opacity-80'
-            )}
+            className={cn(LINK)}
         >
             {children}
         </a>

--- a/apps/guide/src/components/TableOfContents.tsx
+++ b/apps/guide/src/components/TableOfContents.tsx
@@ -23,13 +23,15 @@ export const rowClassName = cn(
 );
 
 const TOP_LEVEL_DEPTH = 2;
+// remarkHeadingRange throws on anything outside h2 through h4
+const INDENT_BY_DEPTH = [tw`ps-3`, tw`ps-5`, tw`ps-7`] as const;
 
 export function idOf(url: string): string {
     return url.startsWith('#') ? url.slice(1) : url;
 }
 
 export function indentOf(depth: number): string {
-    return depth > TOP_LEVEL_DEPTH ? tw`ps-6` : tw`ps-3`;
+    return INDENT_BY_DEPTH[depth - TOP_LEVEL_DEPTH] ?? INDENT_BY_DEPTH[0];
 }
 
 interface ActiveRange {

--- a/apps/guide/src/lib/mdxComponents.tsx
+++ b/apps/guide/src/lib/mdxComponents.tsx
@@ -1,4 +1,4 @@
-import { Card, CodeBlock, cn, tw } from '@seedcord/ui';
+import { Card, CodeBlock, CopyAnchorButton, cn, tw } from '@seedcord/ui';
 import { highlightInlineToHtml, highlightToHtml, isHighlightable } from '@seedcord/ui/shiki';
 
 import { Callout } from '#components/Callout';
@@ -75,6 +75,7 @@ interface Fenced {
     code: string;
     lang: BundledLanguage;
     title: string | undefined;
+    output: boolean;
 }
 
 // mdx renders a fence as <pre><code className="language-x">
@@ -95,7 +96,39 @@ function readFence(children: ReactNode): Fenced | null {
     return {
         code: code.replace(/\n$/, ''),
         lang: named && isHighlightable(named) ? named : 'ts',
-        title: typeof title === 'string' ? title : undefined
+        title: typeof title === 'string' ? title : undefined,
+        output: 'data-output' in props
+    };
+}
+
+const HEADING_SIZES = {
+    h2: tw`mt-6 text-2xl/snug`,
+    h3: tw`mt-4 text-xl/snug`,
+    h4: tw`mt-3 text-lg/snug`
+} as const;
+
+const ANCHOR = tw`ms-1 align-middle transition-opacity md:opacity-0 md:group-hover:opacity-100 md:group-has-focus-visible:opacity-100 md:data-[copied=true]:opacity-100`;
+
+function headingFor(tag: keyof typeof HEADING_SIZES): (props: ComponentProps<'h2'>) => ReactElement {
+    return function Heading({ id, children, ...props }: ComponentProps<'h2'>): ReactElement {
+        const Tag = tag;
+
+        return (
+            <Tag
+                {...props}
+                id={id}
+                className={cn('font-display group font-semibold text-(--text)', HEADING_SIZES[tag])}
+            >
+                {children}
+                {id === undefined ? null : (
+                    <CopyAnchorButton
+                        anchorId={id}
+                        label={typeof children === 'string' ? children : id}
+                        className={cn(ANCHOR)}
+                    />
+                )}
+            </Tag>
+        );
     };
 }
 
@@ -111,14 +144,20 @@ async function Fence({ children }: FenceProps): Promise<ReactElement> {
     if (!fence) return <pre>{children}</pre>;
 
     const html = await highlightToHtml(fence.code, fence.lang);
-    return <CodeBlock representation={{ text: fence.code, html }} label={fence.title} />;
+    return (
+        <CodeBlock
+            representation={{ text: fence.code, html }}
+            label={fence.title}
+            copyValue={fence.output ? null : undefined}
+        />
+    );
 }
 
 export const mdxComponents = {
     pre: Fence,
-    h2: (props) => <h2 {...props} className={cn('font-display mt-6 text-2xl/snug font-semibold text-(--text)')} />,
-    h3: (props) => <h3 {...props} className={cn('font-display mt-4 text-xl/snug font-semibold text-(--text)')} />,
-    h4: (props) => <h4 {...props} className={cn('font-display mt-3 text-lg/snug font-semibold text-(--text)')} />,
+    h2: headingFor('h2'),
+    h3: headingFor('h3'),
+    h4: headingFor('h4'),
     p: (props) => <p {...props} className={cn('text-base/relaxed text-(--text)')} />,
     a: (props) => <a {...props} className={cn('text-(--rind-deep) underline underline-offset-4')} />,
     strong: (props) => <strong {...props} className={cn('font-semibold')} />,

--- a/apps/guide/src/lib/mdxComponents.tsx
+++ b/apps/guide/src/lib/mdxComponents.tsx
@@ -2,6 +2,7 @@ import { Card, CodeBlock, CopyAnchorButton, cn, tw } from '@seedcord/ui';
 import { highlightInlineToHtml, highlightToHtml, isHighlightable } from '@seedcord/ui/shiki';
 
 import { Callout } from '#components/Callout';
+import { Ref } from '#components/Ref';
 
 import type { MDXComponents } from 'mdx/types';
 import type { BundledLanguage } from 'shiki';
@@ -159,7 +160,14 @@ export const mdxComponents = {
     h3: headingFor('h3'),
     h4: headingFor('h4'),
     p: (props) => <p {...props} className={cn('text-base/relaxed text-(--text)')} />,
-    a: (props) => <a {...props} className={cn('text-(--rind-deep) underline underline-offset-4')} />,
+    a: (props) => (
+        <a
+            {...props}
+            className={cn(
+                'text-(--link) underline underline-offset-4 transition-opacity duration-150 hover:opacity-80'
+            )}
+        />
+    ),
     strong: (props) => <strong {...props} className={cn('font-semibold')} />,
     ul: (props) => <ul {...props} className={cn('list-disc space-y-1 ps-6 text-base/relaxed text-(--text)')} />,
     ol: (props) => <ol {...props} className={cn('list-decimal space-y-1 ps-6 text-base/relaxed text-(--text)')} />,
@@ -180,5 +188,6 @@ export const mdxComponents = {
     img: GuideImage,
     // a lowercase tag written as jsx in an mdx file skips this map
     Image: GuideImage,
-    Callout
+    Callout,
+    Ref
 } satisfies MDXComponents;

--- a/apps/guide/src/lib/mdxComponents.tsx
+++ b/apps/guide/src/lib/mdxComponents.tsx
@@ -2,7 +2,7 @@ import { Card, CodeBlock, CopyAnchorButton, cn, tw } from '@seedcord/ui';
 import { highlightInlineToHtml, highlightToHtml, isHighlightable } from '@seedcord/ui/shiki';
 
 import { Callout } from '#components/Callout';
-import { Ref } from '#components/Ref';
+import { LINK, Ref } from '#components/Ref';
 
 import type { MDXComponents } from 'mdx/types';
 import type { BundledLanguage } from 'shiki';
@@ -108,19 +108,18 @@ const HEADING_SIZES = {
     h4: tw`mt-3 text-lg/snug`
 } as const;
 
-const ANCHOR = tw`ms-1 align-middle transition-opacity md:opacity-0 md:group-hover:opacity-100 md:group-has-focus-visible:opacity-100 md:data-[copied=true]:opacity-100`;
+const ANCHOR = tw`ms-1 shrink-0 transition-opacity md:opacity-0 md:group-hover:opacity-100 md:group-has-focus-visible:opacity-100 md:data-[copied=true]:opacity-100`;
 
 function headingFor(tag: keyof typeof HEADING_SIZES): (props: ComponentProps<'h2'>) => ReactElement {
+    // the button stays a sibling, since a labelled control inside a heading joins the heading's own name
     return function Heading({ id, children, ...props }: ComponentProps<'h2'>): ReactElement {
         const Tag = tag;
 
         return (
-            <Tag
-                {...props}
-                id={id}
-                className={cn('font-display group font-semibold text-(--text)', HEADING_SIZES[tag])}
-            >
-                {children}
+            <div className={cn('group flex items-center', HEADING_SIZES[tag])}>
+                <Tag {...props} id={id} className={cn('font-display font-semibold text-(--text)')}>
+                    {children}
+                </Tag>
                 {id === undefined ? null : (
                     <CopyAnchorButton
                         anchorId={id}
@@ -128,7 +127,7 @@ function headingFor(tag: keyof typeof HEADING_SIZES): (props: ComponentProps<'h2
                         className={cn(ANCHOR)}
                     />
                 )}
-            </Tag>
+            </div>
         );
     };
 }
@@ -160,14 +159,7 @@ export const mdxComponents = {
     h3: headingFor('h3'),
     h4: headingFor('h4'),
     p: (props) => <p {...props} className={cn('text-base/relaxed text-(--text)')} />,
-    a: (props) => (
-        <a
-            {...props}
-            className={cn(
-                'text-(--link) underline underline-offset-4 transition-opacity duration-150 hover:opacity-80'
-            )}
-        />
-    ),
+    a: (props) => <a {...props} className={cn(LINK)} />,
     strong: (props) => <strong {...props} className={cn('font-semibold')} />,
     ul: (props) => <ul {...props} className={cn('list-disc space-y-1 ps-6 text-base/relaxed text-(--text)')} />,
     ol: (props) => <ol {...props} className={cn('list-decimal space-y-1 ps-6 text-base/relaxed text-(--text)')} />,

--- a/apps/guide/src/lib/mdxComponents.tsx
+++ b/apps/guide/src/lib/mdxComponents.tsx
@@ -1,4 +1,4 @@
-import { CodeBlock, cn, tw } from '@seedcord/ui';
+import { Card, CodeBlock, cn, tw } from '@seedcord/ui';
 import { highlightToHtml, isHighlightable } from '@seedcord/ui/shiki';
 
 import type { MDXComponents } from 'mdx/types';
@@ -57,6 +57,18 @@ function GuideImage({ alt, frame = 'regular', align = 'left', className, ...prop
     );
 }
 
+function GuideTable({ children, ...props }: ComponentProps<'table'>): ReactElement {
+    return (
+        <Card as="div" size="none" className={cn('overflow-hidden')}>
+            <div className={cn('nice-scroll overflow-x-auto')}>
+                <table {...props} className={cn('w-full border-collapse text-left text-sm')}>
+                    {children}
+                </table>
+            </div>
+        </Card>
+    );
+}
+
 // mdx renders a fence as <pre><code className="language-x">
 function readFence(children: ReactNode): { code: string; lang: BundledLanguage } | null {
     if (typeof children !== 'object' || children === null || !('props' in children)) return null;
@@ -101,6 +113,11 @@ export const mdxComponents = {
         />
     ),
     hr: (props) => <hr {...props} className={cn('my-3 border-(--border)')} />,
+    table: GuideTable,
+    thead: (props) => <thead {...props} className={cn('border-b border-(--border) bg-(--surface-moderate)')} />,
+    tbody: (props) => <tbody {...props} className={cn('divide-y divide-(--border)/70')} />,
+    th: (props) => <th {...props} className={cn('px-3 py-2 align-top font-semibold text-(--text)')} />,
+    td: (props) => <td {...props} className={cn('px-3 py-2 align-top text-(--text)')} />,
     img: GuideImage,
     // a lowercase tag written as jsx in an mdx file skips this map
     Image: GuideImage

--- a/apps/guide/src/lib/mdxComponents.tsx
+++ b/apps/guide/src/lib/mdxComponents.tsx
@@ -69,8 +69,14 @@ function GuideTable({ children, ...props }: ComponentProps<'table'>): ReactEleme
     );
 }
 
+interface Fenced {
+    code: string;
+    lang: BundledLanguage;
+    title: string | undefined;
+}
+
 // mdx renders a fence as <pre><code className="language-x">
-function readFence(children: ReactNode): { code: string; lang: BundledLanguage } | null {
+function readFence(children: ReactNode): Fenced | null {
     if (typeof children !== 'object' || children === null || !('props' in children)) return null;
 
     const props = children.props as Record<string, unknown>;
@@ -82,8 +88,13 @@ function readFence(children: ReactNode): { code: string; lang: BundledLanguage }
         .split(/\s+/)
         .find((name) => name.startsWith(LANGUAGE_PREFIX))
         ?.slice(LANGUAGE_PREFIX.length);
+    const title = props['data-title'];
 
-    return { code: code.replace(/\n$/, ''), lang: named && isHighlightable(named) ? named : 'ts' };
+    return {
+        code: code.replace(/\n$/, ''),
+        lang: named && isHighlightable(named) ? named : 'ts',
+        title: typeof title === 'string' ? title : undefined
+    };
 }
 
 async function Fence({ children }: FenceProps): Promise<ReactElement> {
@@ -91,7 +102,7 @@ async function Fence({ children }: FenceProps): Promise<ReactElement> {
     if (!fence) return <pre>{children}</pre>;
 
     const html = await highlightToHtml(fence.code, fence.lang);
-    return <CodeBlock representation={{ text: fence.code, html }} />;
+    return <CodeBlock representation={{ text: fence.code, html }} label={fence.title} />;
 }
 
 export const mdxComponents = {

--- a/apps/guide/src/lib/mdxComponents.tsx
+++ b/apps/guide/src/lib/mdxComponents.tsx
@@ -1,5 +1,7 @@
 import { Card, CodeBlock, cn, tw } from '@seedcord/ui';
-import { highlightToHtml, isHighlightable } from '@seedcord/ui/shiki';
+import { highlightInlineToHtml, highlightToHtml, isHighlightable } from '@seedcord/ui/shiki';
+
+import { Callout } from '#components/Callout';
 
 import type { MDXComponents } from 'mdx/types';
 import type { BundledLanguage } from 'shiki';
@@ -97,6 +99,13 @@ function readFence(children: ReactNode): Fenced | null {
     };
 }
 
+async function InlineCode({ children }: FenceProps): Promise<ReactElement> {
+    const html = typeof children === 'string' ? await highlightInlineToHtml(children) : null;
+    if (!html) return <code className={cn('shiki-inline')}>{children}</code>;
+
+    return <span dangerouslySetInnerHTML={{ __html: html }} />;
+}
+
 async function Fence({ children }: FenceProps): Promise<ReactElement> {
     const fence = readFence(children);
     if (!fence) return <pre>{children}</pre>;
@@ -115,7 +124,7 @@ export const mdxComponents = {
     strong: (props) => <strong {...props} className={cn('font-semibold')} />,
     ul: (props) => <ul {...props} className={cn('list-disc space-y-1 ps-6 text-base/relaxed text-(--text)')} />,
     ol: (props) => <ol {...props} className={cn('list-decimal space-y-1 ps-6 text-base/relaxed text-(--text)')} />,
-    code: (props) => <code {...props} className={cn('rounded-sm bg-(--surface-moderate) px-1.5 py-0.5 text-sm')} />,
+    code: InlineCode,
     blockquote: (props) => (
         <blockquote
             {...props}
@@ -131,5 +140,6 @@ export const mdxComponents = {
     td: (props) => <td {...props} className={cn('px-3 py-2 align-top text-(--text)')} />,
     img: GuideImage,
     // a lowercase tag written as jsx in an mdx file skips this map
-    Image: GuideImage
+    Image: GuideImage,
+    Callout
 } satisfies MDXComponents;

--- a/apps/guide/src/lib/mdxComponents.tsx
+++ b/apps/guide/src/lib/mdxComponents.tsx
@@ -1,14 +1,60 @@
-import { CodeBlock, cn } from '@seedcord/ui';
+import { CodeBlock, cn, tw } from '@seedcord/ui';
 import { highlightToHtml, isHighlightable } from '@seedcord/ui/shiki';
 
 import type { MDXComponents } from 'mdx/types';
 import type { BundledLanguage } from 'shiki';
-import type { ReactElement, ReactNode } from 'react';
+import type { ComponentProps, ReactElement, ReactNode } from 'react';
 
 const LANGUAGE_PREFIX = 'language-';
 
 interface FenceProps {
     children?: ReactNode;
+}
+
+const FRAME_WEIGHTS = {
+    thin: tw`border`,
+    regular: tw`border-2`,
+    thick: tw`border-4`
+} as const;
+
+// auto margins do nothing without the block class below
+const ALIGNMENTS = {
+    left: tw`me-auto`,
+    center: tw`mx-auto`,
+    right: tw`ms-auto`
+} as const;
+
+interface ImageProps extends ComponentProps<'img'> {
+    frame?: keyof typeof FRAME_WEIGHTS | false;
+    align?: keyof typeof ALIGNMENTS;
+}
+
+// a typo would otherwise render as a padded box with no edge
+function pick<T extends Record<string, string>>(options: T, key: keyof T, prop: string): string {
+    const found = options[key];
+    if (found === undefined)
+        throw new Error(`${String(key)} is not a ${prop}. Write one of ${Object.keys(options).join(', ')}.`);
+
+    return found;
+}
+
+function GuideImage({ alt, frame = 'regular', align = 'left', className, ...props }: ImageProps): ReactElement {
+    return (
+        // eslint-disable-next-line @next/next/no-img-element -- next/image requires width and height, both optional on ImageProps
+        <img
+            {...props}
+            alt={alt}
+            loading="lazy"
+            decoding="async"
+            className={cn(
+                'block h-auto max-w-full rounded-md',
+                pick(ALIGNMENTS, align, 'align'),
+                frame !== false &&
+                    cn(pick(FRAME_WEIGHTS, frame, 'frame'), 'border-(--border) bg-(--surface-subtle) p-2'),
+                className
+            )}
+        />
+    );
 }
 
 // mdx renders a fence as <pre><code className="language-x">
@@ -36,14 +82,26 @@ async function Fence({ children }: FenceProps): Promise<ReactElement> {
     return <CodeBlock representation={{ text: fence.code, html }} />;
 }
 
-export const mdxComponents: MDXComponents = {
+export const mdxComponents = {
     pre: Fence,
     h2: (props) => <h2 {...props} className={cn('font-display mt-6 text-2xl/snug font-semibold text-(--text)')} />,
     h3: (props) => <h3 {...props} className={cn('font-display mt-4 text-xl/snug font-semibold text-(--text)')} />,
     h4: (props) => <h4 {...props} className={cn('font-display mt-3 text-lg/snug font-semibold text-(--text)')} />,
     p: (props) => <p {...props} className={cn('text-base/relaxed text-(--text)')} />,
     a: (props) => <a {...props} className={cn('text-(--rind-deep) underline underline-offset-4')} />,
+    strong: (props) => <strong {...props} className={cn('font-semibold')} />,
     ul: (props) => <ul {...props} className={cn('list-disc space-y-1 ps-6 text-base/relaxed text-(--text)')} />,
     ol: (props) => <ol {...props} className={cn('list-decimal space-y-1 ps-6 text-base/relaxed text-(--text)')} />,
-    code: (props) => <code {...props} className={cn('rounded-sm bg-(--surface-moderate) px-1.5 py-0.5 text-sm')} />
-};
+    code: (props) => <code {...props} className={cn('rounded-sm bg-(--surface-moderate) px-1.5 py-0.5 text-sm')} />,
+    blockquote: (props) => (
+        <blockquote
+            {...props}
+            // the p mapping above sets its own color
+            className={cn('flex flex-col gap-3 border-s-2 border-(--border) ps-4 [&>p]:text-(--text-muted)')}
+        />
+    ),
+    hr: (props) => <hr {...props} className={cn('my-3 border-(--border)')} />,
+    img: GuideImage,
+    // a lowercase tag written as jsx in an mdx file skips this map
+    Image: GuideImage
+} satisfies MDXComponents;

--- a/apps/guide/src/lib/rehypeFenceMeta.ts
+++ b/apps/guide/src/lib/rehypeFenceMeta.ts
@@ -24,7 +24,8 @@ export function rehypeFenceMeta() {
             const added: Record<string, unknown> = {};
 
             if (title) added['data-title'] = title;
-            if (OUTPUT.test(meta)) added['data-output'] = '';
+            // a title like "build output.ts" would otherwise read as the output flag
+            if (OUTPUT.test(meta.replace(TITLE, ' '))) added['data-output'] = '';
 
             code.properties = { ...code.properties, ...added };
         }

--- a/apps/guide/src/lib/rehypeFenceMeta.ts
+++ b/apps/guide/src/lib/rehypeFenceMeta.ts
@@ -1,4 +1,5 @@
 const TITLE = /(?:^|\s)title="([^"]*)"/;
+const OUTPUT = /(?:^|\s)output(?:\s|$)/;
 
 interface Element {
     type: string;
@@ -15,13 +16,17 @@ function codeElements(node: Element): Element[] {
 }
 
 // remark-rehype writes the fence meta to data.meta
-export function rehypeFenceTitle() {
+export function rehypeFenceMeta() {
     return (tree: Element): void => {
         for (const code of codeElements(tree)) {
-            const found = TITLE.exec(code.data?.meta ?? '');
-            if (!found?.[1]) continue;
+            const meta = code.data?.meta ?? '';
+            const title = TITLE.exec(meta)?.[1];
+            const added: Record<string, unknown> = {};
 
-            code.properties = { ...code.properties, 'data-title': found[1] };
+            if (title) added['data-title'] = title;
+            if (OUTPUT.test(meta)) added['data-output'] = '';
+
+            code.properties = { ...code.properties, ...added };
         }
     };
 }

--- a/apps/guide/src/lib/rehypeFenceTitle.ts
+++ b/apps/guide/src/lib/rehypeFenceTitle.ts
@@ -1,0 +1,27 @@
+const TITLE = /(?:^|\s)title="([^"]*)"/;
+
+interface Element {
+    type: string;
+    tagName?: string;
+    properties?: Record<string, unknown>;
+    data?: { meta?: string };
+    children?: Element[];
+}
+
+function codeElements(node: Element): Element[] {
+    if (node.type === 'element' && node.tagName === 'code') return [node];
+
+    return (node.children ?? []).flatMap(codeElements);
+}
+
+// remark-rehype writes the fence meta to data.meta
+export function rehypeFenceTitle() {
+    return (tree: Element): void => {
+        for (const code of codeElements(tree)) {
+            const found = TITLE.exec(code.data?.meta ?? '');
+            if (!found?.[1]) continue;
+
+            code.properties = { ...code.properties, 'data-title': found[1] };
+        }
+    };
+}

--- a/apps/guide/src/lib/remarkHeadingRange.ts
+++ b/apps/guide/src/lib/remarkHeadingRange.ts
@@ -23,7 +23,7 @@ function headingsIn(node: Node): Heading[] {
     return (node.children ?? []).flatMap(headingsIn);
 }
 
-// vfile turns this into a message carrying the file and the line
+// vfile reads the file and the line off the node passed as place
 interface Reporter {
     fail(reason: string, place: Node): never;
 }

--- a/apps/guide/src/lib/remarkHeadingRange.ts
+++ b/apps/guide/src/lib/remarkHeadingRange.ts
@@ -1,0 +1,39 @@
+// page.tsx renders the frontmatter title as the h1
+const SHALLOWEST = 2;
+// mdxComponents.tsx does not map anything deeper than h4
+const DEEPEST = 4;
+
+interface Node {
+    type: string;
+    children?: Node[];
+}
+
+interface Heading extends Node {
+    type: 'heading';
+    depth: number;
+}
+
+function isHeading(node: Node): node is Heading {
+    return node.type === 'heading';
+}
+
+function headingsIn(node: Node): Heading[] {
+    if (isHeading(node)) return [node];
+
+    return (node.children ?? []).flatMap(headingsIn);
+}
+
+// vfile turns this into a message carrying the file and the line
+interface Reporter {
+    fail(reason: string, place: Node): never;
+}
+
+export function remarkHeadingRange() {
+    return (tree: Node, file: Reporter): void => {
+        for (const heading of headingsIn(tree)) {
+            if (heading.depth >= SHALLOWEST && heading.depth <= DEEPEST) continue;
+
+            file.fail(`this page writes an h${heading.depth}. The guide takes h2 through h4.`, heading);
+        }
+    };
+}

--- a/apps/guide/src/lib/remarkNoMappedJsx.ts
+++ b/apps/guide/src/lib/remarkNoMappedJsx.ts
@@ -1,0 +1,51 @@
+export const MAPPED_TAGS = [
+    'pre',
+    'h2',
+    'h3',
+    'h4',
+    'p',
+    'a',
+    'strong',
+    'ul',
+    'ol',
+    'code',
+    'blockquote',
+    'hr',
+    'table',
+    'thead',
+    'tbody',
+    'th',
+    'td',
+    'img'
+] as const;
+
+const REJECTED = new Set<string>([...MAPPED_TAGS, 'h1', 'h5', 'h6']);
+
+const JSX_NODES = new Set(['mdxJsxFlowElement', 'mdxJsxTextElement']);
+
+interface Node {
+    type: string;
+    name?: string | null;
+    children?: Node[];
+}
+
+function jsxElementsIn(node: Node): Node[] {
+    const here = JSX_NODES.has(node.type) ? [node] : [];
+
+    return [...here, ...(node.children ?? []).flatMap(jsxElementsIn)];
+}
+
+interface Reporter {
+    fail(reason: string, place: Node): never;
+}
+
+export function remarkNoMappedJsx() {
+    return (tree: Node, file: Reporter): void => {
+        for (const element of jsxElementsIn(tree)) {
+            const name = element.name ?? '';
+            if (!REJECTED.has(name)) continue;
+
+            file.fail(`write <${name}> as markdown. Written as jsx it renders unstyled.`, element);
+        }
+    };
+}

--- a/apps/guide/src/styles/callout.css
+++ b/apps/guide/src/styles/callout.css
@@ -1,0 +1,23 @@
+@layer components {
+    [data-callout] {
+        --cal-border: color-mix(in oklab, var(--cal-hue) 65%, var(--border));
+        --cal-bg: color-mix(in oklab, var(--cal-hue) 20%, var(--surface));
+        --cal-text: color-mix(in oklab, var(--text) 66%, var(--cal-hue) 34%);
+    }
+
+    [data-callout='note'] {
+        --cal-hue: var(--accent-r);
+    }
+    [data-callout='tip'] {
+        --cal-hue: var(--rind);
+    }
+    [data-callout='warning'] {
+        --cal-hue: var(--amber);
+    }
+    [data-callout='danger'] {
+        --cal-hue: var(--flesh);
+    }
+    [data-callout='transport'] {
+        --cal-hue: var(--husk);
+    }
+}

--- a/apps/guide/src/styles/callout.css
+++ b/apps/guide/src/styles/callout.css
@@ -1,5 +1,7 @@
 @layer components {
     [data-callout] {
+        /* a kind with no rule below would leave every color-mix invalid */
+        --cal-hue: var(--border);
         --cal-border: color-mix(in oklab, var(--cal-hue) 65%, var(--border));
         --cal-bg: color-mix(in oklab, var(--cal-hue) 20%, var(--surface));
         --cal-text: color-mix(in oklab, var(--text) 66%, var(--cal-hue) 34%);

--- a/apps/guide/tests/components/Callout.test.tsx
+++ b/apps/guide/tests/components/Callout.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { Callout } from '#components/Callout';
+
+import type { CalloutProps } from '#components/Callout';
+
+describe('Callout', () => {
+    it('names its kind above the body', () => {
+        render(<Callout type="note">Codegen runs first.</Callout>);
+
+        expect(screen.getByText('Note')).toBeInTheDocument();
+        expect(screen.getByText('Codegen runs first.')).toBeInTheDocument();
+    });
+
+    it.each([
+        ['gateway', 'Gateway only'],
+        ['http', 'Http only']
+    ] as const)('says %s only', (only, label) => {
+        render(
+            <Callout type="transport" only={only}>
+                A difference.
+            </Callout>
+        );
+
+        expect(screen.getByText(label)).toBeInTheDocument();
+    });
+
+    it('says both differ when the transport callout names no side', () => {
+        render(<Callout type="transport">A difference.</Callout>);
+
+        expect(screen.getByText('Gateway and http differ')).toBeInTheDocument();
+    });
+
+    // mdx does not typecheck the props a page writes
+    it('refuses an unknown type', () => {
+        const wrong = { type: 'nonsense' } as unknown as CalloutProps;
+
+        expect(() => render(<Callout {...wrong}>A body.</Callout>)).toThrow('nonsense');
+    });
+});

--- a/apps/guide/tests/components/Callout.test.tsx
+++ b/apps/guide/tests/components/Callout.test.tsx
@@ -38,4 +38,16 @@ describe('Callout', () => {
 
         expect(() => render(<Callout {...wrong}>A body.</Callout>)).toThrow('nonsense');
     });
+
+    it('refuses an unknown only', () => {
+        const wrong = { type: 'transport', only: 'websocket' } as unknown as CalloutProps;
+
+        expect(() => render(<Callout {...wrong}>A body.</Callout>)).toThrow('websocket');
+    });
+
+    it('refuses only on a kind that names no transport', () => {
+        const wrong = { type: 'danger', only: 'gateway' } as unknown as CalloutProps;
+
+        expect(() => render(<Callout {...wrong}>A body.</Callout>)).toThrow('transport');
+    });
 });

--- a/apps/guide/tests/components/Ref.test.tsx
+++ b/apps/guide/tests/components/Ref.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { Ref } from '#components/Ref';
+import { DOCS_URL } from '#lib/site';
+
+function hrefOf(name: string): string | null {
+    return screen.getByRole('link', { name }).getAttribute('href');
+}
+
+describe('Ref', () => {
+    it('derives the slug from the symbol name', () => {
+        render(<Ref pkg="core">Notice</Ref>);
+
+        expect(hrefOf('Notice')).toBe(`${DOCS_URL}/packages/core/latest/notice`);
+    });
+
+    it('kebab-cases a multi-word name the way the reference site does', () => {
+        render(<Ref pkg="gateway">SlashHandler</Ref>);
+
+        expect(hrefOf('SlashHandler')).toBe(`${DOCS_URL}/packages/gateway/latest/slash-handler`);
+    });
+
+    it('turns a dotted member into a nested path', () => {
+        render(<Ref pkg="core">Paginator.start</Ref>);
+
+        expect(hrefOf('Paginator.start')).toBe(`${DOCS_URL}/packages/core/latest/paginator/start`);
+    });
+
+    it('drops a generic from the name', () => {
+        render(<Ref pkg="core">Plugin&lt;Options&gt;</Ref>);
+
+        expect(hrefOf('Plugin<Options>')).toBe(`${DOCS_URL}/packages/core/latest/plugin`);
+    });
+
+    it('opens the reference site in a new tab', () => {
+        render(<Ref pkg="core">Notice</Ref>);
+        const link = screen.getByRole('link', { name: 'Notice' });
+
+        expect(link).toHaveAttribute('target', '_blank');
+        expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'));
+    });
+});

--- a/apps/guide/tests/components/Ref.test.tsx
+++ b/apps/guide/tests/components/Ref.test.tsx
@@ -21,10 +21,10 @@ describe('Ref', () => {
         expect(hrefOf('SlashHandler')).toBe(`${DOCS_URL}/packages/gateway/latest/slash-handler`);
     });
 
-    it('turns a dotted member into a nested path', () => {
-        render(<Ref pkg="core">Paginator.start</Ref>);
+    it.each(['Paginator.start', 'Paginator#start'])('turns %s into a nested path', (name) => {
+        render(<Ref pkg="core">{name}</Ref>);
 
-        expect(hrefOf('Paginator.start')).toBe(`${DOCS_URL}/packages/core/latest/paginator/start`);
+        expect(hrefOf(name)).toBe(`${DOCS_URL}/packages/core/latest/paginator/start`);
     });
 
     it('drops a generic from the name', () => {

--- a/apps/guide/tests/components/TableOfContents.test.tsx
+++ b/apps/guide/tests/components/TableOfContents.test.tsx
@@ -1,0 +1,41 @@
+import { MotionProvider } from '@seedcord/ui';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { TableOfContents } from '#components/TableOfContents';
+
+import type { TOCItemType } from 'fumadocs-core/toc';
+
+const TITLES = ['Two', 'Three', 'Four'] as const;
+
+const NESTED: readonly TOCItemType[] = TITLES.map((title, index) => ({
+    title,
+    url: `#${title.toLowerCase()}`,
+    depth: index + 2
+}));
+
+const INDENT_PREFIX = 'ps-';
+
+function indentOfRow(title: string): number {
+    const row = screen.getByRole('link', { name: title });
+    const found = row.className.split(/\s+/).find((name) => name.startsWith(INDENT_PREFIX));
+    if (found === undefined) throw new Error(`no ${INDENT_PREFIX}* class on the ${title} row`);
+    return Number(found.slice(INDENT_PREFIX.length));
+}
+
+describe('TableOfContents', () => {
+    it('indents one step further for every heading level', () => {
+        render(
+            <MotionProvider>
+                <TableOfContents items={NESTED} activeIds={[]} />
+            </MotionProvider>
+        );
+
+        const steps = TITLES.map((title) => indentOfRow(title));
+
+        for (const [index, step] of steps.entries()) {
+            if (index === 0) continue;
+            expect(step).toBeGreaterThan(steps[index - 1] ?? 0);
+        }
+    });
+});

--- a/apps/guide/tests/lib/headings.test.tsx
+++ b/apps/guide/tests/lib/headings.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { mdxComponents } from '#lib/mdxComponents';
+
+const { h2: H2, h3: H3, h4: H4 } = mdxComponents;
+
+describe('a heading', () => {
+    it.each([
+        ['h2', H2],
+        ['h3', H3],
+        ['h4', H4]
+    ])('gives %s a control that copies a link to it', (_name, Heading) => {
+        render(<Heading id="a-command-needs-a-route">A command needs a route</Heading>);
+
+        expect(screen.getByRole('button', { name: /Copy link to A command needs a route/ })).toBeInTheDocument();
+    });
+
+    it('still names itself without reading the control inside it', () => {
+        render(<H2 id="a-command-needs-a-route">A command needs a route</H2>);
+
+        expect(screen.getByRole('heading', { name: 'A command needs a route' })).toBeInTheDocument();
+    });
+});

--- a/apps/guide/tests/lib/mdxComponents.test.tsx
+++ b/apps/guide/tests/lib/mdxComponents.test.tsx
@@ -2,8 +2,17 @@ import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
 import { mdxComponents } from '#lib/mdxComponents';
+import { MAPPED_TAGS } from '#lib/remarkNoMappedJsx';
 
 const { Image, pre: Fence } = mdxComponents;
+
+describe('the rejected jsx tag list', () => {
+    it('names every lowercase tag the map claims', () => {
+        const mapped = Object.keys(mdxComponents).filter((tag) => tag === tag.toLowerCase());
+
+        expect([...MAPPED_TAGS].sort()).toEqual(mapped.sort());
+    });
+});
 
 function classesOf(alt: string): string[] {
     return screen.getByRole('img', { name: alt }).className.split(/\s+/);

--- a/apps/guide/tests/lib/mdxComponents.test.tsx
+++ b/apps/guide/tests/lib/mdxComponents.test.tsx
@@ -64,9 +64,9 @@ describe('the image component', () => {
             </>
         );
 
-        const widths = ['thin', 'regular', 'thick'].map((alt) => borderWidthOf(alt));
-
-        expect(new Set(widths).size).toBe(widths.length);
+        expect(borderWidthOf('thin')).toBe('border');
+        expect(borderWidthOf('regular')).toBe('border-2');
+        expect(borderWidthOf('thick')).toBe('border-4');
     });
 
     it('drops the border and keeps frame off the dom', () => {
@@ -85,9 +85,9 @@ describe('the image component', () => {
             </>
         );
 
-        const margins = ['left', 'center', 'right'].map((alt) => marginOf(alt));
-
-        expect(new Set(margins).size).toBe(margins.length);
+        expect(marginOf('left')).toBe('me-auto');
+        expect(marginOf('center')).toBe('mx-auto');
+        expect(marginOf('right')).toBe('ms-auto');
     });
 
     it('keeps align off the dom', () => {

--- a/apps/guide/tests/lib/mdxComponents.test.tsx
+++ b/apps/guide/tests/lib/mdxComponents.test.tsx
@@ -34,6 +34,18 @@ describe('a fence', () => {
 
         expect(screen.queryByText('src/commands/Ping.ts')).toBeNull();
     });
+
+    it('drops the copy button on a fence tagged as output', async () => {
+        await renderFence({ className: 'language-bash', 'data-output': '' });
+
+        expect(screen.queryByRole('button', { name: /Copy/ })).toBeNull();
+    });
+
+    it('keeps the copy button on every other fence', async () => {
+        await renderFence({ className: 'language-bash' });
+
+        expect(screen.getByRole('button', { name: /Copy/ })).toBeInTheDocument();
+    });
 });
 
 describe('the image component', () => {

--- a/apps/guide/tests/lib/mdxComponents.test.tsx
+++ b/apps/guide/tests/lib/mdxComponents.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 
 import { mdxComponents } from '#lib/mdxComponents';
 
-const { Image } = mdxComponents;
+const { Image, pre: Fence } = mdxComponents;
 
 function classesOf(alt: string): string[] {
     return screen.getByRole('img', { name: alt }).className.split(/\s+/);
@@ -16,6 +16,25 @@ function borderWidthOf(alt: string): string | undefined {
 function marginOf(alt: string): string | undefined {
     return classesOf(alt).find((name) => /^m[a-z]-auto$/.test(name));
 }
+
+describe('a fence', () => {
+    // mdx gives pre one code child
+    async function renderFence(props: Record<string, unknown>): Promise<void> {
+        render(await Fence({ children: <code {...props}>const a = 1;</code> }));
+    }
+
+    it('captions the block with the fence title', async () => {
+        await renderFence({ className: 'language-ts', 'data-title': 'src/commands/Ping.ts' });
+
+        expect(screen.getByText('src/commands/Ping.ts')).toBeInTheDocument();
+    });
+
+    it('draws no caption when the fence gives no title', async () => {
+        await renderFence({ className: 'language-ts' });
+
+        expect(screen.queryByText('src/commands/Ping.ts')).toBeNull();
+    });
+});
 
 describe('the image component', () => {
     it('draws a border by default', () => {

--- a/apps/guide/tests/lib/mdxComponents.test.tsx
+++ b/apps/guide/tests/lib/mdxComponents.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { mdxComponents } from '#lib/mdxComponents';
+
+const { Image } = mdxComponents;
+
+function classesOf(alt: string): string[] {
+    return screen.getByRole('img', { name: alt }).className.split(/\s+/);
+}
+
+function borderWidthOf(alt: string): string | undefined {
+    return classesOf(alt).find((name) => name === 'border' || /^border-\d+$/.test(name));
+}
+
+function marginOf(alt: string): string | undefined {
+    return classesOf(alt).find((name) => /^m[a-z]-auto$/.test(name));
+}
+
+describe('the image component', () => {
+    it('draws a border by default', () => {
+        render(<Image src="/logo.svg" alt="framed" />);
+
+        expect(borderWidthOf('framed')).toBeDefined();
+    });
+
+    it('gives each weight its own border', () => {
+        render(
+            <>
+                <Image src="/logo.svg" alt="thin" frame="thin" />
+                <Image src="/logo.svg" alt="regular" frame="regular" />
+                <Image src="/logo.svg" alt="thick" frame="thick" />
+            </>
+        );
+
+        const widths = ['thin', 'regular', 'thick'].map((alt) => borderWidthOf(alt));
+
+        expect(new Set(widths).size).toBe(widths.length);
+    });
+
+    it('drops the border and keeps frame off the dom', () => {
+        render(<Image src="/logo.svg" alt="bare" frame={false} />);
+
+        expect(borderWidthOf('bare')).toBeUndefined();
+        expect(screen.getByRole('img', { name: 'bare' })).not.toHaveAttribute('frame');
+    });
+
+    it('gives each alignment its own margin', () => {
+        render(
+            <>
+                <Image src="/logo.svg" alt="left" align="left" />
+                <Image src="/logo.svg" alt="center" align="center" />
+                <Image src="/logo.svg" alt="right" align="right" />
+            </>
+        );
+
+        const margins = ['left', 'center', 'right'].map((alt) => marginOf(alt));
+
+        expect(new Set(margins).size).toBe(margins.length);
+    });
+
+    it('keeps align off the dom', () => {
+        render(<Image src="/logo.svg" alt="centred" align="center" />);
+
+        expect(screen.getByRole('img', { name: 'centred' })).not.toHaveAttribute('align');
+    });
+
+    it('keeps a class the page passed in', () => {
+        render(<Image src="/logo.svg" alt="classy" className="test-only-marker" />);
+
+        expect(classesOf('classy')).toContain('test-only-marker');
+    });
+
+    // mdx does not typecheck the props a page writes
+    it.each(['frame', 'align'])('refuses an unknown %s', (prop) => {
+        expect(() => render(<Image src="/logo.svg" alt="typo" {...{ [prop]: 'nonsense' }} />)).toThrow('nonsense');
+    });
+});

--- a/apps/guide/tests/mdxPipeline.test.ts
+++ b/apps/guide/tests/mdxPipeline.test.ts
@@ -32,6 +32,18 @@ describe('heading depth', () => {
         await expect(compileGuideMdx(source)).rejects.toThrow(name);
     });
 
+    // a lowercase jsx tag skips the component map
+    it.each(['<h5>five</h5>', '<p>a paragraph</p>', '<table><tbody /></table>'])(
+        'refuses %s written as jsx',
+        async (source) => {
+            await expect(compileGuideMdx(source)).rejects.toThrow();
+        }
+    );
+
+    it('leaves a tag the map never claims alone', async () => {
+        await expect(compileGuideMdx('a line<br />and another')).resolves.toContain('br');
+    });
+
     it('points at the line the heading is on', async () => {
         const thrown = await compileGuideMdx(['## two', '', '##### five'].join('\n')).catch((error: unknown) => error);
 

--- a/apps/guide/tests/mdxPipeline.test.ts
+++ b/apps/guide/tests/mdxPipeline.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import { compileGuideMdx } from './mdxPipeline';
+
+describe('a markdown image', () => {
+    it('keeps its src a string the component map can render', async () => {
+        const code = await compileGuideMdx('![the mark](/logo.svg)');
+
+        expect(code).toContain('src="/logo.svg"');
+    });
+
+    it('carries the size read off the file', async () => {
+        const code = await compileGuideMdx('![the mark](/logo.svg)');
+
+        expect(code).toContain('width="596.16"');
+        expect(code).toContain('height="500.4"');
+    });
+});
+
+describe('heading depth', () => {
+    it('takes h2 through h4', async () => {
+        await expect(compileGuideMdx(['## two', '', '### three', '', '#### four'].join('\n'))).resolves.toContain(
+            '_components.h4'
+        );
+    });
+
+    it.each([
+        ['# one', 'h1'],
+        ['##### five', 'h5'],
+        ['###### six', 'h6']
+    ])('refuses %s', async (source, name) => {
+        await expect(compileGuideMdx(source)).rejects.toThrow(name);
+    });
+
+    it('points at the line the heading is on', async () => {
+        const thrown = await compileGuideMdx(['## two', '', '##### five'].join('\n')).catch((error: unknown) => error);
+
+        expect(thrown).toMatchObject({ line: 3, file: 'content/docs/sample.mdx' });
+    });
+});
+
+describe('a pipe table', () => {
+    it('parses into a table the component map can style', async () => {
+        const code = await compileGuideMdx(['| a | b |', '| --- | --- |', '| 1 | 2 |'].join('\n'));
+
+        expect(code).toContain('_components.table');
+    });
+});

--- a/apps/guide/tests/mdxPipeline.test.ts
+++ b/apps/guide/tests/mdxPipeline.test.ts
@@ -39,6 +39,18 @@ describe('heading depth', () => {
     });
 });
 
+describe('a fence caption', () => {
+    function fence(meta: string): string {
+        return [`\`\`\`ts ${meta}`, 'const a = 1;', '```'].join('\n');
+    }
+
+    it('carries the title through to the code element', async () => {
+        const code = await compileGuideMdx(fence('title="src/commands/Ping.ts"'));
+
+        expect(code).toContain('src/commands/Ping.ts');
+    });
+});
+
 describe('a pipe table', () => {
     it('parses into a table the component map can style', async () => {
         const code = await compileGuideMdx(['| a | b |', '| --- | --- |', '| 1 | 2 |'].join('\n'));

--- a/apps/guide/tests/mdxPipeline.test.ts
+++ b/apps/guide/tests/mdxPipeline.test.ts
@@ -61,6 +61,13 @@ describe('a fence caption', () => {
 
         expect(code).not.toContain('data-output');
     });
+
+    it('reads the word output outside the title only', async () => {
+        const code = await compileGuideMdx(fence('title="build output log.ts"'));
+
+        expect(code).toContain('build output log.ts');
+        expect(code).not.toContain('data-output');
+    });
 });
 
 describe('a pipe table', () => {

--- a/apps/guide/tests/mdxPipeline.test.ts
+++ b/apps/guide/tests/mdxPipeline.test.ts
@@ -49,6 +49,18 @@ describe('a fence caption', () => {
 
         expect(code).toContain('src/commands/Ping.ts');
     });
+
+    it('marks a fence the author tagged as output', async () => {
+        const code = await compileGuideMdx(fence('output'));
+
+        expect(code).toContain('data-output');
+    });
+
+    it('leaves an untagged fence unmarked', async () => {
+        const code = await compileGuideMdx(fence('title="a.ts"'));
+
+        expect(code).not.toContain('data-output');
+    });
 });
 
 describe('a pipe table', () => {

--- a/apps/guide/tests/mdxPipeline.ts
+++ b/apps/guide/tests/mdxPipeline.ts
@@ -1,0 +1,15 @@
+import { compile } from '@mdx-js/mdx';
+import { mdxPreset } from 'fumadocs-core/content/mdx/preset-bundler';
+
+import config from '../source.config';
+
+type PresetOptions = Parameters<typeof mdxPreset>[0];
+
+export async function compileGuideMdx(source: string): Promise<string> {
+    const authored = typeof config.mdxOptions === 'function' ? await config.mdxOptions() : config.mdxOptions;
+    // source.config.ts never picks the 'minimal' preset, the other arm of the declared type
+    const options = await mdxPreset(authored as PresetOptions);
+    const file = { value: source, path: 'content/docs/sample.mdx' };
+
+    return String(await compile(file, { ...options, jsx: true }));
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -401,6 +401,9 @@ importers:
 
   apps/guide:
     dependencies:
+      '@seedcord/docs-engine':
+        specifier: workspace:^
+        version: link:../../tooling/docs-engine
       '@seedcord/ui':
         specifier: workspace:^
         version: link:../../tooling/ui

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -406,10 +406,10 @@ importers:
         version: link:../../tooling/ui
       fumadocs-core:
         specifier: 16.14.4
-        version: 16.14.4(@mdx-js/mdx@3.1.1(supports-color@10.2.2))(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.31.0(react@19.2.8))(next@16.2.12(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@10.2.2)(zod@4.4.3)
+        version: 16.14.4(@mdx-js/mdx@3.1.1(supports-color@10.2.2))(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.31.0(react@19.2.8))(next@16.2.12(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@10.2.2)(zod@3.25.76)
       fumadocs-mdx:
         specifier: 15.2.3
-        version: 15.2.3(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.18)(fumadocs-core@16.14.4(@mdx-js/mdx@3.1.1(supports-color@10.2.2))(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.31.0(react@19.2.8))(next@16.2.12(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@10.2.2)(zod@4.4.3))(next@16.2.12(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(rolldown@1.2.1)(supports-color@10.2.2)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0))
+        version: 15.2.3(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.18)(fumadocs-core@16.14.4(@mdx-js/mdx@3.1.1(supports-color@10.2.2))(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.31.0(react@19.2.8))(next@16.2.12(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@10.2.2)(zod@3.25.76))(next@16.2.12(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(rolldown@1.2.1)(supports-color@10.2.2)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0))
       motion:
         specifier: catalog:deps
         version: 12.43.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -426,6 +426,9 @@ importers:
         specifier: catalog:deps
         version: 4.4.3
     devDependencies:
+      '@mdx-js/mdx':
+        specifier: ^3.1.1
+        version: 3.1.1(supports-color@10.2.2)
       '@seedcord/eslint-config':
         specifier: workspace:^
         version: link:../../tooling/eslint-config
@@ -5909,6 +5912,7 @@ packages:
   eslint@9.39.4:
     resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -14018,7 +14022,7 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  fumadocs-core@16.14.4(@mdx-js/mdx@3.1.1(supports-color@10.2.2))(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.31.0(react@19.2.8))(next@16.2.12(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@10.2.2)(zod@4.4.3):
+  fumadocs-core@16.14.4(@mdx-js/mdx@3.1.1(supports-color@10.2.2))(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.31.0(react@19.2.8))(next@16.2.12(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@10.2.2)(zod@3.25.76):
     dependencies:
       '@fumari/image-size': 0.1.0
       estree-util-value-to-estree: 3.5.0
@@ -14049,18 +14053,18 @@ snapshots:
       next: 16.2.12(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
-      zod: 4.4.3
+      zod: 3.25.76
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@15.2.3(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.18)(fumadocs-core@16.14.4(@mdx-js/mdx@3.1.1(supports-color@10.2.2))(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.31.0(react@19.2.8))(next@16.2.12(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@10.2.2)(zod@4.4.3))(next@16.2.12(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(rolldown@1.2.1)(supports-color@10.2.2)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0)):
+  fumadocs-mdx@15.2.3(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.18)(fumadocs-core@16.14.4(@mdx-js/mdx@3.1.1(supports-color@10.2.2))(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.31.0(react@19.2.8))(next@16.2.12(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@10.2.2)(zod@3.25.76))(next@16.2.12(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(rolldown@1.2.1)(supports-color@10.2.2)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0)):
     dependencies:
       '@mdx-js/mdx': 3.1.1(supports-color@10.2.2)
       '@standard-schema/spec': 1.1.0
       chokidar: 5.0.0
       esbuild: 0.28.1
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.14.4(@mdx-js/mdx@3.1.1(supports-color@10.2.2))(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.31.0(react@19.2.8))(next@16.2.12(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@10.2.2)(zod@4.4.3)
+      fumadocs-core: 16.14.4(@mdx-js/mdx@3.1.1(supports-color@10.2.2))(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.31.0(react@19.2.8))(next@16.2.12(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@10.2.2)(zod@3.25.76)
       github-slugger: 2.0.0
       magic-string: 1.2.0
       mdast-util-mdx: 3.0.0(supports-color@10.2.2)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ catalogs:
       specifier: ^4.6.2
       version: 4.6.2
     lucide-react:
-      specifier: ^1.28.0
+      specifier: ^1.31.0
       version: 1.31.0
     motion:
       specifier: ^12.43.0
@@ -410,6 +410,9 @@ importers:
       fumadocs-mdx:
         specifier: 15.2.3
         version: 15.2.3(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.18)(fumadocs-core@16.14.4(@mdx-js/mdx@3.1.1(supports-color@10.2.2))(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.31.0(react@19.2.8))(next@16.2.12(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@10.2.2)(zod@3.25.76))(next@16.2.12(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(rolldown@1.2.1)(supports-color@10.2.2)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.5)(yaml@2.9.0))
+      lucide-react:
+        specifier: catalog:deps
+        version: 1.31.0(react@19.2.8)
       motion:
         specifier: catalog:deps
         version: 12.43.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -54,7 +54,7 @@ catalogs:
     chalk: ^6.0.0
     discord-api-types: ^0.38.52
     lodash.merge: ^4.6.2
-    lucide-react: ^1.28.0
+    lucide-react: ^1.31.0
     motion: ^12.43.0
     next: ^16.2.12
     prettier: ^3.9.6

--- a/tooling/docs-engine/src/client.ts
+++ b/tooling/docs-engine/src/client.ts
@@ -2,6 +2,7 @@
 // `@microsoft/api-extractor-model`, `prettier`, or `node:*` belongs in index.ts, because a `node:*` import
 // reachable from a client bundle breaks `next build`.
 export * from '#src/anchors';
+export { slugifySegment } from '#src/Slugger';
 export * from '#src/tones';
 export * from '#routing/url-builder';
 export * from '#packages/identity';

--- a/tooling/docs-engine/src/client.ts
+++ b/tooling/docs-engine/src/client.ts
@@ -1,6 +1,5 @@
-// Node-free subset, safe to import from client components. Anything that value-imports
-// `@microsoft/api-extractor-model`, `prettier`, or `node:*` belongs in index.ts, because a `node:*` import
-// reachable from a client bundle breaks `next build`.
+// Node-free subset, safe in a client component. Anything that value-imports `@microsoft/api-extractor-model`,
+// `prettier`, or `node:*` belongs in index.ts, because a `node:*` import in a client bundle breaks `next build`.
 export * from '#src/anchors';
 export { slugifySegment } from '#src/Slugger';
 export * from '#src/tones';

--- a/tooling/ui/src/CodeBlock.tsx
+++ b/tooling/ui/src/CodeBlock.tsx
@@ -27,7 +27,7 @@ export function CodeBlock({ representation, label, copyValue, actions, className
     const showHeader = Boolean(label) || showCopy || Boolean(actions);
 
     return (
-        <Card as="figure" variant="default" size="none" className={cn('overflow-hidden bg-(--bg-code)', className)}>
+        <Card as="figure" variant="flat" size="none" className={cn('overflow-hidden bg-(--bg-code)', className)}>
             {showHeader ? (
                 <figcaption
                     className={cn(

--- a/tooling/ui/src/CodeBlock.tsx
+++ b/tooling/ui/src/CodeBlock.tsx
@@ -8,7 +8,7 @@ import type { ReactElement, ReactNode } from 'react';
 
 export interface CodeBlockProps {
     representation: CodeRepresentation;
-    label?: string;
+    label?: string | undefined;
     /**
      * Optional override for the copy-button's clipboard value. Defaults to
      * `representation.text`. Pass `null` to suppress the copy button.

--- a/tooling/ui/src/CodeBlock.tsx
+++ b/tooling/ui/src/CodeBlock.tsx
@@ -13,7 +13,7 @@ export interface CodeBlockProps {
      * Optional override for the copy-button's clipboard value. Defaults to
      * `representation.text`. Pass `null` to suppress the copy button.
      */
-    copyValue?: string | null;
+    copyValue?: string | null | undefined;
     /** Rendered in the header beside the copy button. */
     actions?: ReactNode;
     className?: string;

--- a/tooling/ui/src/CodeBlock.tsx
+++ b/tooling/ui/src/CodeBlock.tsx
@@ -9,10 +9,7 @@ import type { ReactElement, ReactNode } from 'react';
 export interface CodeBlockProps {
     representation: CodeRepresentation;
     label?: string | undefined;
-    /**
-     * Optional override for the copy-button's clipboard value. Defaults to
-     * `representation.text`. Pass `null` to suppress the copy button.
-     */
+    /** Defaults to `representation.text`. Pass `null` to leave the copy button out. */
     copyValue?: string | null | undefined;
     /** Rendered in the header beside the copy button. */
     actions?: ReactNode;

--- a/tooling/ui/src/CodeBlock.tsx
+++ b/tooling/ui/src/CodeBlock.tsx
@@ -27,11 +27,11 @@ export function CodeBlock({ representation, label, copyValue, actions, className
     const showHeader = Boolean(label) || showCopy || Boolean(actions);
 
     return (
-        <Card as="figure" variant="default" size="none" className={cn('overflow-hidden', className)}>
+        <Card as="figure" variant="default" size="none" className={cn('overflow-hidden bg-(--bg-code)', className)}>
             {showHeader ? (
                 <figcaption
                     className={cn(
-                        'flex items-center justify-between gap-3 border-b border-(--border)/70 bg-(--surface-moderate) px-3 py-1 text-xs font-medium text-(--text-muted)'
+                        'flex items-center justify-between gap-3 border-b border-(--border)/70 bg-(--bg-code-header) px-3 py-1 text-xs font-medium text-(--text-muted)'
                     )}
                 >
                     <span className={cn('truncate')}>{label}</span>

--- a/tooling/ui/src/styles/tokens.css
+++ b/tooling/ui/src/styles/tokens.css
@@ -21,6 +21,8 @@
     --husk: #9aa089;
     /* resource accent */
     --accent-r: #8b90a7;
+    /* for warnings */
+    --amber: #e0952a;
     /* switch thumb, kept constant in both themes so it stays light on the gray off-track and green on-track */
     --switch-thumb: #f8f6e8;
 
@@ -125,6 +127,9 @@
 
     --bg-surface-subtle: color-mix(in oklab, var(--bg) 95%, var(--surface) 5%);
     --bg-surface-moderate: color-mix(in oklab, var(--bg) 90%, var(--surface) 10%);
+    --bg-code: color-mix(in oklab, var(--bg) 96%, var(--text) 4%);
+    --bg-code-header: color-mix(in oklab, var(--bg) 94%, var(--text) 6%);
+    --bg-chip: color-mix(in oklab, var(--bg) 88%, var(--text) 12%);
     --bg-accent-b-subtle: color-mix(in oklab, var(--bg) 94%, var(--rind) 6%);
     --bg-accent-b-moderate: color-mix(in oklab, var(--bg) 85%, var(--rind) 15%);
     --bg-accent-b-strong: color-mix(in oklab, var(--bg) 76%, var(--rind) 24%);

--- a/tooling/ui/src/styles/tokens.css
+++ b/tooling/ui/src/styles/tokens.css
@@ -34,6 +34,7 @@
     --text: var(--color-text);
     --surface: var(--color-surface);
     --border: color-mix(in oklab, var(--color-base-slate) 68%, var(--color-bg));
+    --link: var(--rind-deep);
 
     --shell-max: 80rem;
     --radius-surface: 0.375rem;
@@ -63,6 +64,7 @@
     --color-text: #f8f6e8;
     --color-surface: rgba(255, 255, 255, 0.04);
     --border: color-mix(in oklab, var(--pith) 28%, var(--color-bg));
+    --link: var(--rind);
 
     color-scheme: dark;
 }

--- a/tooling/ui/src/styles/tokens.css
+++ b/tooling/ui/src/styles/tokens.css
@@ -7,7 +7,7 @@
 
     /* the brand pith. both themes hold this value while --color-bg flips dark */
     --pith: #f8f6e8;
-    /* canonical brand ink (watermelon seeds + the offset mark shadow), fixed in both themes */
+    /* brand ink for the seeds and the offset mark shadow, fixed in both themes */
     --seed-dark: #2d3328;
 
     /* mater red */
@@ -23,13 +23,13 @@
     --accent-r: #8b90a7;
     /* for warnings */
     --amber: #e0952a;
-    /* switch thumb, kept constant in both themes so it stays light on the gray off-track and green on-track */
+    /* the thumb must read on a gray off-track and a green on-track, in either theme */
     --switch-thumb: #f8f6e8;
 
     --overlay: rgba(0, 0, 0, 0.6);
     --deprecated-dark: #cf3234;
 
-    /* Tailwind v4 alias layer (consumed via bg-(--bg), text-(--text), etc.) */
+    /* what bg-(--bg) and text-(--text) resolve to */
     --bg: var(--color-bg);
     --text: var(--color-text);
     --surface: var(--color-surface);
@@ -69,7 +69,6 @@
     color-scheme: dark;
 }
 
-/* Computed variants — auto-follow theme via inherited bases */
 :root {
     /* Surface Mixes */
     --bg-dim: color-mix(in oklab, var(--color-bg) 94%, black 6%);
@@ -89,10 +88,10 @@
     --text-muted-light: color-mix(in oklab, var(--color-text) 85%, transparent);
     --text-faint: color-mix(in oklab, var(--color-text) 42%, transparent);
 
-    /* Focus ring (primitive focus-visible default) */
+    /* the focus-visible ring on every primitive */
     --focus-outline-b: color-mix(in oklab, var(--rind) 78%, transparent);
 
-    /* Popover/Tooltip surface — slightly tinted toward dark for contrast at any theme */
+    /* Popover/Tooltip surface */
     --bg-popover: color-mix(in oklab, var(--bg) 98%, var(--color-base-dark) 2%);
 
     /* Shadows */

--- a/tooling/ui/src/styles/tokens.css
+++ b/tooling/ui/src/styles/tokens.css
@@ -34,6 +34,7 @@
     --border: color-mix(in oklab, var(--color-base-slate) 68%, var(--color-bg));
 
     --shell-max: 80rem;
+    --radius-surface: 0.375rem;
 
     /* mirrored in @seedcord/ui/lib/motion.ts */
     --ease-out-strong: cubic-bezier(0.23, 1, 0.32, 1);
@@ -45,6 +46,11 @@
 
 /* the app layouts load a webfont for --font-display and --font-mono only */
 @theme {
+    /* a Badge-sized chip takes 2px less than a card */
+    --radius-sm: calc(var(--radius-surface) - 0.125rem);
+    --radius-md: var(--radius-surface);
+    --radius-lg: var(--radius-surface);
+
     --font-sans:
         -apple-system, BlinkMacSystemFont, 'Segoe UI Variable Text', 'Segoe UI', system-ui, Cantarell, 'Noto Sans',
         'Helvetica Neue', Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Noto Color Emoji';

--- a/tooling/ui/src/styles/utilities.css
+++ b/tooling/ui/src/styles/utilities.css
@@ -131,6 +131,7 @@
         border-radius: 0.35em;
         background-color: var(--bg-chip);
         padding: 0.1em 0.36em;
+        font-size: 0.9em;
     }
 
     .shiki a,

--- a/tooling/ui/src/styles/utilities.css
+++ b/tooling/ui/src/styles/utilities.css
@@ -43,8 +43,8 @@
         min-width: 100%;
     }
 
-    /* shiki dual-render wraps two <pre> in a theme-group div. Without this rule the wrapper
-     * is `width: auto` and absorbs the children's max-content, breaking the scroll chain. */
+    /* renderDual in shiki.ts wraps the two themed <pre> in this div. at auto width it
+     * absorbs their max-content and the block stops scrolling. */
     .code-scroll-area .shiki-theme-group {
         display: block;
         width: max-content;
@@ -83,7 +83,7 @@
         background-clip: content-box;
     }
 
-    /* hard offset ink shadow for the brand mark. mainly for the pith ground, fades to nothing on the dark one */
+    /* hard offset ink shadow for the brand mark, near invisible on the dark ground */
     .drop-shadow-mark {
         filter: drop-shadow(2px 2px 0 color-mix(in srgb, var(--seed-dark) 85%, transparent));
     }

--- a/tooling/ui/src/styles/utilities.css
+++ b/tooling/ui/src/styles/utilities.css
@@ -127,12 +127,10 @@
 
     .shiki-inline {
         display: inline;
+        border: 1px solid var(--border);
         border-radius: 0.35em;
-        background-color: color-mix(in oklab, var(--bg) 94%, var(--text) 6%);
+        background-color: var(--bg-chip);
         padding: 0.1em 0.36em;
-    }
-    [data-theme='dark'] .shiki-inline {
-        background-color: color-mix(in oklab, var(--bg) 89%, var(--text) 11%);
     }
 
     .shiki a,


### PR DESCRIPTION
## Checklist

- [x] Tests cover the change
- [x] `pnpm prePush` is green
- [x] Changeset added with `pnpm cs`, for any change to a published package


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the guide with practical examples covering commands, routing, validation, transports, callouts, references, images, tables, and more.
  * Added styled note, tip, warning, danger, and transport callouts.
  * Added enhanced code blocks with titles, output formatting, and smarter copy controls.
  * Added heading copy links, improved tables, image presentation, and external documentation references.

* **Improvements**
  * Refined navigation, theme-toggle placement, link styling, table-of-contents indentation, and heading scroll behavior.
  * Updated code and documentation styling for clearer visual presentation.

* **Tests**
  * Added coverage for guide components, MDX rendering, headings, callouts, references, images, and code blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->