### PR TITLE
feat: match in context menu handlers + command fixes

### DIFF
--- a/.changeset/context-menu-match.md
+++ b/.changeset/context-menu-match.md
@@ -1,0 +1,7 @@
+---
+'@seedcord/gateway': minor
+'@seedcord/http': minor
+'@seedcord/errors': minor
+---
+
+A context menu handler registered for several command names runs one arm per name through `match` and reads the fired name from `commandName`. On gateway each arm receives the target narrowed to that one command's cache state.

--- a/.changeset/context-menu-match.md
+++ b/.changeset/context-menu-match.md
@@ -1,7 +1,7 @@
 ---
-'@seedcord/gateway': patch
-'@seedcord/http': patch
-'@seedcord/errors': patch
+'@seedcord/gateway': minor
+'@seedcord/http': minor
+'@seedcord/errors': minor
 ---
 
 A context menu handler registered for several command names runs one arm per name through `match` and reads the fired name from `commandName`. On gateway each arm receives the target narrowed to that one command's cache state.

--- a/.changeset/context-menu-match.md
+++ b/.changeset/context-menu-match.md
@@ -1,7 +1,7 @@
 ---
-'@seedcord/gateway': minor
-'@seedcord/http': minor
-'@seedcord/errors': minor
+'@seedcord/gateway': patch
+'@seedcord/http': patch
+'@seedcord/errors': patch
 ---
 
 A context menu handler registered for several command names runs one arm per name through `match` and reads the fired name from `commandName`. On gateway each arm receives the target narrowed to that one command's cache state.

--- a/.changeset/event-match-prototype-lookup.md
+++ b/.changeset/event-match-prototype-lookup.md
@@ -1,0 +1,5 @@
+---
+'@seedcord/gateway': patch
+---
+
+`EventHandler.match` threw `EventMatchArmMissing` for an unregistered event only when the name missed `Object.prototype`. An event named `toString` or `constructor` found the prototype's method and called it. This couldn't happen in the first place, but still was inconsistent behavior.

--- a/.changeset/naming-convention-match-arms.md
+++ b/.changeset/naming-convention-match-arms.md
@@ -1,0 +1,5 @@
+---
+'@seedcord/eslint-config': patch
+---
+
+`@typescript-eslint/naming-convention` no longer warns on an object key that holds a function. A `match` arm keys on a route string or a context menu name, both of which carry slashes and spaces.

--- a/packages/errors/src/ErrorCodes.ts
+++ b/packages/errors/src/ErrorCodes.ts
@@ -122,6 +122,8 @@ export enum SeedcordErrorCode {
     EventMiddlewareNameUnavailable = 1613,
     /** An autocomplete payload carried no focused option. */
     AutocompleteNoFocusedOption = 1614,
+    /** A context menu handler's match() has no arm for the command name that fired. */
+    ContextMenuMatchArmMissing = 1615,
 
     /** A Cooldown gate was given a duration string that is not a well-formed positive duration. */
     GateInvalidCooldownDuration = 1701,

--- a/packages/errors/src/ErrorMessages.ts
+++ b/packages/errors/src/ErrorMessages.ts
@@ -116,6 +116,8 @@ const messages = {
         `match() has no arm for the focused field ${JSON.stringify(field)}.`,
     [SeedcordErrorCode.EventMatchArmMissing]: (event: string) =>
         `match() has no arm for the event ${JSON.stringify(event)}.`,
+    [SeedcordErrorCode.ContextMenuMatchArmMissing]: (name: string) =>
+        `match() has no arm for the context menu command ${JSON.stringify(name)}.`,
     [SeedcordErrorCode.EventMiddlewareNameUnavailable]: () =>
         `this.eventName is only available on middleware the controller constructed with a fired event name.`,
     [SeedcordErrorCode.AutocompleteNoFocusedOption]: () => `Autocomplete payload has no focused option.`,

--- a/packages/gateway/src/handlers/event/EventHandler.ts
+++ b/packages/gateway/src/handlers/event/EventHandler.ts
@@ -79,9 +79,8 @@ export abstract class EventHandler<in out Names extends ValidNonInteractionKeys>
     protected async match<Ret>(arms: EventMatchArms<Names, Ret>): Promise<Ret> {
         const name = this.firedEvent;
         if (name === undefined) throw new SeedcordError(SeedcordErrorCode.EventMatchArmMissing, ['<no event>']);
-        // justified: each arm takes its own payload tuple, so no single param type unifies the arms in a cast. read
-        // the arm as unknown keyed by the runtime event name, then narrow to a function before calling it.
-        const arm = (arms as Record<string, unknown>)[name];
+        // hasOwn, since a plain lookup for an event named `toString` returns Object.prototype's
+        const arm = Object.hasOwn(arms, name) ? (arms as Record<string, unknown>)[name] : undefined;
         if (typeof arm !== 'function') throw new SeedcordError(SeedcordErrorCode.EventMatchArmMissing, [name]);
         // this.event narrows to never on a multi-event handler. getEvent() returns the real tuple, spread so each arm gets its named params.
         return await (arm as (...args: unknown[]) => Promisable<Ret>)(...this.getEvent());

--- a/packages/gateway/src/handlers/interaction/ContextMenuHandler.ts
+++ b/packages/gateway/src/handlers/interaction/ContextMenuHandler.ts
@@ -1,4 +1,6 @@
 import { ContextMenuKindBrand, ContextMenuNamesBrand } from '@seedcord/core/internal';
+import { SeedcordErrorCode } from '@seedcord/errors';
+import { SeedcordError } from '@seedcord/errors/internal';
 
 import { InteractionHandler } from '#handlers/interaction/InteractionHandler';
 
@@ -15,6 +17,31 @@ import type {
     User,
     UserContextMenuCommandInteraction
 } from 'discord.js';
+import type { Promisable } from 'type-fest';
+
+type UserMenuArms<Names extends NamesFor<ApplicationCommandType.User>, Ret> = {
+    [Name in Names]: (
+        target: User,
+        member: CacheTypeReducer<
+            MenuCacheFor<ApplicationCommandType.User, Name>,
+            GuildMember,
+            APIInteractionGuildMember
+        > | null
+    ) => Promisable<Ret>;
+};
+
+type MessageMenuArms<Names extends NamesFor<ApplicationCommandType.Message>, Ret> = {
+    [Name in Names]: (
+        target: Message<BooleanCache<MenuCacheFor<ApplicationCommandType.Message, Name>>>
+    ) => Promisable<Ret>;
+};
+
+function armFor<Ret>(arms: object, name: string): (...args: never[]) => Promisable<Ret> {
+    // hasOwn, since a plain lookup for a command named `constructor` returns Object.prototype's
+    const arm = Object.hasOwn(arms, name) ? (arms as Record<string, unknown>)[name] : undefined;
+    if (typeof arm !== 'function') throw new SeedcordError(SeedcordErrorCode.ContextMenuMatchArmMissing, [name]);
+    return arm as (...args: never[]) => Promisable<Ret>;
+}
 
 /**
  * Base class for a user context-menu command handler (right-click a user).
@@ -53,6 +80,41 @@ export abstract class UserContextMenuHandler<
     protected get targetMember(): CacheTypeReducer<Cache, GuildMember, APIInteractionGuildMember> | null {
         return this.event.targetMember;
     }
+
+    /** Which of the registered commands fired. */
+    protected get commandName(): Names {
+        return this.event.commandName as Names;
+    }
+
+    /**
+     * Run the arm for whichever command fired. Use this only when the handler is registered for several
+     * names.
+     *
+     * Provide one arm per registered name, keyed by the name Discord shows in the right-click menu. Each
+     * arm receives the clicked user and that user's guild member, both narrowed to the cache state of that
+     * one command. The arms must cover every name in the generic. A missing name or an unknown key is a
+     * compile error.
+     *
+     * @param arms - One handler per registered command name.
+     * @returns The result of the arm that ran.
+     *
+     * @example
+     * ```ts
+     * \@UserContextMenuRoute('View Profile', 'Warn')
+     * class Moderation extends UserContextMenuHandler<'View Profile' | 'Warn'> {
+     *     async execute() {
+     *         await this.match({
+     *             'View Profile': (user) => this.reply(`Profile for ${user.tag}.`),
+     *             Warn: (user, member) => this.reply(`Warned ${member?.displayName ?? user.tag}.`)
+     *         });
+     *     }
+     * }
+     * ```
+     */
+    protected async match<Ret>(arms: UserMenuArms<Names, Ret>): Promise<Ret> {
+        const arm = armFor<Ret>(arms, this.event.commandName);
+        return await (arm as (target: User, member: unknown) => Promisable<Ret>)(this.target, this.targetMember);
+    }
 }
 
 /**
@@ -85,5 +147,39 @@ export abstract class MessageContextMenuHandler<
 
     protected get target(): Message<BooleanCache<Cache>> {
         return this.event.targetMessage;
+    }
+
+    /** Which of the registered commands fired. */
+    protected get commandName(): Names {
+        return this.event.commandName as Names;
+    }
+
+    /**
+     * Run the arm for whichever command fired. Use this only when the handler is registered for several
+     * names.
+     *
+     * Provide one arm per registered name, keyed by the name Discord shows in the right-click menu. Each
+     * arm receives the clicked message, narrowed to the cache state of that one command. The arms must
+     * cover every name in the generic. A missing name or an unknown key is a compile error.
+     *
+     * @param arms - One handler per registered command name.
+     * @returns The result of the arm that ran.
+     *
+     * @example
+     * ```ts
+     * \@MessageContextMenuRoute('Report Message', 'Pin Message')
+     * class MessageTools extends MessageContextMenuHandler<'Report Message' | 'Pin Message'> {
+     *     async execute() {
+     *         await this.match({
+     *             'Report Message': (message) => this.report(message),
+     *             'Pin Message': (message) => message.pin()
+     *         });
+     *     }
+     * }
+     * ```
+     */
+    protected async match<Ret>(arms: MessageMenuArms<Names, Ret>): Promise<Ret> {
+        const arm = armFor<Ret>(arms, this.event.commandName);
+        return await (arm as (target: Message<BooleanCache<Cache>>) => Promisable<Ret>)(this.target);
     }
 }

--- a/packages/gateway/tests/handlers/event-match-arm.test.ts
+++ b/packages/gateway/tests/handlers/event-match-arm.test.ts
@@ -1,0 +1,45 @@
+import { isSeedcordError, SeedcordErrorCode } from '@seedcord/errors';
+import { describe, expect, it } from 'vitest';
+
+import { EventHandler } from '#handlers/event/EventHandler';
+
+import type { Core } from '#interfaces/Core';
+import type { ClientEvents, Events, Message } from 'discord.js';
+
+// justified: nothing on this path reads core
+const core = {} as unknown as Core;
+
+const message = { id: 'm1' } as unknown as Message;
+
+class Watcher extends EventHandler<Events.MessageCreate> {
+    public async execute(): Promise<void> {
+        await Promise.resolve();
+    }
+
+    public run(): Promise<string> {
+        return this.match({ messageCreate: () => 'created' });
+    }
+}
+
+// justified: only a cast fires a name outside ClientEvents
+function watcherFiring(name: string): Watcher {
+    const payload = [message] as unknown as ClientEvents[Events.MessageCreate];
+    return new Watcher(payload, core, name as Events.MessageCreate);
+}
+
+describe('EventHandler.match', () => {
+    it('runs the arm for the event that fired', async () => {
+        await expect(watcherFiring('messageCreate').run()).resolves.toBe('created');
+    });
+
+    it('throws for an event named after an Object.prototype member', async () => {
+        let caught: unknown;
+        try {
+            await watcherFiring('toString').run();
+        } catch (error) {
+            caught = error;
+        }
+
+        expect(isSeedcordError(caught, 'SeedcordError', SeedcordErrorCode.EventMatchArmMissing)).toBe(true);
+    });
+});

--- a/packages/gateway/tests/interfaces/context-menu-match.test.ts
+++ b/packages/gateway/tests/interfaces/context-menu-match.test.ts
@@ -1,0 +1,155 @@
+import { isSeedcordError, SeedcordErrorCode } from '@seedcord/errors';
+import { describe, expect, expectTypeOf, it } from 'vitest';
+
+import { MessageContextMenuHandler, UserContextMenuHandler } from '#handlers/interaction/ContextMenuHandler';
+
+import type { Core } from '#interfaces/Core';
+import type {
+    APIInteractionGuildMember,
+    GuildMember,
+    Message,
+    MessageContextMenuCommandInteraction,
+    User,
+    UserContextMenuCommandInteraction
+} from 'discord.js';
+
+declare module '@seedcord/core' {
+    interface UserContextMenuRegistry {
+        'View Profile': { cache: 'cached' };
+        'Say Hello': { cache: undefined };
+    }
+    interface MessageContextMenuRegistry {
+        'Report Message': { cache: 'cached' };
+        'Pin Message': { cache: undefined };
+    }
+}
+
+// justified: nothing on this path reads core
+const core = {} as unknown as Core;
+
+// MenuCacheFor collapses to undefined when the names differ in cache state
+function userMenu(name: string): UserContextMenuCommandInteraction<undefined> {
+    return {
+        commandName: name,
+        targetUser: { id: 'u1' } as unknown as User,
+        targetMember: { id: 'm1' } as unknown as GuildMember
+    } as unknown as UserContextMenuCommandInteraction<undefined>;
+}
+
+function messageMenu(name: string): MessageContextMenuCommandInteraction<undefined> {
+    return {
+        commandName: name,
+        targetMessage: { id: 'msg1' } as unknown as Message
+    } as unknown as MessageContextMenuCommandInteraction<undefined>;
+}
+
+class Menu extends UserContextMenuHandler<'View Profile' | 'Say Hello'> {
+    public async execute(): Promise<void> {
+        await Promise.resolve();
+    }
+
+    public run(): Promise<string> {
+        return this.match({
+            'View Profile': () => 'profile',
+            'Say Hello': () => 'hello'
+        });
+    }
+
+    public runPartial(): Promise<string> {
+        const arms = { 'View Profile': () => 'profile' };
+        // justified: reaching the runtime throw means dropping an arm past the compiler
+        return this.match(arms as unknown as { 'View Profile': () => string; 'Say Hello': () => string });
+    }
+
+    public readName(): 'View Profile' | 'Say Hello' {
+        return this.commandName;
+    }
+}
+
+class Tools extends MessageContextMenuHandler<'Report Message' | 'Pin Message'> {
+    public async execute(): Promise<void> {
+        await Promise.resolve();
+    }
+
+    public run(): Promise<string> {
+        return this.match({
+            'Report Message': (message) => `reported ${message.id}`,
+            'Pin Message': (message) => `pinned ${message.id}`
+        });
+    }
+}
+
+class Narrowing extends UserContextMenuHandler<'View Profile' | 'Say Hello'> {
+    public async execute(): Promise<void> {
+        expectTypeOf(this.targetMember).toEqualTypeOf<GuildMember | APIInteractionGuildMember | null>();
+
+        await this.match({
+            'View Profile': (target, member) => {
+                expectTypeOf(target).toEqualTypeOf<User>();
+                expectTypeOf(member).toEqualTypeOf<GuildMember | null>();
+            },
+            'Say Hello': (_target, member) => {
+                expectTypeOf(member).toEqualTypeOf<GuildMember | APIInteractionGuildMember | null>();
+            }
+        });
+    }
+}
+void Narrowing;
+
+class MissingArm extends UserContextMenuHandler<'View Profile' | 'Say Hello'> {
+    public async execute(): Promise<void> {
+        // @ts-expect-error every name in the generic needs an arm.
+        await this.match({
+            'View Profile': () => undefined
+        });
+    }
+}
+void MissingArm;
+
+class UnknownArm extends UserContextMenuHandler<'View Profile'> {
+    public async execute(): Promise<void> {
+        await this.match({
+            'View Profile': () => undefined,
+            // @ts-expect-error 'Say Hello' is not one of this handler's registered names.
+            'Say Hello': () => undefined
+        });
+    }
+}
+void UnknownArm;
+
+describe('context menu match', () => {
+    it('runs the arm for the command that fired', async () => {
+        await expect(new Menu(userMenu('View Profile'), core).run()).resolves.toBe('profile');
+        await expect(new Menu(userMenu('Say Hello'), core).run()).resolves.toBe('hello');
+    });
+
+    it('hands a message arm the clicked message', async () => {
+        await expect(new Tools(messageMenu('Pin Message'), core).run()).resolves.toBe('pinned msg1');
+    });
+
+    it('throws when the fired command has no arm', async () => {
+        let caught: unknown;
+        try {
+            await new Menu(userMenu('Say Hello'), core).runPartial();
+        } catch (error) {
+            caught = error;
+        }
+
+        expect(isSeedcordError(caught, 'SeedcordError', SeedcordErrorCode.ContextMenuMatchArmMissing)).toBe(true);
+    });
+
+    it('throws for a command named after an Object.prototype member', async () => {
+        let caught: unknown;
+        try {
+            await new Menu(userMenu('constructor'), core).run();
+        } catch (error) {
+            caught = error;
+        }
+
+        expect(isSeedcordError(caught, 'SeedcordError', SeedcordErrorCode.ContextMenuMatchArmMissing)).toBe(true);
+    });
+
+    it('reads the fired command name without an arm', () => {
+        expect(new Menu(userMenu('Say Hello'), core).readName()).toBe('Say Hello');
+    });
+});

--- a/packages/gateway/tests/interfaces/context-menu-match.test.ts
+++ b/packages/gateway/tests/interfaces/context-menu-match.test.ts
@@ -27,7 +27,6 @@ declare module '@seedcord/core' {
 // justified: nothing on this path reads core
 const core = {} as unknown as Core;
 
-// MenuCacheFor collapses to undefined when the names differ in cache state
 function userMenu(name: string): UserContextMenuCommandInteraction<undefined> {
     return {
         commandName: name,
@@ -56,9 +55,12 @@ class Menu extends UserContextMenuHandler<'View Profile' | 'Say Hello'> {
     }
 
     public runPartial(): Promise<string> {
-        const arms = { 'View Profile': () => 'profile' };
-        // justified: reaching the runtime throw means dropping an arm past the compiler
-        return this.match(arms as unknown as { 'View Profile': () => string; 'Say Hello': () => string });
+        const arms = {
+            'View Profile': (): string => 'profile',
+            'Say Hello': (): string => 'hello'
+        };
+        Reflect.deleteProperty(arms, 'Say Hello');
+        return this.match(arms);
     }
 
     public readName(): 'View Profile' | 'Say Hello' {

--- a/packages/gateway/tests/utils/mock-env.ts
+++ b/packages/gateway/tests/utils/mock-env.ts
@@ -5,12 +5,9 @@ vi.mock('envapt', () => ({
         isDevelopment: true,
         isProduction: false
     },
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     Envapt: () => () => {}
 }));
 
-// v8 split: @Envapt moved to envapt/legacy, so neutralize it too.
 vi.mock('envapt/legacy', () => ({
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     Envapt: () => () => {}
 }));

--- a/packages/http/src/handlers/interaction/ContextMenuHandler.ts
+++ b/packages/http/src/handlers/interaction/ContextMenuHandler.ts
@@ -1,4 +1,6 @@
 import { ContextMenuKindBrand, ContextMenuNamesBrand } from '@seedcord/core/internal';
+import { SeedcordErrorCode } from '@seedcord/errors';
+import { SeedcordError } from '@seedcord/errors/internal';
 
 import { InteractionHandler } from '#handlers/interaction/InteractionHandler';
 
@@ -11,6 +13,24 @@ import type {
     APIUserApplicationCommandInteraction,
     ApplicationCommandType
 } from 'discord-api-types/v10';
+import type { Promisable } from 'type-fest';
+
+type UserMenuArms<Names extends NamesFor<ApplicationCommandType.User>, Ret> = Record<
+    Names,
+    (target: APIUser, member: APIInteractionDataResolvedGuildMember | null) => Promisable<Ret>
+>;
+
+type MessageMenuArms<Names extends NamesFor<ApplicationCommandType.Message>, Ret> = Record<
+    Names,
+    (target: APIMessage) => Promisable<Ret>
+>;
+
+function armFor<Ret>(arms: object, name: string): (...args: never[]) => Promisable<Ret> {
+    // hasOwn, since a plain lookup for a command named `constructor` returns Object.prototype's
+    const arm = Object.hasOwn(arms, name) ? (arms as Record<string, unknown>)[name] : undefined;
+    if (typeof arm !== 'function') throw new SeedcordError(SeedcordErrorCode.ContextMenuMatchArmMissing, [name]);
+    return arm as (...args: never[]) => Promisable<Ret>;
+}
 
 /**
  * Base class for a user context-menu command handler on the HTTP transport (right-click a user).
@@ -40,6 +60,42 @@ export abstract class UserContextMenuHandler<
         const { target_id: targetId, resolved } = this.event.data;
         return resolved.members?.[targetId] ?? null;
     }
+
+    /** Which of the registered commands fired. */
+    protected get commandName(): Names {
+        return this.event.data.name as Names;
+    }
+
+    /**
+     * Run the arm for whichever command fired. Use this only when the handler is registered for several
+     * names.
+     *
+     * Provide one arm per registered name, keyed by the name Discord shows in the right-click menu. Each
+     * arm receives the clicked user and that user's guild member. The arms must cover every name in the
+     * generic. A missing name or an unknown key is a compile error.
+     *
+     * @param arms - One handler per registered command name.
+     * @returns The result of the arm that ran.
+     *
+     * @example
+     * ```ts
+     * \@UserContextMenuRoute('View Profile', 'Warn')
+     * class Moderation extends UserContextMenuHandler<'View Profile' | 'Warn'> {
+     *     async execute() {
+     *         await this.match({
+     *             'View Profile': (user) => this.reply(`Profile for ${user.username}.`),
+     *             Warn: (user, member) => this.reply(`Warned ${member?.nick ?? user.username}.`)
+     *         });
+     *     }
+     * }
+     * ```
+     */
+    protected async match<Ret>(arms: UserMenuArms<Names, Ret>): Promise<Ret> {
+        const arm = armFor<Ret>(arms, this.event.data.name);
+        return await (
+            arm as (target: APIUser, member: APIInteractionDataResolvedGuildMember | null) => Promisable<Ret>
+        )(this.target, this.targetMember);
+    }
 }
 
 /**
@@ -62,5 +118,39 @@ export abstract class MessageContextMenuHandler<
         const { target_id: targetId, resolved } = this.event.data;
         // justified: discord resolves the target it delivered target_id for
         return resolved.messages[targetId] as APIMessage;
+    }
+
+    /** Which of the registered commands fired. */
+    protected get commandName(): Names {
+        return this.event.data.name as Names;
+    }
+
+    /**
+     * Run the arm for whichever command fired. Use this only when the handler is registered for several
+     * names.
+     *
+     * Provide one arm per registered name, keyed by the name Discord shows in the right-click menu. Each
+     * arm receives the clicked message. The arms must cover every name in the generic. A missing name or
+     * an unknown key is a compile error.
+     *
+     * @param arms - One handler per registered command name.
+     * @returns The result of the arm that ran.
+     *
+     * @example
+     * ```ts
+     * \@MessageContextMenuRoute('Report Message', 'Quote Message')
+     * class MessageTools extends MessageContextMenuHandler<'Report Message' | 'Quote Message'> {
+     *     async execute() {
+     *         await this.match({
+     *             'Report Message': (message) => this.report(message),
+     *             'Quote Message': (message) => this.reply(`> ${message.content}`)
+     *         });
+     *     }
+     * }
+     * ```
+     */
+    protected async match<Ret>(arms: MessageMenuArms<Names, Ret>): Promise<Ret> {
+        const arm = armFor<Ret>(arms, this.event.data.name);
+        return await (arm as (target: APIMessage) => Promisable<Ret>)(this.target);
     }
 }

--- a/packages/http/tests/node/handlers/context-menu-match.test.ts
+++ b/packages/http/tests/node/handlers/context-menu-match.test.ts
@@ -1,0 +1,153 @@
+import { isSeedcordError, SeedcordErrorCode } from '@seedcord/errors';
+import { ApplicationCommandType } from 'discord-api-types/v10';
+import { describe, expect, expectTypeOf, it } from 'vitest';
+
+import { MessageContextMenuHandler, UserContextMenuHandler } from '#handlers/interaction/ContextMenuHandler';
+
+import type { Core } from '#interfaces/Core';
+import type {
+    APIInteractionDataResolvedGuildMember,
+    APIMessage,
+    APIMessageApplicationCommandInteraction,
+    APIUser,
+    APIUserApplicationCommandInteraction
+} from 'discord-api-types/v10';
+
+declare module '@seedcord/core' {
+    interface UserContextMenuRegistry {
+        'hb Profile': { cache: 'cached' };
+        'hb Greet': { cache: undefined };
+    }
+    interface MessageContextMenuRegistry {
+        'hb Report': { cache: 'cached' };
+        'hb Pin': { cache: undefined };
+    }
+}
+
+// justified: nothing on this path reads core
+const core = {} as unknown as Core;
+
+const user: APIUser = { id: 'u1', username: 'dhruv', discriminator: '0', global_name: null, avatar: null };
+
+function userMenuEvent(name: string): APIUserApplicationCommandInteraction {
+    return {
+        application_id: 'app-1',
+        id: 'int-1',
+        token: 'tok',
+        type: 2,
+        data: {
+            id: 'c1',
+            type: ApplicationCommandType.User,
+            name,
+            target_id: 'u1',
+            resolved: { users: { u1: user }, members: { u1: { nick: 'dee' } } }
+        }
+    } as unknown as APIUserApplicationCommandInteraction;
+}
+
+function messageMenuEvent(name: string): APIMessageApplicationCommandInteraction {
+    return {
+        application_id: 'app-1',
+        id: 'int-1',
+        token: 'tok',
+        type: 2,
+        data: {
+            id: 'c1',
+            type: ApplicationCommandType.Message,
+            name,
+            target_id: 'msg1',
+            resolved: { messages: { msg1: { id: 'msg1' } } }
+        }
+    } as unknown as APIMessageApplicationCommandInteraction;
+}
+
+class Menu extends UserContextMenuHandler<'hb Profile' | 'hb Greet'> {
+    public async execute(): Promise<void> {
+        await Promise.resolve();
+    }
+
+    public run(): Promise<string> {
+        return this.match({
+            'hb Profile': (target, member) => {
+                expectTypeOf(target).toEqualTypeOf<APIUser>();
+                expectTypeOf(member).toEqualTypeOf<APIInteractionDataResolvedGuildMember | null>();
+                return `profile:${target.username}:${member?.nick ?? 'none'}`;
+            },
+            'hb Greet': (target) => `greet:${target.username}`
+        });
+    }
+
+    public runPartial(): Promise<string> {
+        const arms = { 'hb Profile': () => 'profile' };
+        // justified: reaching the runtime throw means dropping an arm past the compiler
+        return this.match(arms as unknown as { 'hb Profile': () => string; 'hb Greet': () => string });
+    }
+
+    public readName(): 'hb Profile' | 'hb Greet' {
+        return this.commandName;
+    }
+}
+
+class Tools extends MessageContextMenuHandler<'hb Report' | 'hb Pin'> {
+    public async execute(): Promise<void> {
+        await Promise.resolve();
+    }
+
+    public run(): Promise<string> {
+        return this.match({
+            'hb Report': (message) => {
+                expectTypeOf(message).toEqualTypeOf<APIMessage>();
+                return `reported ${message.id}`;
+            },
+            'hb Pin': (message) => `pinned ${message.id}`
+        });
+    }
+}
+
+class MissingArm extends UserContextMenuHandler<'hb Profile' | 'hb Greet'> {
+    public async execute(): Promise<void> {
+        // @ts-expect-error every name in the generic needs an arm.
+        await this.match({
+            'hb Profile': () => undefined
+        });
+    }
+}
+void MissingArm;
+
+class UnknownArm extends UserContextMenuHandler<'hb Profile'> {
+    public async execute(): Promise<void> {
+        await this.match({
+            'hb Profile': () => undefined,
+            // @ts-expect-error 'hb Greet' is not one of this handler's registered names.
+            'hb Greet': () => undefined
+        });
+    }
+}
+void UnknownArm;
+
+describe('http context menu match', () => {
+    it('runs the arm for the command that fired', async () => {
+        await expect(new Menu(userMenuEvent('hb Profile'), core).run()).resolves.toBe('profile:dhruv:dee');
+        await expect(new Menu(userMenuEvent('hb Greet'), core).run()).resolves.toBe('greet:dhruv');
+    });
+
+    it('hands a message arm the clicked message', async () => {
+        await expect(new Tools(messageMenuEvent('hb Pin'), core).run()).resolves.toBe('pinned msg1');
+    });
+
+    it('throws when the fired command has no arm', async () => {
+        await expect(new Menu(userMenuEvent('hb Greet'), core).runPartial()).rejects.toSatisfy((error: unknown) =>
+            isSeedcordError(error, 'SeedcordError', SeedcordErrorCode.ContextMenuMatchArmMissing)
+        );
+    });
+
+    it('throws for a command named after an Object.prototype member', async () => {
+        await expect(new Menu(userMenuEvent('constructor'), core).run()).rejects.toSatisfy((error: unknown) =>
+            isSeedcordError(error, 'SeedcordError', SeedcordErrorCode.ContextMenuMatchArmMissing)
+        );
+    });
+
+    it('reads the fired command name without an arm', () => {
+        expect(new Menu(userMenuEvent('hb Greet'), core).readName()).toBe('hb Greet');
+    });
+});

--- a/packages/http/tests/node/handlers/context-menu-match.test.ts
+++ b/packages/http/tests/node/handlers/context-menu-match.test.ts
@@ -78,9 +78,12 @@ class Menu extends UserContextMenuHandler<'hb Profile' | 'hb Greet'> {
     }
 
     public runPartial(): Promise<string> {
-        const arms = { 'hb Profile': () => 'profile' };
-        // justified: reaching the runtime throw means dropping an arm past the compiler
-        return this.match(arms as unknown as { 'hb Profile': () => string; 'hb Greet': () => string });
+        const arms = {
+            'hb Profile': (): string => 'profile',
+            'hb Greet': (): string => 'greet'
+        };
+        Reflect.deleteProperty(arms, 'hb Greet');
+        return this.match(arms);
     }
 
     public readName(): 'hb Profile' | 'hb Greet' {

--- a/plugins/kysely-postgres/tests/utils/mock-env.ts
+++ b/plugins/kysely-postgres/tests/utils/mock-env.ts
@@ -5,6 +5,5 @@ vi.mock('envapt', () => ({
         isDevelopment: true,
         isProduction: false
     },
-    // eslint-disable-next-line @typescript-eslint/naming-convention -- mirrors envapt's exported decorator name
     Envapt: () => () => {}
 }));

--- a/plugins/mongoose/tests/utils/mock-env.ts
+++ b/plugins/mongoose/tests/utils/mock-env.ts
@@ -5,6 +5,5 @@ vi.mock('envapt', () => ({
         isDevelopment: true,
         isProduction: false
     },
-    // eslint-disable-next-line @typescript-eslint/naming-convention -- mirrors envapt's exported decorator name
     Envapt: () => () => {}
 }));

--- a/tooling/eslint-config-base/src/rules/typescript-rules.ts
+++ b/tooling/eslint-config-base/src/rules/typescript-rules.ts
@@ -113,6 +113,11 @@ export const TYPESCRIPT_RULES: Linter.RulesRecord = {
             selector: 'property',
             format: null
         },
+        // match arms are keyed by route strings and context menu names that hold slashes and spaces
+        {
+            selector: ['objectLiteralMethod', 'typeMethod'],
+            format: null
+        },
         {
             selector: 'parameter',
             format: ['camelCase', 'PascalCase'],

--- a/tooling/eslint-config-base/src/rules/typescript-rules.ts
+++ b/tooling/eslint-config-base/src/rules/typescript-rules.ts
@@ -113,10 +113,15 @@ export const TYPESCRIPT_RULES: Linter.RulesRecord = {
             selector: 'property',
             format: null
         },
-        // match arms are keyed by route strings and context menu names that hold slashes and spaces
+        // match arms key on route strings and context menu names. prettier unquotes a one-word name like `Report`
         {
             selector: ['objectLiteralMethod', 'typeMethod'],
+            modifiers: ['requiresQuotes'],
             format: null
+        },
+        {
+            selector: ['objectLiteralMethod', 'typeMethod'],
+            format: ['camelCase', 'PascalCase']
         },
         {
             selector: 'parameter',


### PR DESCRIPTION
## Checklist

- [x] Tests cover the change
- [x] `pnpm prePush` is green
- [x] Changeset added with `pnpm cs`, for any change to a published package


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added command-specific matching for user and message context-menu handlers.
  * Exposed the fired command name to context-menu handlers.
  * Added type-safe handler arms with target and member data narrowing.

* **Bug Fixes**
  * Context-menu matches now report a clear error when no handler exists.
  * Prevented event names such as `toString` and `constructor` from matching incorrectly.

* **Developer Experience**
  * Updated naming rules to support route and context-menu names containing spaces and slashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->