### PR TITLE
fix: async listener handling and add global error management

### DIFF
--- a/.changeset/async-listener-rejection.md
+++ b/.changeset/async-listener-rejection.md
@@ -1,0 +1,5 @@
+---
+'@seedcord/event-emitter': patch
+---
+
+An async `on()` listener that throws used to crash the process. Its error now reaches `onListenerError`, the same as a synchronous one.

--- a/.changeset/async-listener-rejection.md
+++ b/.changeset/async-listener-rejection.md
@@ -2,4 +2,4 @@
 '@seedcord/event-emitter': patch
 ---
 
-An async `on()` listener that throws used to crash the process. Its error now reaches `onListenerError`, the same as a synchronous one.
+An async listener that throws used to crash the process. Its error now reaches `onListenerError`, the same as a synchronous one. This covers listeners registered with both `on()` and `once()`.

--- a/.changeset/async-log-sink-rejection.md
+++ b/.changeset/async-log-sink-rejection.md
@@ -1,0 +1,5 @@
+---
+'@seedcord/logger': patch
+---
+
+A log sink whose `onLog` returns a rejected promise used to crash the process. It now prints the same one-time console warning a synchronous throw does.

--- a/.changeset/catch-process-errors.md
+++ b/.changeset/catch-process-errors.md
@@ -1,0 +1,6 @@
+---
+'@seedcord/types': minor
+'@seedcord/core': minor
+---
+
+`errors.catchProcessErrors` reports a throw that escaped every handler, and defaults on. The bot keeps running after a rejection. An uncaught exception runs the coordinated shutdown and exits 1.

--- a/.changeset/stale-host-reset.md
+++ b/.changeset/stale-host-reset.md
@@ -1,0 +1,6 @@
+---
+'@seedcord/gateway': patch
+'@seedcord/http': patch
+---
+
+Calling `start()` again on a host whose startup already failed used to tear down whichever host had replaced it, taking its signal handlers and its logger config with it. The retry now throws and leaves the live host alone.

--- a/.changeset/stale-host-reset.md
+++ b/.changeset/stale-host-reset.md
@@ -1,6 +1,7 @@
 ---
+'@seedcord/core': patch
 '@seedcord/gateway': patch
 '@seedcord/http': patch
 ---
 
-Calling `start()` again on a host whose startup already failed used to tear down whichever host had replaced it, taking its signal handlers and its logger config with it. The retry now throws and leaves the live host alone.
+A host whose startup failed used to tear down whichever host had replaced it, taking the replacement's signal handlers and logger config with it. Teardown now runs only for the host that is still live. A second `start()` racing the first rejects with the same error, where it used to resolve a half-started host.

--- a/packages/core/src/node/Lifecycle/CoordinatedShutdown.ts
+++ b/packages/core/src/node/Lifecycle/CoordinatedShutdown.ts
@@ -95,6 +95,8 @@ export class CoordinatedShutdown extends CoordinatedLifecycle<ShutdownPhase> {
 
         // a dev-mode run leaves the process alive, so a second call would re-execute every task
         if (this.hasShutdown || this.isShuttingDown) {
+            // a crash mid-shutdown must still leave a failing code for whatever supervises the process
+            if (exitCode > this.exitCode) this.exitCode = exitCode;
             this.logger.warn('Shutdown sequence already ran or is in progress');
             return;
         }

--- a/packages/core/src/node/Pluggable.ts
+++ b/packages/core/src/node/Pluggable.ts
@@ -59,6 +59,7 @@ export abstract class Pluggable<BotT extends Transport, BotRt extends Runtime> i
     private initPromise?: Promise<this> | undefined;
 
     private static isInstantiated = false;
+    private static liveHost?: object | undefined;
     private static liveShutdown?: CoordinatedShutdown | undefined;
     private static liveProcessErrors?: (() => void) | undefined;
 
@@ -73,6 +74,7 @@ export abstract class Pluggable<BotT extends Transport, BotRt extends Runtime> i
         }
 
         Pluggable.isInstantiated = true;
+        Pluggable.liveHost = this;
         Pluggable.liveShutdown = shutdown;
         this.shutdown = shutdown;
         this.startup = startup;
@@ -120,13 +122,17 @@ export abstract class Pluggable<BotT extends Transport, BotRt extends Runtime> i
         return this.attachments.map((attachment) => attachment.key);
     }
 
-    /** @internal so the next host can construct */
-    protected static reset(): void {
+    /** @internal */
+    protected static reset(host?: object): boolean {
+        if (host !== undefined && Pluggable.liveHost !== host) return false;
+
         Pluggable.liveShutdown?.removeSignalHandlers();
         Pluggable.liveShutdown = undefined;
         Pluggable.liveProcessErrors?.();
         Pluggable.liveProcessErrors = undefined;
+        Pluggable.liveHost = undefined;
         Pluggable.isInstantiated = false;
+        return true;
     }
 
     /**

--- a/packages/core/src/node/Pluggable.ts
+++ b/packages/core/src/node/Pluggable.ts
@@ -56,6 +56,7 @@ export abstract class Pluggable<BotT extends Transport, BotRt extends Runtime> i
     private readonly completedInits = new Set<Attachment>();
     private readonly disposePhases = new Set<ShutdownPhase>();
     private pluginTasksRegistered = false;
+    private initPromise?: Promise<this> | undefined;
 
     private static isInstantiated = false;
     private static liveShutdown?: CoordinatedShutdown | undefined;
@@ -78,16 +79,23 @@ export abstract class Pluggable<BotT extends Transport, BotRt extends Runtime> i
     }
 
     /** @internal */
-    protected async init(): Promise<this> {
+    protected init(): Promise<this> {
+        // clearing the slot on a rejection lets a later retry throw its own error
+        this.initPromise ??= this.runInit().catch((caught: unknown) => {
+            this.initPromise = undefined;
+            throw caught;
+        });
+        return this.initPromise;
+    }
+
+    private async runInit(): Promise<this> {
         if (this.isInitialized) return this;
         // a rerun after a failed startup would re-init the rolled-back plugins
         if (this.startFailed) throw new SeedcordError(SeedcordErrorCode.LifecycleRestartAfterFailure);
 
         this.registerPluginTasks();
 
-        // two racing start() calls both reach here, since isInitialized is only set once startup settles
-        const wantsProcessErrors = this.config.errors?.catchProcessErrors ?? true;
-        if (wantsProcessErrors && !Pluggable.liveProcessErrors) {
+        if (this.config.errors?.catchProcessErrors ?? true) {
             Pluggable.liveProcessErrors = registerProcessErrors(this, this.shutdown);
         }
 

--- a/packages/core/src/node/Pluggable.ts
+++ b/packages/core/src/node/Pluggable.ts
@@ -7,6 +7,7 @@ import { StartupPhase } from '#src/lifecycle/phases';
 import { pluginLoggerOf, resolvedLifecycleSpecOf } from '#src/plugin/Plugin';
 
 import { withTimeout } from './Lifecycle/withTimeout';
+import { registerProcessErrors } from './processErrors';
 
 import type { CoreBase } from '#interfaces/CoreBase';
 import type { CoordinatedShutdown } from '#node/Lifecycle/CoordinatedShutdown';
@@ -58,6 +59,7 @@ export abstract class Pluggable<BotT extends Transport, BotRt extends Runtime> i
 
     private static isInstantiated = false;
     private static liveShutdown?: CoordinatedShutdown | undefined;
+    private static liveProcessErrors?: (() => void) | undefined;
 
     constructor(shutdown: CoordinatedShutdown, startup: CoordinatedStartup) {
         // a `sideEffects: false` build would drop the same call in the node entry
@@ -82,6 +84,10 @@ export abstract class Pluggable<BotT extends Transport, BotRt extends Runtime> i
         if (this.startFailed) throw new SeedcordError(SeedcordErrorCode.LifecycleRestartAfterFailure);
 
         this.registerPluginTasks();
+
+        if (this.config.errors?.catchProcessErrors ?? true) {
+            Pluggable.liveProcessErrors = registerProcessErrors(this, this.shutdown);
+        }
 
         const startupSettled: PromiseWithResolvers<void> = Promise.withResolvers();
         this.shutdown.gateOnStartup(startupSettled.promise);
@@ -108,6 +114,8 @@ export abstract class Pluggable<BotT extends Transport, BotRt extends Runtime> i
     protected static reset(): void {
         Pluggable.liveShutdown?.removeSignalHandlers();
         Pluggable.liveShutdown = undefined;
+        Pluggable.liveProcessErrors?.();
+        Pluggable.liveProcessErrors = undefined;
         Pluggable.isInstantiated = false;
     }
 
@@ -231,7 +239,7 @@ export abstract class Pluggable<BotT extends Transport, BotRt extends Runtime> i
         if (this.disposePhases.has(phase)) return;
         this.disposePhases.add(phase);
 
-        // registered once per phase, later inits of that phase run in the same task
+        // the budget covers every dispose in this phase because they all run in this one task
         const budget = this.attachments.reduce((sum, a) => {
             const spec = resolvedLifecycleSpecOf(a.instance);
             return a.instance.dispose && spec.dispose.phase === phase ? sum + spec.dispose.timeout : sum;

--- a/packages/core/src/node/Pluggable.ts
+++ b/packages/core/src/node/Pluggable.ts
@@ -85,7 +85,9 @@ export abstract class Pluggable<BotT extends Transport, BotRt extends Runtime> i
 
         this.registerPluginTasks();
 
-        if (this.config.errors?.catchProcessErrors ?? true) {
+        // two racing start() calls both reach here, since isInitialized is only set once startup settles
+        const wantsProcessErrors = this.config.errors?.catchProcessErrors ?? true;
+        if (wantsProcessErrors && !Pluggable.liveProcessErrors) {
             Pluggable.liveProcessErrors = registerProcessErrors(this, this.shutdown);
         }
 

--- a/packages/core/src/node/processErrors.ts
+++ b/packages/core/src/node/processErrors.ts
@@ -1,0 +1,42 @@
+import crypto from 'node:crypto';
+
+import { Logger } from '@seedcord/logger';
+
+import { asError } from '#stops/asError';
+import { PublishDefault } from '#subscribers/publishDefault';
+
+import type { CoreBase } from '#interfaces/CoreBase';
+import type { CoordinatedShutdown } from '#node/Lifecycle/CoordinatedShutdown';
+
+const logger = new Logger('Faults', { channel: 'errors' });
+
+/** @internal */
+export function registerProcessErrors(core: CoreBase, shutdown: CoordinatedShutdown): () => void {
+    function report(caught: unknown, routeId: string): void {
+        const error = asError(caught);
+        const uuid = crypto.randomUUID();
+
+        if (core.config.errors?.errorStack ?? false) logger.error(uuid, error);
+        else logger.error(`${uuid} | ${error.message}`);
+
+        core.bus[PublishDefault]('unknownException', { uuid, error, routeId });
+    }
+
+    const onRejection = (reason: unknown): void => {
+        report(reason, 'process:unhandledRejection');
+    };
+
+    const onException = (caught: unknown): void => {
+        report(caught, 'process:uncaughtException');
+        // node does not exit on its own once a listener is registered
+        void shutdown.run(1);
+    };
+
+    process.on('unhandledRejection', onRejection);
+    process.on('uncaughtException', onException);
+
+    return () => {
+        process.off('unhandledRejection', onRejection);
+        process.off('uncaughtException', onException);
+    };
+}

--- a/packages/core/tests/node/lifecycle/shutdown-exit-code.test.ts
+++ b/packages/core/tests/node/lifecycle/shutdown-exit-code.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+
+import { CoordinatedShutdown } from '#node/Lifecycle/CoordinatedShutdown';
+
+describe('CoordinatedShutdown exit code', () => {
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+    });
+
+    it('raises the code when a crash arrives during an in-flight shutdown', async () => {
+        vi.useFakeTimers();
+        const exit = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+        const shutdown = new CoordinatedShutdown();
+
+        const sigterm = shutdown.run(0);
+        await shutdown.run(1);
+        await sigterm;
+
+        await vi.runAllTimersAsync();
+
+        expect(exit).toHaveBeenCalledWith(1);
+    });
+
+    it('keeps the first code when the second run asks for a lower one', async () => {
+        vi.useFakeTimers();
+        const exit = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+        const shutdown = new CoordinatedShutdown();
+
+        const crash = shutdown.run(1);
+        await shutdown.run(0);
+        await crash;
+
+        await vi.runAllTimersAsync();
+
+        expect(exit).toHaveBeenCalledWith(1);
+    });
+});

--- a/packages/core/tests/node/process-errors.test.ts
+++ b/packages/core/tests/node/process-errors.test.ts
@@ -121,6 +121,15 @@ describe('process error handlers', () => {
         expect(process.listenerCount('unhandledRejection')).toBe(rejections);
     });
 
+    it('a racing start sees the same startup failure', async () => {
+        const host = new TestHost(new CoordinatedShutdown(), new CoordinatedStartup(), {} as Config);
+        host.startup.addTask(StartupPhase.Configuration, 'boom', () => Promise.reject(new Error('boot failed')));
+
+        const settled = await Promise.allSettled([host.run(), host.run()]);
+
+        expect(settled.map((result) => result.status)).toEqual(['rejected', 'rejected']);
+    });
+
     it('removes both listeners after a failed startup', async () => {
         const exceptions = process.listenerCount('uncaughtException');
         const rejections = process.listenerCount('unhandledRejection');

--- a/packages/core/tests/node/process-errors.test.ts
+++ b/packages/core/tests/node/process-errors.test.ts
@@ -48,11 +48,16 @@ async function startHost(config: Config = {} as Config): Promise<{
     return { host, shutdown, reported };
 }
 
-function fireLatest(event: 'uncaughtException' | 'unhandledRejection', error: Error): void {
-    const latest = process.listeners(event).at(-1);
-    if (!latest) throw new Error(`no ${event} listener registered`);
-    // justified: both node signatures take the thrown value first
-    (latest as unknown as (thrown: unknown) => void)(error);
+function fireUncaught(error: Error): void {
+    const latest = process.listeners('uncaughtException').at(-1);
+    if (!latest) throw new Error('no uncaughtException listener registered');
+    latest(error, 'uncaughtException');
+}
+
+function fireRejection(reason: Error): void {
+    const latest = process.listeners('unhandledRejection').at(-1);
+    if (!latest) throw new Error('no unhandledRejection listener registered');
+    latest(reason, Promise.resolve());
 }
 
 describe('process error handlers', () => {
@@ -66,7 +71,7 @@ describe('process error handlers', () => {
         const run = vi.spyOn(shutdown, 'run');
         const thrown = new Error('forgot an await');
 
-        fireLatest('unhandledRejection', thrown);
+        fireRejection(thrown);
 
         await vi.waitFor(() => {
             expect(reported).toHaveLength(1);
@@ -81,7 +86,7 @@ describe('process error handlers', () => {
         const run = vi.spyOn(shutdown, 'run').mockResolvedValue();
         const thrown = new Error('escaped every handler');
 
-        fireLatest('uncaughtException', thrown);
+        fireUncaught(thrown);
 
         await vi.waitFor(() => {
             expect(reported).toHaveLength(1);
@@ -99,6 +104,21 @@ describe('process error handlers', () => {
 
         expect(process.listenerCount('unhandledRejection')).toBe(rejections);
         expect(process.listenerCount('uncaughtException')).toBe(exceptions);
+    });
+
+    it('registers one listener pair when two starts race', async () => {
+        const exceptions = process.listenerCount('uncaughtException');
+        const rejections = process.listenerCount('unhandledRejection');
+
+        const host = new TestHost(new CoordinatedShutdown(), new CoordinatedStartup(), {} as Config);
+        await Promise.all([host.run(), host.run()]);
+
+        expect(process.listenerCount('uncaughtException')).toBe(exceptions + 1);
+
+        TestHost.resetHost();
+
+        expect(process.listenerCount('uncaughtException')).toBe(exceptions);
+        expect(process.listenerCount('unhandledRejection')).toBe(rejections);
     });
 
     it('removes both listeners after a failed startup', async () => {

--- a/packages/core/tests/node/process-errors.test.ts
+++ b/packages/core/tests/node/process-errors.test.ts
@@ -1,0 +1,130 @@
+import { REST } from '@discordjs/rest';
+import { MemoryRateLimiter } from '@seedcord/rate-limiter';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+
+import { CoordinatedShutdown } from '#node/Lifecycle/CoordinatedShutdown';
+import { CoordinatedStartup } from '#node/Lifecycle/CoordinatedStartup';
+import { Pluggable } from '#node/Pluggable';
+import { StartupPhase } from '#src/lifecycle/phases';
+import { Bus } from '#subscribers/Bus';
+
+import type { SubscriptionData } from '#subscribers/types/Subscriptions';
+import type { Config, IRateLimiter } from '@seedcord/types';
+
+class TestHost extends Pluggable<'gateway', 'server'> {
+    public readonly config: Config;
+    public readonly rest = new REST();
+    public readonly applicationId = 'app-1';
+    public readonly rateLimiter: IRateLimiter = new MemoryRateLimiter();
+    public readonly bus: Bus;
+
+    constructor(shutdown: CoordinatedShutdown, startup: CoordinatedStartup, config: Config) {
+        super(shutdown, startup);
+        this.config = config;
+        this.bus = new Bus(this);
+    }
+
+    public run(): Promise<this> {
+        return this.init();
+    }
+
+    public static resetHost(): void {
+        Pluggable.reset();
+    }
+}
+
+// justified: this startup path reads config.errors and nothing else on Config
+async function startHost(config: Config = {} as Config): Promise<{
+    host: TestHost;
+    shutdown: CoordinatedShutdown;
+    reported: SubscriptionData<'unknownException'>[];
+}> {
+    const shutdown = new CoordinatedShutdown();
+    const host = new TestHost(shutdown, new CoordinatedStartup(), config);
+    const reported: SubscriptionData<'unknownException'>[] = [];
+    host.bus.on('unknownException', (payload) => reported.push(payload));
+
+    await host.run();
+    return { host, shutdown, reported };
+}
+
+function fireLatest(event: 'uncaughtException' | 'unhandledRejection', error: Error): void {
+    const latest = process.listeners(event).at(-1);
+    if (!latest) throw new Error(`no ${event} listener registered`);
+    // justified: both node signatures take the thrown value first
+    (latest as unknown as (thrown: unknown) => void)(error);
+}
+
+describe('process error handlers', () => {
+    afterEach(() => {
+        TestHost.resetHost();
+        vi.restoreAllMocks();
+    });
+
+    it('reports an unhandled rejection and keeps the bot running', async () => {
+        const { shutdown, reported } = await startHost();
+        const run = vi.spyOn(shutdown, 'run');
+        const thrown = new Error('forgot an await');
+
+        fireLatest('unhandledRejection', thrown);
+
+        await vi.waitFor(() => {
+            expect(reported).toHaveLength(1);
+        });
+        expect(reported[0]?.error).toBe(thrown);
+        expect(reported[0]?.routeId).toBe('process:unhandledRejection');
+        expect(run).not.toHaveBeenCalled();
+    });
+
+    it('reports an uncaught exception and shuts down with exit code 1', async () => {
+        const { shutdown, reported } = await startHost();
+        const run = vi.spyOn(shutdown, 'run').mockResolvedValue();
+        const thrown = new Error('escaped every handler');
+
+        fireLatest('uncaughtException', thrown);
+
+        await vi.waitFor(() => {
+            expect(reported).toHaveLength(1);
+        });
+        expect(reported[0]?.error).toBe(thrown);
+        expect(reported[0]?.routeId).toBe('process:uncaughtException');
+        expect(run).toHaveBeenCalledWith(1);
+    });
+
+    it('registers neither listener when catchProcessErrors is off', async () => {
+        const rejections = process.listenerCount('unhandledRejection');
+        const exceptions = process.listenerCount('uncaughtException');
+
+        await startHost({ errors: { catchProcessErrors: false } } as unknown as Config);
+
+        expect(process.listenerCount('unhandledRejection')).toBe(rejections);
+        expect(process.listenerCount('uncaughtException')).toBe(exceptions);
+    });
+
+    it('removes both listeners after a failed startup', async () => {
+        const exceptions = process.listenerCount('uncaughtException');
+        const rejections = process.listenerCount('unhandledRejection');
+
+        const host = new TestHost(new CoordinatedShutdown(), new CoordinatedStartup(), {} as Config);
+        host.startup.addTask(StartupPhase.Configuration, 'boom', () => Promise.reject(new Error('boot failed')));
+        await expect(host.run()).rejects.toThrow();
+        expect(process.listenerCount('uncaughtException')).toBe(exceptions + 1);
+
+        TestHost.resetHost();
+
+        expect(process.listenerCount('uncaughtException')).toBe(exceptions);
+        expect(process.listenerCount('unhandledRejection')).toBe(rejections);
+    });
+
+    it('removes both listeners when the host resets', async () => {
+        const exceptions = process.listenerCount('uncaughtException');
+        const rejections = process.listenerCount('unhandledRejection');
+        await startHost();
+        expect(process.listenerCount('uncaughtException')).toBe(exceptions + 1);
+
+        TestHost.resetHost();
+
+        expect(process.listenerCount('uncaughtException')).toBe(exceptions);
+        expect(process.listenerCount('unhandledRejection')).toBe(rejections);
+    });
+});

--- a/packages/core/tests/subscribers/Bus.listener-isolation.test.ts
+++ b/packages/core/tests/subscribers/Bus.listener-isolation.test.ts
@@ -50,6 +50,23 @@ describe('Bus listener isolation', () => {
         expect(reached).toBe(true);
     });
 
+    it('logs a rejected async listener through its own logger', async () => {
+        const bus = stubBus();
+        const error = vi.spyOn(busLoggerOf(bus), 'error');
+        const thrown = new Error('listener blew up');
+
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises -- the void position is what this pins
+        bus.on('unknownException', async () => {
+            await Promise.resolve();
+            throw thrown;
+        });
+        bus[PublishDefault]('unknownException', faultPayload());
+
+        await vi.waitFor(() => {
+            expect(error).toHaveBeenCalledWith('listener for unknownException threw', thrown);
+        });
+    });
+
     it('logs the listener error through its own logger', () => {
         const bus = stubBus();
         const error = vi.spyOn(busLoggerOf(bus), 'error');

--- a/packages/event-emitter/src/TypedEventEmitter.ts
+++ b/packages/event-emitter/src/TypedEventEmitter.ts
@@ -103,7 +103,13 @@ export class TypedEventEmitter<TEvents extends EventMap<TEvents>> {
         const current = [...slot];
         for (const registration of current) {
             try {
-                registration.call(...args);
+                const returned: unknown = registration.call(...args);
+                // an async listener rejects after this try has already returned
+                if (returned instanceof Promise) {
+                    void returned.catch((error: unknown) => {
+                        this.onListenerError(error, event);
+                    });
+                }
             } catch (error) {
                 this.onListenerError(error, event);
             }

--- a/packages/event-emitter/src/TypedEventEmitter.ts
+++ b/packages/event-emitter/src/TypedEventEmitter.ts
@@ -43,7 +43,8 @@ export class TypedEventEmitter<TEvents extends EventMap<TEvents>> {
                 if (fired) return;
                 fired = true;
                 this.removeRegistration(event, registration);
-                original(...args);
+                // dispatchSafe reads this to catch an async listener's rejection
+                return original(...args);
             },
             original
         };
@@ -103,13 +104,9 @@ export class TypedEventEmitter<TEvents extends EventMap<TEvents>> {
         const current = [...slot];
         for (const registration of current) {
             try {
-                const returned: unknown = registration.call(...args);
-                // an async listener rejects after this try has already returned
-                if (returned instanceof Promise) {
-                    void returned.catch((error: unknown) => {
-                        this.onListenerError(error, event);
-                    });
-                }
+                void Promise.resolve(registration.call(...args)).catch((error: unknown) => {
+                    this.onListenerError(error, event);
+                });
             } catch (error) {
                 this.onListenerError(error, event);
             }

--- a/packages/event-emitter/tests/emit-safe.test.ts
+++ b/packages/event-emitter/tests/emit-safe.test.ts
@@ -53,6 +53,40 @@ describe('TypedEventEmitter.emitSafe', () => {
         });
     });
 
+    it('routes a rejected async once() listener to onListenerError', async () => {
+        const ee = new SafeEmitter();
+        const boom = new Error('boom');
+
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises -- the void position is exactly what this pins
+        ee.once('e', async () => {
+            await Promise.resolve();
+            throw boom;
+        });
+
+        expect(ee.fire(1)).toBe(true);
+        await vi.waitFor(() => {
+            expect(ee.errors).toEqual([boom]);
+        });
+    });
+
+    it('routes a rejected thenable that is not a native promise', async () => {
+        const ee = new SafeEmitter();
+        const boom = new Error('boom');
+
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises -- a listener returning a thenable is the case under test
+        ee.on('e', () => ({
+            // eslint-disable-next-line unicorn/no-thenable -- this object is the foreign thenable
+            then: (_resolve: (value: unknown) => void, reject: (error: unknown) => void): void => {
+                reject(boom);
+            }
+        }));
+
+        expect(ee.fire(1)).toBe(true);
+        await vi.waitFor(() => {
+            expect(ee.errors).toEqual([boom]);
+        });
+    });
+
     it('default onListenerError isolates the caller and re-throws the error on a microtask', () => {
         const scheduled: (() => void)[] = [];
         const spy = vi.spyOn(globalThis, 'queueMicrotask').mockImplementation((cb) => {

--- a/packages/event-emitter/tests/emit-safe.test.ts
+++ b/packages/event-emitter/tests/emit-safe.test.ts
@@ -34,6 +34,25 @@ describe('TypedEventEmitter.emitSafe', () => {
         expect(ee.errors).toEqual([boom]);
     });
 
+    it('routes a rejected async listener to onListenerError', async () => {
+        const ee = new SafeEmitter();
+        const boom = new Error('boom');
+        const after = vi.fn();
+
+        // eslint-disable-next-line @typescript-eslint/no-misused-promises -- the void position is exactly what this pins
+        ee.on('e', async () => {
+            await Promise.resolve();
+            throw boom;
+        });
+        ee.on('e', after);
+
+        expect(ee.fire(1)).toBe(true);
+        expect(after).toHaveBeenCalledWith(1);
+        await vi.waitFor(() => {
+            expect(ee.errors).toEqual([boom]);
+        });
+    });
+
     it('default onListenerError isolates the caller and re-throws the error on a microtask', () => {
         const scheduled: (() => void)[] = [];
         const spy = vi.spyOn(globalThis, 'queueMicrotask').mockImplementation((cb) => {

--- a/packages/gateway/src/Seedcord.ts
+++ b/packages/gateway/src/Seedcord.ts
@@ -8,6 +8,7 @@ import {
     Pluggable,
     SubscriberLoader
 } from '@seedcord/core/node/internal';
+import { isSeedcordError, SeedcordErrorCode } from '@seedcord/errors';
 import { LoggerChannelRegistry } from '@seedcord/logger';
 import { installNodeDefaults } from '@seedcord/logger/node';
 import { MemoryRateLimiter } from '@seedcord/rate-limiter';
@@ -125,6 +126,8 @@ export class Seedcord extends Pluggable<'gateway', 'server'> implements Core, Se
         try {
             await super.init();
         } catch (caught) {
+            // resetting here would strip the handlers of whichever host replaced this one
+            if (isSeedcordError(caught, undefined, SeedcordErrorCode.LifecycleRestartAfterFailure)) throw caught;
             // shutdown releases any resource opened before the failure, then rethrow
             await this.shutdown.run(1, false);
             Seedcord.reset();

--- a/packages/gateway/src/Seedcord.ts
+++ b/packages/gateway/src/Seedcord.ts
@@ -8,7 +8,6 @@ import {
     Pluggable,
     SubscriberLoader
 } from '@seedcord/core/node/internal';
-import { isSeedcordError, SeedcordErrorCode } from '@seedcord/errors';
 import { LoggerChannelRegistry } from '@seedcord/logger';
 import { installNodeDefaults } from '@seedcord/logger/node';
 import { MemoryRateLimiter } from '@seedcord/rate-limiter';
@@ -86,10 +85,11 @@ export class Seedcord extends Pluggable<'gateway', 'server'> implements Core, Se
         return this.bot.client.user?.username;
     }
 
-    protected static override reset(): void {
-        super.reset();
+    protected static override reset(host?: object): boolean {
+        if (!super.reset(host)) return false;
         // reset() would drop the dev TUI's log sink
         LoggerChannelRegistry.instance.configure({});
+        return true;
     }
 
     private registerStartupTasks(): void {
@@ -126,11 +126,9 @@ export class Seedcord extends Pluggable<'gateway', 'server'> implements Core, Se
         try {
             await super.init();
         } catch (caught) {
-            // resetting here would strip the handlers of whichever host replaced this one
-            if (isSeedcordError(caught, undefined, SeedcordErrorCode.LifecycleRestartAfterFailure)) throw caught;
             // shutdown releases any resource opened before the failure, then rethrow
             await this.shutdown.run(1, false);
-            Seedcord.reset();
+            Seedcord.reset(this);
             throw caught;
         }
         return this;

--- a/packages/gateway/tests/seedcord-host.test.ts
+++ b/packages/gateway/tests/seedcord-host.test.ts
@@ -1,4 +1,5 @@
 import { ShutdownPhase, StartupPhase } from '@seedcord/core/node/internal';
+import { LoggerChannelRegistry } from '@seedcord/logger';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 import { Seedcord } from '#src/Seedcord';
@@ -67,6 +68,22 @@ describe('Seedcord host', () => {
         await expect(dead.start()).rejects.toThrow(/new instance/);
 
         expect(process.listenerCount('SIGTERM')).toBe(base + 1);
+    });
+
+    it('a racing start failure tears the host down once', async () => {
+        const seedcord = new Seedcord(testConfig());
+        seedcord.startup.addTask(StartupPhase.Configuration, 'boom', () => Promise.reject(new Error('boom')));
+        seedcord.shutdown.addTask(
+            ShutdownPhase.Drain,
+            'slow',
+            () => new Promise<void>((resolve) => setTimeout(resolve, 50))
+        );
+        const configure = vi.spyOn(LoggerChannelRegistry.instance, 'configure');
+
+        const settled = await Promise.allSettled([seedcord.start(), seedcord.start()]);
+
+        expect(settled.map((result) => result.status)).toEqual(['rejected', 'rejected']);
+        expect(configure).toHaveBeenCalledTimes(1);
     });
 
     it('a start failure after login destroys the client', async () => {

--- a/packages/gateway/tests/seedcord-host.test.ts
+++ b/packages/gateway/tests/seedcord-host.test.ts
@@ -54,6 +54,21 @@ describe('Seedcord host', () => {
         expect(() => new Seedcord(testConfig())).not.toThrow();
     });
 
+    it('a stale host retrying start leaves the live host alone', async () => {
+        const dead = new Seedcord(testConfig());
+        dead.startup.addTask(StartupPhase.Configuration, 'boom', () => Promise.reject(new Error('boom')));
+        await expect(dead.start()).rejects.toThrow();
+
+        const base = process.listenerCount('SIGTERM');
+        // eslint-disable-next-line no-new -- construction registers the handlers under test
+        new Seedcord(testConfig());
+        expect(process.listenerCount('SIGTERM')).toBe(base + 1);
+
+        await expect(dead.start()).rejects.toThrow(/new instance/);
+
+        expect(process.listenerCount('SIGTERM')).toBe(base + 1);
+    });
+
     it('a start failure after login destroys the client', async () => {
         const seedcord = new Seedcord(testConfig());
         // justified: the mock client cannot complete a real login handshake

--- a/packages/http/src/node/Seedcord.ts
+++ b/packages/http/src/node/Seedcord.ts
@@ -13,7 +13,7 @@ import {
     StartupPhase,
     SubscriberLoader
 } from '@seedcord/core/node/internal';
-import { isSeedcordError, SeedcordErrorCode, paint } from '@seedcord/errors';
+import { SeedcordErrorCode, paint } from '@seedcord/errors';
 import { applicationIdFromToken, SeedcordError, validateDiscordToken } from '@seedcord/errors/internal';
 import { Logger, LoggerChannelRegistry } from '@seedcord/logger';
 import { installNodeDefaults } from '@seedcord/logger/node';
@@ -124,19 +124,18 @@ export class Seedcord<Cfg extends HttpConfig = HttpConfig>
         try {
             await super.init();
         } catch (caught) {
-            // resetting here would strip the handlers of whichever host replaced this one
-            if (isSeedcordError(caught, undefined, SeedcordErrorCode.LifecycleRestartAfterFailure)) throw caught;
             await this.shutdown.run(1, false);
-            Seedcord.reset();
+            Seedcord.reset(this);
             throw caught;
         }
         return this;
     }
 
-    protected static override reset(): void {
-        super.reset();
+    protected static override reset(host?: object): boolean {
+        if (!super.reset(host)) return false;
         // super.reset() drops the dev TUI's log sink
         LoggerChannelRegistry.instance.configure({});
+        return true;
     }
 
     private registerStartupTasks(): void {

--- a/packages/http/src/node/Seedcord.ts
+++ b/packages/http/src/node/Seedcord.ts
@@ -13,7 +13,7 @@ import {
     StartupPhase,
     SubscriberLoader
 } from '@seedcord/core/node/internal';
-import { SeedcordErrorCode, paint } from '@seedcord/errors';
+import { isSeedcordError, SeedcordErrorCode, paint } from '@seedcord/errors';
 import { applicationIdFromToken, SeedcordError, validateDiscordToken } from '@seedcord/errors/internal';
 import { Logger, LoggerChannelRegistry } from '@seedcord/logger';
 import { installNodeDefaults } from '@seedcord/logger/node';
@@ -124,6 +124,8 @@ export class Seedcord<Cfg extends HttpConfig = HttpConfig>
         try {
             await super.init();
         } catch (caught) {
+            // resetting here would strip the handlers of whichever host replaced this one
+            if (isSeedcordError(caught, undefined, SeedcordErrorCode.LifecycleRestartAfterFailure)) throw caught;
             await this.shutdown.run(1, false);
             Seedcord.reset();
             throw caught;

--- a/packages/logger/src/LoggerChannelRegistry.ts
+++ b/packages/logger/src/LoggerChannelRegistry.ts
@@ -69,13 +69,19 @@ export class LoggerChannelRegistry {
 
     private emit(sink: ILogSink, record: LogRecord): void {
         try {
-            sink.onLog(record);
+            void Promise.resolve(sink.onLog(record)).catch((error: unknown) => {
+                this.sinkFailed(sink, error);
+            });
         } catch (error: unknown) {
-            if (this.broken.has(sink)) return;
-            this.broken.add(sink);
-            // eslint-disable-next-line no-console -- console because the log pipeline is the thing that broke
-            console.error('[seedcord] a log sink threw, dropping its output for this process', error);
+            this.sinkFailed(sink, error);
         }
+    }
+
+    private sinkFailed(sink: ILogSink, error: unknown): void {
+        if (this.broken.has(sink)) return;
+        this.broken.add(sink);
+        // eslint-disable-next-line no-console -- console because the log pipeline is the thing that broke
+        console.error('[seedcord] a log sink threw, dropping its output for this process', error);
     }
 
     /** Installs a capture sink (the dev TUI, a remote drain). Survives a `configure` replace. */

--- a/packages/logger/tests/core.test.ts
+++ b/packages/logger/tests/core.test.ts
@@ -287,6 +287,14 @@ class ThrowingSink implements ILogSink {
     }
 }
 
+class RejectingSink implements ILogSink {
+    public readonly kind: ILogSink['kind'] = 'console';
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises, @typescript-eslint/require-await -- a void-returning interface taking an async method is the bug under test
+    public async onLog(): Promise<void> {
+        throw new Error('sink exploded later');
+    }
+}
+
 describe('a sink that throws', () => {
     it('keeps the throw away from whatever logged', () => {
         registry.configure({ level: 'trace', sinks: [new ThrowingSink()] });
@@ -311,5 +319,18 @@ describe('a sink that throws', () => {
         new Logger('Bot').info('ping');
 
         expect(capture.records).toHaveLength(1);
+    });
+
+    it('reports an async sink that rejects, and reports it once', async () => {
+        const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+        registry.configure({ level: 'trace', sinks: [new RejectingSink()] });
+
+        new Logger('Bot').info('first');
+        new Logger('Bot').info('second');
+
+        await vi.waitFor(() => {
+            expect(consoleError).toHaveBeenCalledTimes(1);
+        });
+        expect(consoleError.mock.calls[0]?.[0]).toContain('a log sink threw');
     });
 });

--- a/packages/types/src/Interfaces/Errors.ts
+++ b/packages/types/src/Interfaces/Errors.ts
@@ -37,6 +37,18 @@ export interface ErrorsConfig {
      */
     defaultError?: new (uuid: UUID) => RenderableNotice;
     /**
+     * Whether the framework reports a throw that escapes every handler, such as a promise your code
+     * never awaited or a `setTimeout` callback that threw. Both report as an unknown fault. The bot
+     * keeps running after an unhandled rejection. An uncaught exception runs the coordinated shutdown
+     * and exits 1.
+     *
+     * Turn it off when the surrounding application registers its own `unhandledRejection` and
+     * `uncaughtException` handlers.
+     *
+     * @defaultValue `true`
+     */
+    catchProcessErrors?: boolean;
+    /**
      * discord.js API error codes the interaction error path swallows quietly, reporting no fault, for a
      * code thrown by the handler's own work. When empty, every such code reports and a real
      * bug (a double ack from a misplaced defer) surfaces. Add a code here to swallow it once you have


### PR DESCRIPTION
## Checklist

- [x] Tests cover the change
- [x] `pnpm prePush` is green
- [x] Changeset added with `pnpm cs`, for any change to a published package



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic handling for unhandled promise rejections and uncaught exceptions, enabled by default.
  * Reports process-level errors and emits diagnostic events.
  * Uncaught exceptions now trigger coordinated shutdown with exit code 1.
  * Added configuration to disable process-level error handling.

* **Bug Fixes**
  * Async listener failures and log sink rejections are now handled consistently without crashing the process.
  * Shutdown preserves the highest exit code across repeated or overlapping attempts.
  * Retrying startup after a failed attempt no longer disrupts the replacement host’s configuration or signal handlers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->