### PR TITLE
feat: hovers as its own fence tag

### DIFF
--- a/apps/guide/content/dev/mdx-kit.mdx
+++ b/apps/guide/content/dev/mdx-kit.mdx
@@ -37,6 +37,8 @@ Tagging a fence `output` drops the copy button, for lines a terminal printed bac
 
 Tagging a fence `twoslash` runs the TypeScript compiler over it while the page builds. An error the sample never declared fails the build. A sample that stopped compiling cannot reach a page.
 
+Errors, `^?` queries, and completions all render on a `twoslash` fence. A checked fence weighs about what a plain one does. Adding `hovers` next to the tag makes every token hoverable, which prints that token's whole type into the page and costs around five times the bytes. Use it on the samples where the types are the lesson.
+
 A declared error renders under the line it came from, with the caret under the squiggled token.
 
 ```ts twoslash title="src/commands/Ping.ts"
@@ -88,6 +90,22 @@ A `^|` marker draws what an editor would offer at that point. The code is incomp
 const routes = { ping: 1, pong: 2, purge: 3, prune: 4 };
 routes.p;
 //      ^|
+```
+
+## Hovers
+
+On a `twoslash hovers` fence every token carries the type the compiler gave it. Hover one, or tab into the block and walk it with the arrow keys.
+
+```ts twoslash hovers
+import { SlashHandler, SlashRoute } from '@seedcord/gateway';
+
+@SlashRoute('ping')
+export class Ping extends SlashHandler<'ping'> {
+    public async execute(): Promise<void> {
+        const detailed = this.options.getBoolean('detailed');
+        await this.reply(detailed === true ? 'Pong, at length' : 'Pong');
+    }
+}
 ```
 
 ## Cuts

--- a/apps/guide/src/lib/mdxComponents.tsx
+++ b/apps/guide/src/lib/mdxComponents.tsx
@@ -7,6 +7,7 @@ import { TypeHover } from '#components/TypeHover';
 import { FENCE_ATTR, LANGUAGE_PREFIX } from '#lib/rehypeFenceMeta';
 import { twoslashBlock } from '#lib/twoslash';
 
+import type { FenceMode } from '#lib/twoslash';
 import type { MDXComponents } from 'mdx/types';
 import type { BundledLanguage } from 'shiki';
 import type { ComponentProps, ReactElement, ReactNode } from 'react';
@@ -78,7 +79,13 @@ interface Fenced {
     lang: BundledLanguage;
     title: string | undefined;
     output: boolean;
-    twoslash: boolean;
+    mode: FenceMode;
+}
+
+function modeOf(props: Record<string, unknown>): FenceMode {
+    if (!(FENCE_ATTR.twoslash in props)) return 'off';
+
+    return FENCE_ATTR.hovers in props ? 'hovers' : 'check';
 }
 
 // mdx renders a fence as <pre><code className="language-x">
@@ -101,7 +108,7 @@ function readFence(children: ReactNode): Fenced | null {
         lang: named && isHighlightable(named) ? named : 'ts',
         title: typeof title === 'string' ? title : undefined,
         output: FENCE_ATTR.output in props,
-        twoslash: FENCE_ATTR.twoslash in props
+        mode: modeOf(props)
     };
 }
 
@@ -146,13 +153,13 @@ async function Fence({ children }: FenceProps): Promise<ReactElement> {
     const fence = readFence(children);
     if (!fence) return <pre>{children}</pre>;
 
-    const representation = await twoslashBlock(fence.code, fence.lang, fence.twoslash);
+    const representation = await twoslashBlock(fence.code, fence.lang, fence.mode);
 
     const block = (
         <CodeBlock representation={representation} label={fence.title} copyValue={fence.output ? null : undefined} />
     );
 
-    return fence.twoslash ? <TypeHover>{block}</TypeHover> : block;
+    return fence.mode === 'hovers' ? <TypeHover>{block}</TypeHover> : block;
 }
 
 export const mdxComponents = {

--- a/apps/guide/src/lib/rehypeFenceMeta.ts
+++ b/apps/guide/src/lib/rehypeFenceMeta.ts
@@ -1,7 +1,7 @@
 import { parseCodeBlockAttributes } from 'fumadocs-core/mdx-plugins/codeblock-utils';
 
 // a name outside this list stays in the meta untouched
-const FENCE_NAMES = ['title', 'output', 'twoslash'];
+const FENCE_NAMES = ['title', 'output', 'twoslash', 'hovers'];
 
 export const LANGUAGE_PREFIX = 'language-';
 
@@ -9,7 +9,8 @@ export const LANGUAGE_PREFIX = 'language-';
 export const FENCE_ATTR = {
     title: 'data-title',
     output: 'data-output',
-    twoslash: 'data-twoslash'
+    twoslash: 'data-twoslash',
+    hovers: 'data-hovers'
 } as const;
 
 const TWOSLASH_LANGS = new Set(['ts', 'tsx', 'typescript']);
@@ -59,6 +60,9 @@ export function rehypeFenceMeta() {
                     file.fail(`twoslash checks ${names}. This fence is tagged ${lang || 'nothing'}.`, code);
                 }
                 added[FENCE_ATTR.twoslash] = '';
+                if ('hovers' in attributes) added[FENCE_ATTR.hovers] = '';
+            } else if ('hovers' in attributes) {
+                file.fail('hovers needs twoslash on the same fence.', code);
             }
 
             code.properties = { ...code.properties, ...added };

--- a/apps/guide/src/lib/twoslash.ts
+++ b/apps/guide/src/lib/twoslash.ts
@@ -190,17 +190,26 @@ const TWOSLASH_OPTIONS = {
 // the transformer aliases the fence lang before it reads the cache. the pre-warm below writes it
 const LANG_ALIAS: Record<string, string> = { typescript: 'ts' };
 
-const twoslash = transformerTwoslash({
+const SHARED = {
     langs: ['ts', 'tsx'],
     langAlias: LANG_ALIAS,
     typesCache,
-    renderer,
     twoslasher: dedenting,
     twoslashOptions: TWOSLASH_OPTIONS
-});
+};
 
-export async function twoslashBlock(code: string, lang: BundledLanguage, tagged: boolean): Promise<CodeRepresentation> {
-    if (!tagged) return { text: code, html: await highlightToHtml(code, lang) };
+// a hovered token carries its whole printed type into the markup
+const withoutHovers: TwoslashRenderer = { ...renderer, nodeStaticInfo: (_info, node) => node };
+
+const TRANSFORMER = {
+    check: transformerTwoslash({ ...SHARED, renderer: withoutHovers }),
+    hovers: transformerTwoslash({ ...SHARED, renderer })
+};
+
+export type FenceMode = 'off' | keyof typeof TRANSFORMER;
+
+export async function twoslashBlock(code: string, lang: BundledLanguage, mode: FenceMode): Promise<CodeRepresentation> {
+    if (mode === 'off') return { text: code, html: await highlightToHtml(code, lang) };
 
     // a trailing marker leaves the newline above it behind
     const text = dedent(removeTwoslashNotations(code).replace(/\n+$/, ''));
@@ -214,8 +223,10 @@ export async function twoslashBlock(code: string, lang: BundledLanguage, tagged:
         await learnFormatting(compiled.nodes);
         typesCache.write(code, compiled, extension);
 
+        const options = { transformers: [TRANSFORMER[mode]], throwOnFailure: true };
+
         // a sample that stopped compiling would otherwise render as plain text and pass the build
-        return { text, html: await highlightToHtml(code, lang, { transformers: [twoslash], throwOnFailure: true }) };
+        return { text, html: await highlightToHtml(code, lang, options) };
     } catch (error) {
         // a bad marker reaches typescript as a bare "Debug Failure" with no file and no line
         throw new Error(`twoslash failed on this sample:\n\n${code}\n\n${String(error)}`, { cause: error });

--- a/apps/guide/tests/lib/twoslash.test.ts
+++ b/apps/guide/tests/lib/twoslash.test.ts
@@ -7,7 +7,7 @@ function sample(...lines: string[]): string {
 }
 
 async function render(code: string, lang: 'ts' | 'tsx' | 'typescript' = 'ts'): Promise<string> {
-    const { html } = await twoslashBlock(code, lang, true);
+    const { html } = await twoslashBlock(code, lang, 'hovers');
 
     return html ?? '';
 }
@@ -127,13 +127,51 @@ describe('the twoslash transformer', () => {
     });
 
     it('stays out of the way when the fence carries no flag', async () => {
-        const { html } = await twoslashBlock('const count = 12;', 'ts', false);
+        const { html } = await twoslashBlock('const count = 12;', 'ts', 'off');
 
         expect(html).not.toContain('twoslash');
     });
 
+    describe('a fence checked without hovers', () => {
+        async function checked(code: string): Promise<string> {
+            const { html } = await twoslashBlock(code, 'ts', 'check');
+
+            return html ?? '';
+        }
+
+        it('names an undeclared error', async () => {
+            await expect(checked('const count: number = "twelve";')).rejects.toThrow(
+                'not marked as being expected: 2322'
+            );
+        });
+
+        it('leaves every token unhoverable', async () => {
+            const html = await checked("const routes = ['ping', 'ban'] as const;");
+
+            expect(html).not.toContain('twoslash-hover');
+        });
+
+        it('still renders a declared error', async () => {
+            const html = await checked(sample('// @errors: 2322', 'const count: number = "twelve";'));
+
+            expect(html).toContain('twoslash-error-line');
+        });
+
+        it('still renders a type query', async () => {
+            const html = await checked(
+                sample("const routes = ['ping', 'ban'] as const;", 'const first = routes[0];', '//    ^?')
+            );
+
+            expect(html).toContain('twoslash-query-line');
+        });
+    });
+
     it('hands the copy button a sample with no twoslash notation', async () => {
-        const { text } = await twoslashBlock(sample('// @errors: 2322', 'const count: number = "twelve";'), 'ts', true);
+        const { text } = await twoslashBlock(
+            sample('// @errors: 2322', 'const count: number = "twelve";'),
+            'ts',
+            'hovers'
+        );
 
         expect(text).toBe('const count: number = "twelve";');
     });
@@ -144,7 +182,7 @@ describe('the twoslash transformer', () => {
         const { html, text } = await twoslashBlock(
             sample('// @errors: 2322', 'const count: number = "twelve";'),
             'ts',
-            true
+            'hovers'
         );
 
         expect(html).not.toContain('twoslash');
@@ -188,7 +226,7 @@ describe('the twoslash transformer', () => {
         );
 
         it('copies without the indentation it was nested under', async () => {
-            const { text } = await twoslashBlock(nested, 'ts', true);
+            const { text } = await twoslashBlock(nested, 'ts', 'hovers');
 
             expect(text).toBe("await this.reply('Pong');");
         });
@@ -296,7 +334,7 @@ describe('the twoslash transformer', () => {
     });
 
     it('leaves the copy text without a trailing blank line', async () => {
-        const { text } = await twoslashBlock(sample('const first = 1;', '//    ^?'), 'ts', true);
+        const { text } = await twoslashBlock(sample('const first = 1;', '//    ^?'), 'ts', 'hovers');
 
         expect(text).toBe('const first = 1;');
     });

--- a/apps/guide/tests/mdxPipeline.test.ts
+++ b/apps/guide/tests/mdxPipeline.test.ts
@@ -81,6 +81,18 @@ describe('a fence caption', () => {
         expect(code).not.toContain('data-output');
     });
 
+    it('reads hovers as its own flag', async () => {
+        const plain = await compileGuideMdx(fence('twoslash'));
+        const withHovers = await compileGuideMdx(fence('twoslash hovers'));
+
+        expect(plain).not.toContain('data-hovers');
+        expect(withHovers).toContain('data-hovers');
+    });
+
+    it('refuses hovers without twoslash', async () => {
+        await expect(compileGuideMdx(fence('hovers'))).rejects.toThrow('hovers needs twoslash');
+    });
+
     it('refuses a js fence tagged twoslash', async () => {
         const source = ['```js twoslash', 'const a = 1;', '```'].join('\n');
 


### PR DESCRIPTION
## Checklist

- [x] Tests cover the change
- [x] `pnpm prePush` is green
- [-] Changeset added with `pnpm cs`, for any change to a published package


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for interactive type hovers in code examples, including documentation and usage examples.
  * Added separate code-example modes for type checking and hover annotations.
  * Plain code fences can now render without additional type analysis.

* **Bug Fixes**
  * Improved validation for hover-enabled examples, with clear errors when required settings are missing.
  * Type-check-only examples now correctly display errors and type queries without hover annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->