### PR TITLE
refactor: shiki refactors

### DIFF
--- a/apps/docs/tests/lib/docs/renderReadme.test.ts
+++ b/apps/docs/tests/lib/docs/renderReadme.test.ts
@@ -42,7 +42,7 @@ describe('renderReadme', () => {
         const html = await renderReadme('```ts\nconst answer = 42;\n```');
 
         // same shiki output as the TSDoc prose renderer (renderParagraphs)
-        expect(html).toContain('shiki-theme-group');
+        expect(html).toContain('class="shiki');
         expect(html).toMatch(/style="[^"]*color:/i);
     });
 
@@ -50,7 +50,7 @@ describe('renderReadme', () => {
         // a bare ``` fence gives Marked an empty lang string, which must still use the ts default
         const html = await renderReadme('```\nconst answer = 42;\n```');
 
-        expect(html).toContain('shiki-theme-group');
+        expect(html).toContain('class="shiki');
         expect(html).toMatch(/color:[^"]*">const/i);
     });
 
@@ -59,6 +59,6 @@ describe('renderReadme', () => {
         const html = await renderReadme('```python\nprint("hi")\n```');
 
         expect(html).toContain('print("hi")');
-        expect(html).not.toContain('shiki-theme-group');
+        expect(html).not.toContain('class="shiki');
     });
 });

--- a/apps/guide/src/components/TypeHover.tsx
+++ b/apps/guide/src/components/TypeHover.tsx
@@ -142,15 +142,6 @@ function focusLeftTheBlock(event: FocusEvent<HTMLDivElement>): boolean {
     return !event.currentTarget.contains(to) && !to?.closest(POPOVER);
 }
 
-// highlightToHtml renders each block once per theme and hides one
-function isShowing(node: Element): boolean {
-    for (let step: Element | null = node; step; step = step.parentElement) {
-        if (getComputedStyle(step).display === 'none') return false;
-    }
-
-    return true;
-}
-
 type Show = (event: { target: EventTarget | null }, fromKey?: boolean) => void;
 
 // one tab stop per code block, since a page carries dozens of tokens
@@ -172,9 +163,7 @@ function useTokenWalk(
             const step = ARROW_STEP[event.key];
             if (!step || !block.current) return;
 
-            const tokens = [...block.current.querySelectorAll(TOKEN)].filter(
-                (node) => node.querySelector(TYPE) && isShowing(node)
-            );
+            const tokens = [...block.current.querySelectorAll(TOKEN)].filter((node) => node.querySelector(TYPE));
             const next = tokens[tokens.indexOf(marked.current as Element) + step];
             if (!next) return;
 

--- a/apps/guide/src/lib/rehypeFenceMeta.ts
+++ b/apps/guide/src/lib/rehypeFenceMeta.ts
@@ -1,6 +1,7 @@
-const TITLE = /(?:^|\s)title="([^"]*)"/;
-const OUTPUT = /(?:^|\s)output(?:\s|$)/;
-const TWOSLASH = /(?:^|\s)twoslash(?:\s|$)/;
+import { parseCodeBlockAttributes } from 'fumadocs-core/mdx-plugins/codeblock-utils';
+
+// a name outside this list stays in the meta untouched
+const FENCE_NAMES = ['title', 'output', 'twoslash'];
 
 export const LANGUAGE_PREFIX = 'language-';
 
@@ -46,15 +47,12 @@ function languageOf(code: Element): string {
 export function rehypeFenceMeta() {
     return (tree: Element, file: Reporter): void => {
         for (const code of codeElements(tree)) {
-            const meta = code.data?.meta ?? '';
-            const title = TITLE.exec(meta)?.[1];
-            // a title like "build output.ts" would otherwise read as a flag
-            const flags = meta.replace(TITLE, ' ');
+            const { attributes } = parseCodeBlockAttributes(code.data?.meta ?? '', FENCE_NAMES);
             const added: Record<string, unknown> = {};
 
-            if (title) added[FENCE_ATTR.title] = title;
-            if (OUTPUT.test(flags)) added[FENCE_ATTR.output] = '';
-            if (TWOSLASH.test(flags)) {
+            if (typeof attributes.title === 'string') added[FENCE_ATTR.title] = attributes.title;
+            if ('output' in attributes) added[FENCE_ATTR.output] = '';
+            if ('twoslash' in attributes) {
                 const lang = languageOf(code);
                 if (!TWOSLASH_LANGS.has(lang)) {
                     const names = [...TWOSLASH_LANGS].join(', ');

--- a/apps/guide/src/lib/twoslash.ts
+++ b/apps/guide/src/lib/twoslash.ts
@@ -3,7 +3,7 @@ import { highlightToHtml } from '@seedcord/ui/shiki';
 import ts from 'typescript';
 import { createTwoslasher } from 'twoslash';
 import { removeTwoslashNotations } from 'twoslash/fallback';
-import { removeCodeRanges, resolveNodePositions } from 'twoslash-protocol';
+import { removeCodeRanges, resolveNodePositions, splitLines } from 'twoslash-protocol';
 
 import { formatHoverType } from '#lib/formatHoverType';
 import { SAMPLE_AUGMENTATION } from '#lib/sampleTypes';
@@ -94,14 +94,9 @@ function commonIndent(code: string): number {
 }
 
 function indentRanges(code: string, width: number): [number, number][] {
-    const ranges: [number, number][] = [];
-    let index = 0;
-    for (const line of code.split('\n')) {
-        if (line.trim()) ranges.push([index, index + width]);
-        index += line.length + 1;
-    }
-
-    return ranges;
+    return splitLines(code)
+        .filter(([line]) => line.trim())
+        .map(([, start]) => [start, start + width]);
 }
 
 function dedent(code: string): string {
@@ -192,11 +187,12 @@ const TWOSLASH_OPTIONS = {
     extraFiles: { 'seedcord-gen.d.ts': SAMPLE_AUGMENTATION }
 };
 
-// the transformer aliases a typescript fence to ts before it reads the cache
+// the transformer aliases the fence lang before it reads the cache. the pre-warm below writes it
 const LANG_ALIAS: Record<string, string> = { typescript: 'ts' };
 
 const twoslash = transformerTwoslash({
     langs: ['ts', 'tsx'],
+    langAlias: LANG_ALIAS,
     typesCache,
     renderer,
     twoslasher: dedenting,

--- a/apps/guide/tests/components/TypeHover.test.tsx
+++ b/apps/guide/tests/components/TypeHover.test.tsx
@@ -102,26 +102,6 @@ describe('the type hover', () => {
             expect(block.querySelectorAll(`${TOKEN_SELECTOR}[tabindex]`)).toHaveLength(0);
         });
 
-        // highlightToHtml renders each block once per theme and hides one with css
-        it('skips the tokens in the hidden theme copy', async () => {
-            render(
-                <TypeHover>
-                    <div>
-                        <div style={{ display: 'none' }} dangerouslySetInnerHTML={{ __html: token('HiddenCopy') }} />
-                        <div dangerouslySetInnerHTML={{ __html: token('SlashHandler') }} />
-                    </div>
-                </TypeHover>
-            );
-            const block = document.querySelector('[role="group"]');
-            if (!(block instanceof HTMLElement)) throw new Error('no block rendered');
-            block.focus();
-
-            await userEvent.keyboard('{ArrowRight}');
-
-            await waitFor(() => expect(isOpen()).toBe(true));
-            expect(shownSymbol()).toBe('SlashHandler');
-        });
-
         it('drops the tab stop shiki puts inside the type', async () => {
             const block = renderBlock();
             block.focus();

--- a/apps/guide/tests/lib/twoslash.test.ts
+++ b/apps/guide/tests/lib/twoslash.test.ts
@@ -35,7 +35,8 @@ describe('the twoslash transformer', () => {
             )
         );
 
-        expect(html).toContain('class="shiki shiki-light seedcord-light twoslash');
+        // shiki owns the theme classes between these two
+        expect(html).toMatch(/<pre class="[^"]*\bshiki\b[^"]*\btwoslash\b/);
         expect(html).not.toContain('twoslash-error-line');
     });
 

--- a/tooling/ui/src/shiki.ts
+++ b/tooling/ui/src/shiki.ts
@@ -37,79 +37,9 @@ function ensureHighlighter(): Promise<HighlighterCore> {
     highlighterPromise ??= createHighlighterCore({
         themes: [seedcordBrandLight, seedcordBrandDark],
         langs: [langTs, langTsx, langJs, langJsx, langJson, langBash],
-        // the transformers below were written against oniguruma's tokenization
         engine: createOnigurumaEngine(import('shiki/wasm'))
     });
     return highlighterPromise;
-}
-
-interface HastTextNode {
-    type: 'text';
-    value: string;
-}
-interface HastElement {
-    type: 'element';
-    tagName: string;
-    properties?: Record<string, unknown>;
-    children: HastChild[];
-}
-type HastChild = HastTextNode | HastElement;
-
-function getClasses(node: HastElement): string[] {
-    const cls = node.properties?.class;
-    if (typeof cls === 'string') return cls.split(/\s+/).filter(Boolean);
-    if (Array.isArray(cls)) return cls.filter((c): c is string => typeof c === 'string');
-    return [];
-}
-
-function isLineElement(child: HastChild): child is HastElement {
-    return child.type === 'element' && child.tagName === 'span' && getClasses(child).includes('line');
-}
-
-function extractText(node: HastChild): string {
-    if (node.type === 'text') return node.value;
-    return node.children.map(extractText).join('');
-}
-
-function setText(node: HastChild, text: string): void {
-    if (node.type === 'text') {
-        node.value = text;
-        return;
-    }
-    node.children = [{ type: 'text', value: text }];
-}
-
-function dropSuffix(line: HastElement, suffix: string): void {
-    let remaining = suffix.length;
-    while (remaining > 0 && line.children.length > 0) {
-        const lastIdx = line.children.length - 1;
-        const last = line.children[lastIdx];
-        if (!last) break;
-        const text = extractText(last);
-        if (text.length <= remaining) {
-            remaining -= text.length;
-            line.children.splice(lastIdx, 1);
-            continue;
-        }
-        setText(last, text.slice(0, text.length - remaining));
-        remaining = 0;
-    }
-}
-
-function dropPrefix(line: HastElement, prefix: string): void {
-    let remaining = prefix.length;
-    while (remaining > 0 && line.children.length > 0) {
-        const first = line.children[0];
-        if (!first) break;
-        const text = extractText(first);
-        if (text.length <= remaining) {
-            remaining -= text.length;
-            line.children.shift();
-            continue;
-        }
-        setText(first, text.slice(remaining));
-        remaining = 0;
-    }
 }
 
 // shiki's decorations API needs token boundaries the TS grammar doesn't give (a return type `: Foo`
@@ -204,45 +134,6 @@ function applyLinkMarkers(html: string, markers: readonly SentinelLink[]): strin
     return result;
 }
 
-const stripFunctionWrap: ShikiTransformer = {
-    name: 'seedcord-strip-function-wrap',
-    code(codeEl) {
-        const root = codeEl as HastElement;
-        const lines = root.children.filter(isLineElement);
-        if (lines.length === 0) return;
-
-        const first = lines[0];
-        if (first) dropPrefix(first, 'function ');
-
-        for (let i = lines.length - 1; i >= 0; i -= 1) {
-            const line = lines[i];
-            if (!line || line.children.length === 0) continue;
-            dropSuffix(line, ' {}');
-            break;
-        }
-    }
-};
-
-const stripMemberWrap: ShikiTransformer = {
-    name: 'seedcord-strip-member-wrap',
-    code(codeEl) {
-        const root = codeEl as HastElement;
-        const lines = root.children.filter(isLineElement);
-        if (lines.length === 0) return;
-
-        const first = lines[0];
-        if (first) dropPrefix(first, 'class _ { ');
-
-        for (let i = lines.length - 1; i >= 0; i -= 1) {
-            const line = lines[i];
-            if (!line || line.children.length === 0) continue;
-            dropSuffix(line, ' }');
-            dropSuffix(line, ';');
-            break;
-        }
-    }
-};
-
 // safari breaks shiki's dual-theme mode (`themes: {…}` + `defaultColor: false`) because webkit does
 // not resolve a span's `color: var(--shiki-dark)` against an inline custom property on that same span.
 // globals.css switches the rendered pair by visibility.
@@ -255,17 +146,13 @@ async function renderDual(
     instrumented: string,
     markers: readonly SentinelLink[],
     lang: BundledLanguage,
-    transformers: ShikiTransformer[] = []
+    transformers: ShikiTransformer[] = [],
+    grammarContextCode?: string
 ): Promise<string> {
     const highlighter = await ensureHighlighter();
-    const lightRaw = decorateBlock(
-        highlighter.codeToHtml(instrumented, { lang, theme: THEMES.light, transformers }),
-        'light'
-    );
-    const darkRaw = decorateBlock(
-        highlighter.codeToHtml(instrumented, { lang, theme: THEMES.dark, transformers }),
-        'dark'
-    );
+    const shared = { lang, transformers, ...(!(grammarContextCode === undefined) && { grammarContextCode }) };
+    const lightRaw = decorateBlock(highlighter.codeToHtml(instrumented, { ...shared, theme: THEMES.light }), 'light');
+    const darkRaw = decorateBlock(highlighter.codeToHtml(instrumented, { ...shared, theme: THEMES.dark }), 'dark');
     const light = applyLinkMarkers(lightRaw, markers);
     const dark = applyLinkMarkers(darkRaw, markers);
     return `<div class="shiki-theme-group">${light}${dark}</div>`;
@@ -293,21 +180,13 @@ export async function highlightToHtml(
     }
 }
 
-// shiki reads `extends` inside `<T extends X>` as a keyword only with a statement in front of it. a
-// `class _ {…}` wrap breaks multi-line type-param constraints.
+// shiki reads `extends` inside `<T extends X>` as a keyword only with a statement in front of it
 export async function highlightSignatureToHtml(code: string, links: readonly CodeLink[] = []): Promise<string | null> {
     if (!code) return '';
 
     try {
-        const FN_PREFIX = 'function ';
-        const wrapped = `${FN_PREFIX}${code} {}`;
-        const shifted: CodeLink[] = links.map((l) => ({
-            ...l,
-            start: l.start + FN_PREFIX.length,
-            end: l.end + FN_PREFIX.length
-        }));
-        const { code: instrumented, markers } = instrumentLinks(wrapped, shifted);
-        return await renderDual(instrumented, markers, 'ts', [stripFunctionWrap]);
+        const { code: instrumented, markers } = instrumentLinks(code, links);
+        return await renderDual(instrumented, markers, 'ts', [], 'function ');
     } catch {
         return null;
     }
@@ -318,53 +197,20 @@ export async function highlightMemberToHtml(code: string, links: readonly CodeLi
     if (!code) return '';
 
     try {
-        const PREFIX = 'class _ { ';
-        const wrapped = `${PREFIX}${code}; }`;
-        const shifted: CodeLink[] = links.map((l) => ({
-            ...l,
-            start: l.start + PREFIX.length,
-            end: l.end + PREFIX.length
-        }));
-        const { code: instrumented, markers } = instrumentLinks(wrapped, shifted);
-        return await renderDual(instrumented, markers, 'ts', [stripMemberWrap]);
+        const { code: instrumented, markers } = instrumentLinks(code, links);
+        return await renderDual(instrumented, markers, 'ts', [], 'class _ { ');
     } catch {
         return null;
     }
 }
 
 // `<X extends Y = Z>` only tokenizes inside real generic brackets
-const stripTypeParamWrap: ShikiTransformer = {
-    name: 'seedcord-strip-type-param-wrap',
-    code(codeEl) {
-        const root = codeEl as HastElement;
-        const lines = root.children.filter(isLineElement);
-        if (lines.length === 0) return;
-
-        const first = lines[0];
-        if (first) dropPrefix(first, 'type _<');
-
-        for (let i = lines.length - 1; i >= 0; i -= 1) {
-            const line = lines[i];
-            if (!line || line.children.length === 0) continue;
-            dropSuffix(line, '> = unknown;');
-            break;
-        }
-    }
-};
-
 export async function highlightTypeParamToHtml(code: string, links: readonly CodeLink[] = []): Promise<string | null> {
     if (!code) return '';
 
     try {
-        const PREFIX = 'type _<';
-        const wrapped = `${PREFIX}${code}> = unknown;`;
-        const shifted: CodeLink[] = links.map((l) => ({
-            ...l,
-            start: l.start + PREFIX.length,
-            end: l.end + PREFIX.length
-        }));
-        const { code: instrumented, markers } = instrumentLinks(wrapped, shifted);
-        return await renderDual(instrumented, markers, 'ts', [stripTypeParamWrap]);
+        const { code: instrumented, markers } = instrumentLinks(code, links);
+        return await renderDual(instrumented, markers, 'ts', [], 'type _<');
     } catch {
         return null;
     }

--- a/tooling/ui/src/shiki.ts
+++ b/tooling/ui/src/shiki.ts
@@ -133,17 +133,19 @@ export async function highlightTypeParamToHtml(code: string, links: readonly Cod
     }
 }
 
-const CODE_INNER_RE = /<code[^>]*>([\s\S]*?)<\/code>/;
-
 export async function highlightInlineToHtml(code: string, lang: BundledLanguage = 'ts'): Promise<string | null> {
     if (!code) return '';
 
     try {
-        const html = await render(code, [], lang);
-        const inner = html.match(CODE_INNER_RE);
-        if (!inner) return null;
+        const highlighter = await ensureHighlighter();
+        const tokens = highlighter.codeToHtml(code, {
+            lang,
+            themes: THEMES,
+            defaultColor: 'light-dark()',
+            structure: 'inline'
+        });
 
-        return `<code class="shiki-inline">${inner[1]}</code>`;
+        return `<code class="shiki-inline">${tokens}</code>`;
     } catch {
         return null;
     }

--- a/tooling/ui/src/shiki.ts
+++ b/tooling/ui/src/shiki.ts
@@ -59,15 +59,8 @@ function toDecorations(links: readonly CodeLink[]): DecorationItem[] {
     }));
 }
 
-// safari breaks shiki's dual-theme mode (`themes: {…}` + `defaultColor: false`) because webkit does
-// not resolve a span's `color: var(--shiki-dark)` against an inline custom property on that same span.
-// globals.css switches the rendered pair by visibility.
-
-function decorateBlock(html: string, variant: 'light' | 'dark'): string {
-    return html.replace('<pre class="shiki', `<pre class="shiki shiki-${variant}`);
-}
-
-async function renderDual(
+// each token carries `color: light-dark(light, dark)`. shiki.css has the pre-2024 fallback
+async function render(
     code: string,
     links: readonly CodeLink[],
     lang: BundledLanguage,
@@ -75,16 +68,15 @@ async function renderDual(
     grammarContextCode?: string
 ): Promise<string> {
     const highlighter = await ensureHighlighter();
-    const shared = {
+
+    return highlighter.codeToHtml(code, {
         lang,
         transformers,
+        themes: THEMES,
+        defaultColor: 'light-dark()',
         decorations: toDecorations(links),
         ...(!(grammarContextCode === undefined) && { grammarContextCode })
-    };
-    const light = decorateBlock(highlighter.codeToHtml(code, { ...shared, theme: THEMES.light }), 'light');
-    const dark = decorateBlock(highlighter.codeToHtml(code, { ...shared, theme: THEMES.dark }), 'dark');
-
-    return `<div class="shiki-theme-group">${light}${dark}</div>`;
+    });
 }
 
 interface HighlightOptions {
@@ -101,7 +93,7 @@ export async function highlightToHtml(
     if (!code) return '';
 
     try {
-        return await renderDual(code, links, lang, transformers);
+        return await render(code, links, lang, transformers);
     } catch (error) {
         if (throwOnFailure) throw error;
         return null;
@@ -113,7 +105,7 @@ export async function highlightSignatureToHtml(code: string, links: readonly Cod
     if (!code) return '';
 
     try {
-        return await renderDual(code, links, 'ts', [], 'function ');
+        return await render(code, links, 'ts', [], 'function ');
     } catch {
         return null;
     }
@@ -124,7 +116,7 @@ export async function highlightMemberToHtml(code: string, links: readonly CodeLi
     if (!code) return '';
 
     try {
-        return await renderDual(code, links, 'ts', [], 'class _ { ');
+        return await render(code, links, 'ts', [], 'class _ { ');
     } catch {
         return null;
     }
@@ -135,7 +127,7 @@ export async function highlightTypeParamToHtml(code: string, links: readonly Cod
     if (!code) return '';
 
     try {
-        return await renderDual(code, links, 'ts', [], 'type _<');
+        return await render(code, links, 'ts', [], 'type _<');
     } catch {
         return null;
     }
@@ -143,21 +135,15 @@ export async function highlightTypeParamToHtml(code: string, links: readonly Cod
 
 const CODE_INNER_RE = /<code[^>]*>([\s\S]*?)<\/code>/;
 
-// per-theme render again, same webkit reason as renderDual. globals.css switches this pair on `display`.
 export async function highlightInlineToHtml(code: string, lang: BundledLanguage = 'ts'): Promise<string | null> {
     if (!code) return '';
 
     try {
-        const highlighter = await ensureHighlighter();
-        const lightInner = highlighter.codeToHtml(code, { lang, theme: THEMES.light }).match(CODE_INNER_RE);
-        const darkInner = highlighter.codeToHtml(code, { lang, theme: THEMES.dark }).match(CODE_INNER_RE);
-        if (!lightInner || !darkInner) return null;
-        return (
-            `<span class="shiki-inline-group">` +
-            `<code class="shiki-inline shiki-light">${lightInner[1]}</code>` +
-            `<code class="shiki-inline shiki-dark">${darkInner[1]}</code>` +
-            `</span>`
-        );
+        const html = await render(code, [], lang);
+        const inner = html.match(CODE_INNER_RE);
+        if (!inner) return null;
+
+        return `<code class="shiki-inline">${inner[1]}</code>`;
     } catch {
         return null;
     }

--- a/tooling/ui/src/shiki.ts
+++ b/tooling/ui/src/shiki.ts
@@ -191,9 +191,6 @@ function applyLinkMarkers(html: string, markers: readonly SentinelLink[]): strin
     if (markers.length === 0) return html;
 
     let result = normalizeSentinels(html);
-    // shiki sometimes tokenizes a lone sentinel into a span of its own, which leaves the open/close
-    // regex below nothing to match until the span is unwrapped
-    result = result.replaceAll(/<span[^>]*>\s*([-])\s*<\/span>/g, '$1');
 
     for (const marker of markers) {
         const attrs = marker.opensNewTab ? ' target="_blank" rel="noreferrer noopener"' : '';

--- a/tooling/ui/src/shiki.ts
+++ b/tooling/ui/src/shiki.ts
@@ -9,7 +9,7 @@ import { createOnigurumaEngine } from 'shiki/engine/oniguruma';
 
 import { seedcordBrandDark, seedcordBrandLight } from './brandTheme';
 
-import type { BundledLanguage, ShikiTransformer } from 'shiki';
+import type { BundledLanguage, DecorationItem, ShikiTransformer } from 'shiki';
 
 const THEMES = {
     light: 'seedcord-light',
@@ -28,7 +28,7 @@ export interface CodeLink {
     href: string;
     start: number;
     end: number;
-    // undefined falls back to the href protocol in instrumentLinks
+    // undefined falls back to the href protocol
     external?: boolean;
 }
 
@@ -42,96 +42,21 @@ function ensureHighlighter(): Promise<HighlighterCore> {
     return highlighterPromise;
 }
 
-// shiki's decorations API needs token boundaries the TS grammar doesn't give (a return type `: Foo`
-// tokenizes as one segment). the U+E000 sentinels below wrap a link range and survive tokenization
-// because the grammar reads them as identifier continuations.
-
-// a raw literal from that range renders as one of apple's private glyphs in a macos editor
-const LINK_OPEN = '\uE000';
-const LINK_OPEN_BOUND = '\uE001';
-const LINK_CLOSE = '\uE002';
-const LINK_CLOSE_BOUND = '\uE003';
-const INDEX_BASE = 0xe1_00;
-const SENTINEL_MIN = 0xe0_00;
-const SENTINEL_MAX = 0xe1_ff;
-const HEX_RADIX = 16;
-const DECIMAL_RADIX = 10;
-
-function escapeRegex(value: string): string {
-    return RegExp.escape(value);
-}
-
-function escapeHtmlAttr(value: string): string {
-    return value.replaceAll('&', '&amp;').replaceAll('"', '&quot;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
-}
-
-interface SentinelLink {
-    open: string;
-    close: string;
-    href: string;
-    opensNewTab: boolean;
-}
-
 const EXTERNAL_URL_RE = /^https?:\/\//i;
 
-// shiki writes the PUA chars out as numeric entities. decode first.
-function normalizeSentinels(html: string): string {
-    return html.replaceAll(/&#(x?)([0-9a-fA-F]+);/g, (match, isHex: string, value: string) => {
-        const code = Number.parseInt(value, isHex ? HEX_RADIX : DECIMAL_RADIX);
-        if (Number.isNaN(code)) return match;
-        if (code >= SENTINEL_MIN && code <= SENTINEL_MAX) return String.fromCharCode(code);
-        return match;
-    });
-}
+const NEW_TAB = { target: '_blank', rel: ['noreferrer', 'noopener'] };
 
-function instrumentLinks(code: string, links: readonly CodeLink[]): { code: string; markers: SentinelLink[] } {
-    if (links.length === 0) return { code, markers: [] };
-
-    // sorted by start because the cursor below only moves forward
-    const ordered = [...links].sort((a, b) => a.start - b.start);
-    const markers: SentinelLink[] = [];
-    let result = '';
-    let cursor = 0;
-    for (let i = 0; i < ordered.length; i += 1) {
-        const link = ordered[i];
-        if (!link) continue;
-        const indexCode = INDEX_BASE + i;
-        if (indexCode > SENTINEL_MAX) break;
-        const indexChar = String.fromCharCode(indexCode);
-        const open = `${LINK_OPEN}${indexChar}${LINK_OPEN_BOUND}`;
-        const close = `${LINK_CLOSE}${indexChar}${LINK_CLOSE_BOUND}`;
-        markers.push({
-            open,
-            close,
-            href: escapeHtmlAttr(link.href),
-            opensNewTab: link.external ?? EXTERNAL_URL_RE.test(link.href)
-        });
-
-        result += code.slice(cursor, link.start);
-        result += open;
-        result += code.slice(link.start, link.end);
-        result += close;
-        cursor = link.end;
-    }
-    result += code.slice(cursor);
-    return { code: result, markers };
-}
-
-function applyLinkMarkers(html: string, markers: readonly SentinelLink[]): string {
-    if (markers.length === 0) return html;
-
-    let result = normalizeSentinels(html);
-
-    for (const marker of markers) {
-        const attrs = marker.opensNewTab ? ' target="_blank" rel="noreferrer noopener"' : '';
-        const pattern = new RegExp(String.raw`${escapeRegex(marker.open)}([\s\S]*?)${escapeRegex(marker.close)}`, 'g');
-        result = result.replace(
-            pattern,
-            (_match, content: string) => `<a href="${marker.href}"${attrs}>${content}</a>`
-        );
-    }
-
-    return result;
+// transformerDecorations splits a token at any offset, so a link inside `: Foo` gets its own anchor
+function toDecorations(links: readonly CodeLink[]): DecorationItem[] {
+    return links.map((link) => ({
+        start: link.start,
+        end: link.end,
+        tagName: 'a',
+        properties: {
+            href: link.href,
+            ...((link.external ?? EXTERNAL_URL_RE.test(link.href)) && NEW_TAB)
+        }
+    }));
 }
 
 // safari breaks shiki's dual-theme mode (`themes: {…}` + `defaultColor: false`) because webkit does
@@ -143,18 +68,22 @@ function decorateBlock(html: string, variant: 'light' | 'dark'): string {
 }
 
 async function renderDual(
-    instrumented: string,
-    markers: readonly SentinelLink[],
+    code: string,
+    links: readonly CodeLink[],
     lang: BundledLanguage,
     transformers: ShikiTransformer[] = [],
     grammarContextCode?: string
 ): Promise<string> {
     const highlighter = await ensureHighlighter();
-    const shared = { lang, transformers, ...(!(grammarContextCode === undefined) && { grammarContextCode }) };
-    const lightRaw = decorateBlock(highlighter.codeToHtml(instrumented, { ...shared, theme: THEMES.light }), 'light');
-    const darkRaw = decorateBlock(highlighter.codeToHtml(instrumented, { ...shared, theme: THEMES.dark }), 'dark');
-    const light = applyLinkMarkers(lightRaw, markers);
-    const dark = applyLinkMarkers(darkRaw, markers);
+    const shared = {
+        lang,
+        transformers,
+        decorations: toDecorations(links),
+        ...(!(grammarContextCode === undefined) && { grammarContextCode })
+    };
+    const light = decorateBlock(highlighter.codeToHtml(code, { ...shared, theme: THEMES.light }), 'light');
+    const dark = decorateBlock(highlighter.codeToHtml(code, { ...shared, theme: THEMES.dark }), 'dark');
+
     return `<div class="shiki-theme-group">${light}${dark}</div>`;
 }
 
@@ -172,8 +101,7 @@ export async function highlightToHtml(
     if (!code) return '';
 
     try {
-        const { code: instrumented, markers } = instrumentLinks(code, links);
-        return await renderDual(instrumented, markers, lang, transformers);
+        return await renderDual(code, links, lang, transformers);
     } catch (error) {
         if (throwOnFailure) throw error;
         return null;
@@ -185,8 +113,7 @@ export async function highlightSignatureToHtml(code: string, links: readonly Cod
     if (!code) return '';
 
     try {
-        const { code: instrumented, markers } = instrumentLinks(code, links);
-        return await renderDual(instrumented, markers, 'ts', [], 'function ');
+        return await renderDual(code, links, 'ts', [], 'function ');
     } catch {
         return null;
     }
@@ -197,8 +124,7 @@ export async function highlightMemberToHtml(code: string, links: readonly CodeLi
     if (!code) return '';
 
     try {
-        const { code: instrumented, markers } = instrumentLinks(code, links);
-        return await renderDual(instrumented, markers, 'ts', [], 'class _ { ');
+        return await renderDual(code, links, 'ts', [], 'class _ { ');
     } catch {
         return null;
     }
@@ -209,8 +135,7 @@ export async function highlightTypeParamToHtml(code: string, links: readonly Cod
     if (!code) return '';
 
     try {
-        const { code: instrumented, markers } = instrumentLinks(code, links);
-        return await renderDual(instrumented, markers, 'ts', [], 'type _<');
+        return await renderDual(code, links, 'ts', [], 'type _<');
     } catch {
         return null;
     }

--- a/tooling/ui/src/styles/shiki.css
+++ b/tooling/ui/src/styles/shiki.css
@@ -1,21 +1,10 @@
-/* Safari fails to resolve CSS variables from inline declarations, so we toggle visibility instead. */
-.shiki-theme-group .shiki-dark,
-.shiki-inline-group .shiki-dark {
-    display: none;
-}
-.shiki-theme-group .shiki-light {
-    display: block;
-}
-.shiki-inline-group .shiki-light {
-    display: inline;
-}
-[data-theme='dark'] .shiki-theme-group .shiki-light,
-[data-theme='dark'] .shiki-inline-group .shiki-light {
-    display: none;
-}
-[data-theme='dark'] .shiki-theme-group .shiki-dark {
-    display: block;
-}
-[data-theme='dark'] .shiki-inline-group .shiki-dark {
-    display: inline;
+/* a browser without light-dark() drops the whole color declaration, taking the highlighting with it.
+ * shiki writes these custom properties alongside for exactly that case. */
+@supports not (color: light-dark(red, blue)) {
+    .shiki,
+    .shiki span,
+    .shiki-inline,
+    .shiki-inline span {
+        color: var(--shiki-dark);
+    }
 }

--- a/tooling/ui/src/styles/shiki.css
+++ b/tooling/ui/src/styles/shiki.css
@@ -5,6 +5,13 @@
     .shiki span,
     .shiki-inline,
     .shiki-inline span {
+        color: var(--shiki-light);
+    }
+
+    [data-theme='dark'] .shiki,
+    [data-theme='dark'] .shiki span,
+    [data-theme='dark'] .shiki-inline,
+    [data-theme='dark'] .shiki-inline span {
         color: var(--shiki-dark);
     }
 }

--- a/tooling/ui/src/styles/utilities.css
+++ b/tooling/ui/src/styles/utilities.css
@@ -43,14 +43,6 @@
         min-width: 100%;
     }
 
-    /* renderDual in shiki.ts wraps the two themed <pre> in this div. at auto width it
-     * absorbs their max-content and the block stops scrolling. */
-    .code-scroll-area .shiki-theme-group {
-        display: block;
-        width: max-content;
-        min-width: 100%;
-    }
-
     .code-scroll-area .shiki {
         display: block;
         width: max-content;

--- a/tooling/ui/tests/shiki.test.ts
+++ b/tooling/ui/tests/shiki.test.ts
@@ -27,8 +27,8 @@ function textOf(html: string): string {
         .replaceAll(/&(?:#x3C|#x26|#39|lt|gt|amp|quot);/g, (match) => ENTITIES[match] ?? match);
 }
 
-function lightText(html: string): string {
-    return textOf(/<pre class="shiki shiki-light[\s\S]*?<\/pre>/.exec(html)?.[0] ?? '');
+function codeText(html: string): string {
+    return textOf(/<pre[\s\S]*?<\/pre>/.exec(html)?.[0] ?? '');
 }
 
 // hast decides the attribute order
@@ -41,13 +41,19 @@ function attrsFor(html: string, href: string): string[] {
 }
 
 describe('highlightToHtml', () => {
-    it('renders one block per theme so a span carries a resolved colour', async () => {
+    it('renders one block carrying both theme colours', async () => {
         const html = await highlightToHtml('const x = 1;');
 
-        expect(html).toContain('shiki-theme-group');
-        expect(html).toContain('shiki-light');
-        expect(html).toContain('shiki-dark');
-        expect(html?.match(/<pre/g)).toHaveLength(2);
+        expect(html?.match(/<pre/g)).toHaveLength(1);
+        expect(html).toMatch(/color:light-dark\(#[0-9a-fA-F]+, #[0-9a-fA-F]+\)/);
+    });
+
+    // the @supports fallback in shiki.css reads these
+    it('keeps a per-theme custom property on each token', async () => {
+        const html = await highlightToHtml('const x = 1;');
+
+        expect(html).toContain('--shiki-light:');
+        expect(html).toContain('--shiki-dark:');
     });
 
     it('turns a link range into an anchor around that text', async () => {
@@ -113,7 +119,7 @@ describe('highlightToHtml', () => {
         await expect(highlightToHtml('')).resolves.toBe('');
     });
 
-    it('runs a caller transformer over both themes', async () => {
+    it('runs a caller transformer over the block', async () => {
         const marker: ShikiTransformer = {
             name: 'marker',
             pre(node) {
@@ -123,7 +129,7 @@ describe('highlightToHtml', () => {
 
         const html = (await highlightToHtml('const x = 1;', 'ts', { transformers: [marker] })) ?? '';
 
-        expect(html.match(/from-a-transformer/g)).toHaveLength(2);
+        expect(html.match(/from-a-transformer/g)).toHaveLength(1);
     });
 });
 
@@ -137,19 +143,19 @@ describe('the wrapped fragment helpers', () => {
     it('drops the function wrap a signature needed to tokenize', async () => {
         const html = await highlightSignatureToHtml('doThing(count: number): void');
 
-        expect(lightText(html ?? '')).toBe('doThing(count: number): void');
+        expect(codeText(html ?? '')).toBe('doThing(count: number): void');
     });
 
     it('drops the class wrap a member needed to tokenize', async () => {
         const html = await highlightMemberToHtml('protected readonly name: string');
 
-        expect(lightText(html ?? '')).toBe('protected readonly name: string');
+        expect(codeText(html ?? '')).toBe('protected readonly name: string');
     });
 
     it('drops the type alias wrap a type parameter needed to tokenize', async () => {
         const html = await highlightTypeParamToHtml('T extends string = never');
 
-        expect(lightText(html ?? '')).toBe('T extends string = never');
+        expect(codeText(html ?? '')).toBe('T extends string = never');
     });
 
     it('keeps a multi-line generic signature intact', async () => {
@@ -157,7 +163,7 @@ describe('the wrapped fragment helpers', () => {
 
         const html = await highlightSignatureToHtml(code);
 
-        expect(lightText(html ?? '')).toBe(code);
+        expect(codeText(html ?? '')).toBe(code);
     });
 
     it('anchors a signature link on exactly the linked name', async () => {
@@ -170,7 +176,7 @@ describe('the wrapped fragment helpers', () => {
             ])) ?? '';
 
         expect(anchorTextFor(html, '/d/counter')).toBe('Counter');
-        expect(lightText(html)).toBe(code);
+        expect(codeText(html)).toBe(code);
     });
 
     it('anchors a member link on exactly the linked name', async () => {
@@ -183,7 +189,7 @@ describe('the wrapped fragment helpers', () => {
             ])) ?? '';
 
         expect(anchorTextFor(html, '/d/array-source')).toBe('ArraySource');
-        expect(lightText(html)).toBe(code);
+        expect(codeText(html)).toBe(code);
     });
 
     it('anchors a type parameter link on exactly the linked name', async () => {
@@ -196,7 +202,7 @@ describe('the wrapped fragment helpers', () => {
             ])) ?? '';
 
         expect(anchorTextFor(html, '/d/registry')).toBe('SlashOptionRegistry');
-        expect(lightText(html)).toBe(code);
+        expect(codeText(html)).toBe(code);
     });
 });
 
@@ -211,12 +217,12 @@ describe('isHighlightable', () => {
 });
 
 describe('highlightInlineToHtml', () => {
-    it('pairs a light and dark inline code element', async () => {
-        const html = await highlightInlineToHtml('Foo');
+    it('renders one inline code element carrying both theme colours', async () => {
+        const html = (await highlightInlineToHtml('Foo')) ?? '';
 
-        expect(html).toContain('shiki-inline-group');
-        expect(html).toContain('shiki-inline shiki-light');
-        expect(html).toContain('shiki-inline shiki-dark');
+        expect(html.match(/<code/g)).toHaveLength(1);
+        expect(html).toContain('shiki-inline');
+        expect(html).toMatch(/color:light-dark\(/);
         expect(html).not.toContain('<pre');
     });
 });

--- a/tooling/ui/tests/shiki.test.ts
+++ b/tooling/ui/tests/shiki.test.ts
@@ -224,5 +224,6 @@ describe('highlightInlineToHtml', () => {
         expect(html).toContain('shiki-inline');
         expect(html).toMatch(/color:light-dark\(/);
         expect(html).not.toContain('<pre');
+        expect(html).not.toContain('class="line"');
     });
 });

--- a/tooling/ui/tests/shiki.test.ts
+++ b/tooling/ui/tests/shiki.test.ts
@@ -11,8 +11,20 @@ import {
 
 import type { ShikiTransformer } from 'shiki';
 
+const ENTITIES: Record<string, string> = {
+    '&#x3C;': '<',
+    '&lt;': '<',
+    '&gt;': '>',
+    '&#x26;': '&',
+    '&amp;': '&',
+    '&quot;': '"',
+    '&#39;': "'"
+};
+
 function textOf(html: string): string {
-    return html.replaceAll(/<[^>]+>/g, '');
+    return html
+        .replaceAll(/<[^>]+>/g, '')
+        .replaceAll(/&(?:#x3C|#x26|#39|lt|gt|amp|quot);/g, (match) => ENTITIES[match] ?? match);
 }
 
 function lightText(html: string): string {
@@ -112,6 +124,12 @@ describe('highlightToHtml', () => {
     });
 });
 
+function anchorTextFor(html: string, href: string): string | null {
+    const match = new RegExp(String.raw`<a href="${href}"[^>]*>([\s\S]*?)</a>`).exec(html);
+
+    return match ? textOf(match[1] ?? '') : null;
+}
+
 describe('the wrapped fragment helpers', () => {
     it('drops the function wrap a signature needed to tokenize', async () => {
         const html = await highlightSignatureToHtml('doThing(count: number): void');
@@ -129,6 +147,53 @@ describe('the wrapped fragment helpers', () => {
         const html = await highlightTypeParamToHtml('T extends string = never');
 
         expect(lightText(html ?? '')).toBe('T extends string = never');
+    });
+
+    it('keeps a multi-line generic signature intact', async () => {
+        const code = ['doThing<', '    T extends Record<string, unknown>', '>(value: T): void'].join('\n');
+
+        const html = await highlightSignatureToHtml(code);
+
+        expect(lightText(html ?? '')).toBe(code);
+    });
+
+    it('anchors a signature link on exactly the linked name', async () => {
+        const code = 'doThing(count: Counter): void';
+        const start = code.indexOf('Counter');
+
+        const html =
+            (await highlightSignatureToHtml(code, [
+                { name: 'Counter', href: '/d/counter', start, end: start + 'Counter'.length }
+            ])) ?? '';
+
+        expect(anchorTextFor(html, '/d/counter')).toBe('Counter');
+        expect(lightText(html)).toBe(code);
+    });
+
+    it('anchors a member link on exactly the linked name', async () => {
+        const code = 'protected readonly source: ArraySource';
+        const start = code.indexOf('ArraySource');
+
+        const html =
+            (await highlightMemberToHtml(code, [
+                { name: 'ArraySource', href: '/d/array-source', start, end: start + 'ArraySource'.length }
+            ])) ?? '';
+
+        expect(anchorTextFor(html, '/d/array-source')).toBe('ArraySource');
+        expect(lightText(html)).toBe(code);
+    });
+
+    it('anchors a type parameter link on exactly the linked name', async () => {
+        const code = 'Route extends SlashOptionRegistry';
+        const start = code.indexOf('SlashOptionRegistry');
+
+        const html =
+            (await highlightTypeParamToHtml(code, [
+                { name: 'SlashOptionRegistry', href: '/d/registry', start, end: start + 'SlashOptionRegistry'.length }
+            ])) ?? '';
+
+        expect(anchorTextFor(html, '/d/registry')).toBe('SlashOptionRegistry');
+        expect(lightText(html)).toBe(code);
     });
 });
 

--- a/tooling/ui/tests/shiki.test.ts
+++ b/tooling/ui/tests/shiki.test.ts
@@ -31,10 +31,13 @@ function lightText(html: string): string {
     return textOf(/<pre class="shiki shiki-light[\s\S]*?<\/pre>/.exec(html)?.[0] ?? '');
 }
 
-const ANCHOR_RE = /<a href="([^"]*)"([^>]*)>/g;
+// hast decides the attribute order
+const ANCHOR_RE = /<a\s([^>]*)>/g;
 
 function attrsFor(html: string, href: string): string[] {
-    return [...html.matchAll(ANCHOR_RE)].filter((match) => match[1] === href).map((match) => match[2] ?? '');
+    return [...html.matchAll(ANCHOR_RE)]
+        .map((match) => match[1] ?? '')
+        .filter((attrs) => attrs.includes(`href="${href}"`));
 }
 
 describe('highlightToHtml', () => {
@@ -125,7 +128,7 @@ describe('highlightToHtml', () => {
 });
 
 function anchorTextFor(html: string, href: string): string | null {
-    const match = new RegExp(String.raw`<a href="${href}"[^>]*>([\s\S]*?)</a>`).exec(html);
+    const match = new RegExp(String.raw`<a\s[^>]*href="${href}"[^>]*>([\s\S]*?)</a>`).exec(html);
 
     return match ? textOf(match[1] ?? '') : null;
 }

--- a/tooling/ui/tests/shiki.test.ts
+++ b/tooling/ui/tests/shiki.test.ts
@@ -82,6 +82,18 @@ describe('highlightToHtml', () => {
         expect(remote.every((attrs) => attrs.includes('target="_blank"'))).toBe(true);
     });
 
+    it('keeps a subtraction operator coloured in a block that carries a link', async () => {
+        const code = 'const gap = end - start;';
+        const start = code.indexOf('end');
+        const html =
+            (await highlightToHtml(code, 'ts', {
+                links: [{ name: 'end', href: '/docs/end', start, end: start + 'end'.length }]
+            })) ?? '';
+
+        expect(html).toContain('href="/docs/end"');
+        expect(html).toMatch(/<span[^>]*>\s*-\s*<\/span>/);
+    });
+
     it('returns an empty string for empty input', async () => {
         await expect(highlightToHtml('')).resolves.toBe('');
     });


### PR DESCRIPTION
## Checklist

- [x] Tests cover the change
- [x] `pnpm prePush` is green
- [-] Changeset added with `pnpm cs`, for any change to a published package


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated code highlighting to render a single, theme-aware block with improved light/dark mode support.
  - Improved inline code and linked code rendering, including signatures, members, and type parameters.
  - Enhanced keyboard navigation across highlighted type tokens.
  - Improved code fence metadata handling for titles, output, and Twoslash annotations.

- **Bug Fixes**
  - Improved compatibility for browsers without `light-dark()` support.
  - Fixed highlighting and language-alias handling for TypeScript examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->