### PR TITLE
fix: seedcord wasn't working on windows

### DIFF
--- a/.changeset/windows-file-imports.md
+++ b/.changeset/windows-file-imports.md
@@ -1,0 +1,5 @@
+---
+'@seedcord/utils': patch
+---
+
+Bots now start on Windows. seedcord imported handler, command, and subscriber files by raw filesystem path, and Node read the `D:` drive letter as a URL protocol.

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -76,6 +76,7 @@
         "@seedcord/tsdown-config": "workspace:^",
         "@seedcord/vitest-config": "workspace:^",
         "discord.js": "catalog:peer",
+        "tsx": "catalog:deps",
         "type-fest": "catalog:deps"
     },
     "publishConfig": {

--- a/packages/utils/src/node/directory.ts
+++ b/packages/utils/src/node/directory.ts
@@ -1,5 +1,6 @@
 import { readdir } from 'node:fs/promises';
 import * as path from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 import { SeedcordErrorCode } from '@seedcord/errors';
 import { SeedcordError } from '@seedcord/errors/internal';
@@ -51,7 +52,8 @@ export async function traverseDirectory(
         } else if (isTsOrJsFile(entry)) {
             let imported: Record<string, unknown>;
             try {
-                imported = (await import(fullPath)) as Record<string, unknown>;
+                // node reads a raw windows path's drive letter as a url protocol
+                imported = (await import(pathToFileURL(fullPath).href)) as Record<string, unknown>;
             } catch (err) {
                 throw new SeedcordError(SeedcordErrorCode.CoreDirectoryImportFailed, [relativePath], { cause: err });
             }

--- a/packages/utils/tests/node/traverseDirectory.test.ts
+++ b/packages/utils/tests/node/traverseDirectory.test.ts
@@ -1,11 +1,19 @@
+import { execFile } from 'node:child_process';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
+import { promisify } from 'node:util';
 
 import { SeedcordErrorCode } from '@seedcord/errors';
-import { describe, expect, it } from 'vitest';
+import { afterAll, describe, expect, it } from 'vitest';
 
 import { traverseDirectory } from '#src/node/directory';
 
 const FIXTURES = path.join(import.meta.dirname, 'fixtures');
+const SOURCE = path.join(import.meta.dirname, '..', '..', 'src', 'node', 'directory.ts');
+
+const run = promisify(execFile);
+const scratch = await mkdtemp(path.join(os.tmpdir(), 'seedcord-traverse-'));
 
 async function rejection(walk: Promise<void>): Promise<unknown> {
     return walk.then(
@@ -14,7 +22,37 @@ async function rejection(walk: Promise<void>): Promise<unknown> {
     );
 }
 
+// vitest's evaluator decodes a percent-encoded specifier back to a raw path
+async function walkInNode(dir: string): Promise<string[]> {
+    const script = [
+        "import { pathToFileURL } from 'node:url';",
+        "import path from 'node:path';",
+        'const [source, target] = process.argv.slice(1);',
+        'const { traverseDirectory } = await import(pathToFileURL(source).href);',
+        'const seen = [];',
+        'await traverseDirectory(target, (full) => void seen.push(path.basename(full)));',
+        'console.log(JSON.stringify(seen));'
+    ].join('\n');
+
+    const { stdout } = await run(process.execPath, ['--import', 'tsx/esm', '-e', script, SOURCE, dir]);
+    return JSON.parse(stdout) as string[];
+}
+
+afterAll(async () => {
+    await rm(scratch, { recursive: true, force: true });
+});
+
 describe('traverseDirectory', () => {
+    it('imports a file whose directory name holds a url-special character', async () => {
+        // '?' reproduces the windows drive-letter failure on any platform
+        const dir = path.join(scratch, 'query?segment');
+        await mkdir(dir, { recursive: true });
+        await writeFile(path.join(dir, 'package.json'), '{ "type": "module" }\n');
+        await writeFile(path.join(dir, 'Mod.js'), 'export const ok = true;\n');
+
+        await expect(walkInNode(dir)).resolves.toEqual(['Mod.js']);
+    });
+
     it('visits every ts file under the directory', async () => {
         const seen: string[] = [];
 

--- a/packages/utils/tests/node/traverseDirectory.test.ts
+++ b/packages/utils/tests/node/traverseDirectory.test.ts
@@ -35,6 +35,7 @@ async function walkInNode(dir: string): Promise<string[]> {
     ].join('\n');
 
     const { stdout } = await run(process.execPath, ['--import', 'tsx/esm', '-e', script, SOURCE, dir]);
+    // justified: the script above only prints basenames
     return JSON.parse(stdout) as string[];
 }
 
@@ -44,8 +45,8 @@ afterAll(async () => {
 
 describe('traverseDirectory', () => {
     it('imports a file whose directory name holds a url-special character', async () => {
-        // '?' reproduces the windows drive-letter failure on any platform
-        const dir = path.join(scratch, 'query?segment');
+        // this name must break a raw import specifier and stay legal on windows
+        const dir = path.join(scratch, 'hash#segment');
         await mkdir(dir, { recursive: true });
         await writeFile(path.join(dir, 'package.json'), '{ "type": "module" }\n');
         await writeFile(path.join(dir, 'Mod.js'), 'export const ok = true;\n');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1135,6 +1135,9 @@ importers:
       discord.js:
         specifier: catalog:peer
         version: 14.27.0
+      tsx:
+        specifier: catalog:deps
+        version: 4.23.5
       type-fest:
         specifier: catalog:deps
         version: 5.8.0


### PR DESCRIPTION
## What and why

Fix seedcord breaking on startup on windows due to an path bug. Closes #285 

## Checklist

- [x] Tests cover the change
- [x] `pnpm prePush` is green
- [x] Changeset added with `pnpm cs`, for any change to a published package


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Windows bot startup when importing files from paths containing drive letters.
  * Improved handling of special characters in directory paths during imports.
* **Tests**
  * Added regression coverage for Windows paths and directories containing URL-sensitive characters.
* **Chores**
  * Added development tooling to support improved test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->