### PR TITLE
feat: menu and modal options

### DIFF
--- a/.changeset/modal-and-select-inputs.md
+++ b/.changeset/modal-and-select-inputs.md
@@ -1,0 +1,7 @@
+---
+'@seedcord/gateway': minor
+'@seedcord/errors': minor
+'@seedcord/http': minor
+---
+
+Modal and select menu handlers read their inputs the same way on both transports. `this.fields` reads a modal's submitted values by custom id. A select handler carries `values` plus the resolved `users`, `members`, `roles`, and `channels` for its kind.

--- a/packages/errors/src/ErrorCodes.ts
+++ b/packages/errors/src/ErrorCodes.ts
@@ -124,6 +124,14 @@ export enum SeedcordErrorCode {
     AutocompleteNoFocusedOption = 1614,
     /** A context menu handler's match() has no arm for the command name that fired. */
     ContextMenuMatchArmMissing = 1615,
+    /** No field in the submitted modal carries the requested custom id. */
+    ModalFieldNotFound = 1616,
+    /** A modal field getter was called on a field of another kind. */
+    ModalFieldWrongKind = 1617,
+    /** Nothing was picked in a modal field read as required. */
+    ModalFieldEmpty = 1618,
+    /** A channel select field picked a channel outside the types getSelectedChannels() allows. */
+    ModalFieldChannelType = 1619,
 
     /** A Cooldown gate was given a duration string that is not a well-formed positive duration. */
     GateInvalidCooldownDuration = 1701,

--- a/packages/errors/src/ErrorMessages.ts
+++ b/packages/errors/src/ErrorMessages.ts
@@ -121,6 +121,14 @@ const messages = {
     [SeedcordErrorCode.EventMiddlewareNameUnavailable]: () =>
         `this.eventName is only available on middleware the controller constructed with a fired event name.`,
     [SeedcordErrorCode.AutocompleteNoFocusedOption]: () => `Autocomplete payload has no focused option.`,
+    [SeedcordErrorCode.ModalFieldNotFound]: (customId: string) =>
+        `The submitted modal carries no field with the custom id ${JSON.stringify(customId)}. Check it against the id you gave the component when you built the modal.`,
+    [SeedcordErrorCode.ModalFieldWrongKind]: (customId: string, kind: string, getter: string) =>
+        `Modal field ${JSON.stringify(customId)} holds ${kind}. Read it with ${getter}().`,
+    [SeedcordErrorCode.ModalFieldEmpty]: (customId: string) =>
+        `Modal field ${JSON.stringify(customId)} carries no selection. Build the component as required, or read it without the required argument.`,
+    [SeedcordErrorCode.ModalFieldChannelType]: (customId: string, picked: string, allowed: string) =>
+        `Modal field ${JSON.stringify(customId)} picked a ${picked} channel. This read allows ${allowed}.`,
 
     [SeedcordErrorCode.GateInvalidCooldownDuration]: (input: string) =>
         `Cooldown duration ${JSON.stringify(input)} is not valid. Pass a number of seconds or a duration string like '30m', '24h', or '500ms'.`,

--- a/packages/errors/src/ErrorMessages.ts
+++ b/packages/errors/src/ErrorMessages.ts
@@ -123,8 +123,10 @@ const messages = {
     [SeedcordErrorCode.AutocompleteNoFocusedOption]: () => `Autocomplete payload has no focused option.`,
     [SeedcordErrorCode.ModalFieldNotFound]: (customId: string) =>
         `The submitted modal carries no field with the custom id ${JSON.stringify(customId)}. Check it against the id you gave the component when you built the modal.`,
-    [SeedcordErrorCode.ModalFieldWrongKind]: (customId: string, kind: string, getter: string) =>
-        `Modal field ${JSON.stringify(customId)} holds ${kind}. Read it with ${getter}().`,
+    [SeedcordErrorCode.ModalFieldWrongKind]: (customId: string, kind: string, getter?: string) =>
+        getter
+            ? `Modal field ${JSON.stringify(customId)} holds ${kind}. Read it with ${getter}().`
+            : `Modal field ${JSON.stringify(customId)} holds ${kind}. No getter reads that kind.`,
     [SeedcordErrorCode.ModalFieldEmpty]: (customId: string) =>
         `Modal field ${JSON.stringify(customId)} carries no selection. Build the component as required, or read it without the required argument.`,
     [SeedcordErrorCode.ModalFieldChannelType]: (customId: string, picked: string, allowed: string) =>

--- a/packages/gateway/src/handlers/interaction/components/ModalHandler.ts
+++ b/packages/gateway/src/handlers/interaction/components/ModalHandler.ts
@@ -7,15 +7,15 @@ import { ComponentHandler } from './ComponentHandler';
 import type { SentMessage } from '#bot/ReplySender';
 import type { GatewayReplyResponse } from '#interfaces/ReplyResponse';
 import type { AnyCustomId } from '@seedcord/core/internal';
-import type { CacheType, ModalSubmitInteraction } from 'discord.js';
+import type { CacheType, ModalSubmitFields, ModalSubmitInteraction } from 'discord.js';
 
 /**
  * Base class for a modal submit handler.
  *
  * Register the customId definitions this handler decodes with `@ModalRoute`, list the same ones in the
  * generic, then read `this.params` for a single route or `this.match` for several. Read the submitted
- * inputs from `this.event.fields`, and reply through the handler members. Discord forbids opening a modal in
- * response to a modal, so `showModal` fails compilation on this kind.
+ * inputs from `this.fields`. Reply through the handler members. `showModal` fails compilation on this kind,
+ * because Discord forbids opening a modal in response to a modal.
  *
  * @typeParam Defs - The customId definitions this handler decodes, e.g. `[typeof ConfigId]`.
  * @typeParam Cache - The interaction cache state, `'cached'` by default.
@@ -26,7 +26,7 @@ import type { CacheType, ModalSubmitInteraction } from 'discord.js';
  * class ConfigModal extends ModalHandler<[typeof ConfigId]> {
  *     async execute() {
  *         const { guildId } = this.params;
- *         const name = this.event.fields.getTextInputValue('name');
+ *         const name = this.fields.getTextInputValue('name');
  *         await this.reply(`saved ${name} for ${guildId}`);
  *     }
  * }
@@ -39,6 +39,11 @@ export abstract class ModalHandler<
     // phantom, never set at runtime.
     /** @internal */
     declare readonly [ComponentKindBrand]?: 'modal';
+
+    /** The fields this modal submitted, read by custom id. */
+    protected get fields(): ModalSubmitFields {
+        return this.event.fields;
+    }
 
     /** Rewrite the message this modal was opened from. Throws when a command opened the modal. */
     protected override update(response: GatewayReplyResponse | string): Promise<SentMessage> {

--- a/packages/gateway/src/handlers/interaction/components/ModalHandler.ts
+++ b/packages/gateway/src/handlers/interaction/components/ModalHandler.ts
@@ -41,7 +41,7 @@ export abstract class ModalHandler<
     declare readonly [ComponentKindBrand]?: 'modal';
 
     /** The fields this modal submitted, read by custom id. */
-    protected get fields(): ModalSubmitFields {
+    protected get fields(): ModalSubmitFields<Cache> {
         return this.event.fields;
     }
 

--- a/packages/gateway/src/handlers/interaction/components/SelectMenuHandler.ts
+++ b/packages/gateway/src/handlers/interaction/components/SelectMenuHandler.ts
@@ -15,8 +15,11 @@ import type {
 
 type SelectKey = 'values' | 'users' | 'members' | 'roles' | 'channels';
 
-type EventMember<Kind extends SelectMenuKind, Cache extends CacheType, Key extends SelectKey> =
-    Key extends keyof SelectMenuInteractionFor<Kind, Cache> ? SelectMenuInteractionFor<Kind, Cache>[Key] : never;
+type EventMember<
+    Kind extends SelectMenuKind,
+    Cache extends CacheType,
+    Key extends SelectKey
+> = Key extends keyof SelectMenuInteractionFor<Kind, Cache> ? SelectMenuInteractionFor<Kind, Cache>[Key] : never;
 
 type SelectMenuInteractionFor<
     SelectMenu extends SelectMenuKind,

--- a/packages/gateway/src/handlers/interaction/components/SelectMenuHandler.ts
+++ b/packages/gateway/src/handlers/interaction/components/SelectMenuHandler.ts
@@ -13,6 +13,11 @@ import type {
     UserSelectMenuInteraction
 } from 'discord.js';
 
+type SelectKey = 'values' | 'users' | 'members' | 'roles' | 'channels';
+
+type EventMember<Kind extends SelectMenuKind, Cache extends CacheType, Key extends SelectKey> =
+    Key extends keyof SelectMenuInteractionFor<Kind, Cache> ? SelectMenuInteractionFor<Kind, Cache>[Key] : never;
+
 type SelectMenuInteractionFor<
     SelectMenu extends SelectMenuKind,
     Cache extends CacheType = CacheType
@@ -31,10 +36,12 @@ type SelectMenuInteractionFor<
 /**
  * Base class for a select menu handler.
  *
- * Pass the select kind first and the customId definitions second, the same order as `@SelectMenuRoute`,
- * so `this.event` and `this.event.values` are narrowed to that kind. Read `this.params` for a single
- * route or `this.match` for several, and reply through the handler members or rewrite the source message
- * with `this.update`.
+ * Pass the select kind first and the customId definitions second, the same order as `@SelectMenuRoute`.
+ * Read the picked ids from `this.values`. The kind decides which of `this.users`, `this.members`,
+ * `this.roles`, and `this.channels` this handler carries. The rest are `never`.
+ *
+ * Read `this.params` for a single route or `this.match` for several. Reply through the handler members, or
+ * rewrite the source message with `this.update`.
  *
  * @typeParam Kind - The select kind from {@link SelectMenuKind}, e.g. `SelectMenuKind.User`.
  * @typeParam Defs - The customId definitions this handler decodes, e.g. `[typeof AssignId]`.
@@ -46,7 +53,7 @@ type SelectMenuInteractionFor<
  * class AssignSelect extends SelectMenuHandler<SelectMenuKind.User, [typeof AssignId]> {
  *     async execute() {
  *         const { roleId } = this.params;
- *         await this.reply(`assigning ${this.event.values.length} member(s) to <@&${roleId}>`);
+ *         await this.reply(`assigning ${this.users.size} member(s) to <@&${roleId}>`);
  *     }
  * }
  * ```
@@ -59,4 +66,34 @@ export abstract class SelectMenuHandler<
     // phantom, never set at runtime.
     /** @internal */
     declare readonly [ComponentKindBrand]?: Kind;
+
+    // Out is never on a kind whose interaction carries no such member
+    private eventMember<Out>(key: SelectKey): Out {
+        return (this.event as Partial<Record<SelectKey, unknown>>)[key] as Out;
+    }
+
+    /** The ids this select picked. */
+    protected get values(): string[] {
+        return this.eventMember('values');
+    }
+
+    /** The users this select picked. */
+    protected get users(): EventMember<Kind, Cache, 'users'> {
+        return this.eventMember('users');
+    }
+
+    /** The guild members behind the picked users. Discord resolves these only inside a guild. */
+    protected get members(): EventMember<Kind, Cache, 'members'> {
+        return this.eventMember('members');
+    }
+
+    /** The roles this select picked. */
+    protected get roles(): EventMember<Kind, Cache, 'roles'> {
+        return this.eventMember('roles');
+    }
+
+    /** The channels this select picked. */
+    protected get channels(): EventMember<Kind, Cache, 'channels'> {
+        return this.eventMember('channels');
+    }
 }

--- a/packages/gateway/tests/handlers/component-inputs.test.ts
+++ b/packages/gateway/tests/handlers/component-inputs.test.ts
@@ -1,0 +1,82 @@
+import { CustomId, ModalRoute, SelectMenuKind, SelectMenuRoute } from '@seedcord/core';
+import { describe, expect, it } from 'vitest';
+
+import { ModalHandler, SelectMenuHandler } from '#handlers/interaction/components';
+
+import type { Core } from '#interfaces/Core';
+import type { ModalSubmitInteraction, UserSelectMenuInteraction } from 'discord.js';
+
+const core = {} as unknown as Core;
+
+const ConfigId = new CustomId('config').str('guildId');
+const AssignId = new CustomId('assign').str('roleId');
+
+// each fake carries only the fields the accessors forward
+function modal(customId: string, inputs: Record<string, string>): ModalSubmitInteraction<'cached'> {
+    return {
+        customId,
+        fields: { getTextInputValue: (id: string) => inputs[id] ?? '' }
+    } as unknown as ModalSubmitInteraction<'cached'>;
+}
+
+function userSelect(customId: string, resolved: object): UserSelectMenuInteraction<'cached'> {
+    return { customId, values: ['u1'], ...resolved } as unknown as UserSelectMenuInteraction<'cached'>;
+}
+
+describe('modal fields', () => {
+    it('reads a submitted input through this.fields', () => {
+        @ModalRoute(ConfigId)
+        class ConfigModal extends ModalHandler<[typeof ConfigId]> {
+            async execute(): Promise<void> {
+                await Promise.resolve();
+            }
+
+            read(): string {
+                return this.fields.getTextInputValue('name');
+            }
+        }
+
+        const event = modal(ConfigId.encode({ guildId: 'g1' }), { name: 'seedcord' });
+
+        expect(new ConfigModal(event, core).read()).toBe('seedcord');
+    });
+});
+
+describe('select accessors', () => {
+    it('reads the picked ids off the interaction', () => {
+        @SelectMenuRoute(SelectMenuKind.User, AssignId)
+        class Assign extends SelectMenuHandler<SelectMenuKind.User, [typeof AssignId]> {
+            async execute(): Promise<void> {
+                await Promise.resolve();
+            }
+
+            read(): string[] {
+                return this.values;
+            }
+        }
+
+        const event = userSelect(AssignId.encode({ roleId: 'r1' }), {});
+
+        expect(new Assign(event, core).read()).toEqual(['u1']);
+    });
+
+    it('reads the resolved users and members off the interaction', () => {
+        const users = new Map([['u1', { id: 'u1' }]]);
+        const members = new Map([['u1', { nick: 'boss' }]]);
+
+        @SelectMenuRoute(SelectMenuKind.User, AssignId)
+        class Assign extends SelectMenuHandler<SelectMenuKind.User, [typeof AssignId]> {
+            async execute(): Promise<void> {
+                await Promise.resolve();
+            }
+
+            read(): [unknown, unknown] {
+                return [this.users, this.members];
+            }
+        }
+
+        const event = userSelect(AssignId.encode({ roleId: 'r1' }), { users, members });
+
+        expect(new Assign(event, core).read()).toEqual([users, members]);
+    });
+});

--- a/packages/gateway/tests/handlers/modal-fields.types-test.ts
+++ b/packages/gateway/tests/handlers/modal-fields.types-test.ts
@@ -1,0 +1,26 @@
+import { CustomId, ModalRoute } from '@seedcord/core';
+import { expectTypeOf } from 'vitest';
+
+import { ModalHandler } from '#handlers/interaction/components';
+
+import type { ModalSubmitFields } from 'discord.js';
+
+const ProbeId = new CustomId('modalprobe').str('x');
+
+@ModalRoute(ProbeId)
+class CachedProbe extends ModalHandler<[typeof ProbeId]> {
+    execute(): Promise<void> {
+        expectTypeOf(this.fields).toEqualTypeOf<ModalSubmitFields<'cached'>>();
+        return Promise.resolve();
+    }
+}
+
+@ModalRoute(ProbeId)
+class RawProbe extends ModalHandler<[typeof ProbeId], 'raw'> {
+    execute(): Promise<void> {
+        expectTypeOf(this.fields).toEqualTypeOf<ModalSubmitFields<'raw'>>();
+        return Promise.resolve();
+    }
+}
+
+export type Probes = [CachedProbe, RawProbe];

--- a/packages/gateway/tests/handlers/select-resolved.types-test.ts
+++ b/packages/gateway/tests/handlers/select-resolved.types-test.ts
@@ -1,0 +1,41 @@
+import { CustomId, SelectMenuKind, SelectMenuRoute } from '@seedcord/core';
+import { expectTypeOf } from 'vitest';
+
+import { SelectMenuHandler } from '#handlers/interaction/components';
+
+import type { ChannelSelectMenuInteraction, UserSelectMenuInteraction } from 'discord.js';
+
+const ProbeId = new CustomId('selectprobe').str('x');
+
+@SelectMenuRoute(SelectMenuKind.String, ProbeId)
+class StringProbe extends SelectMenuHandler<SelectMenuKind.String, [typeof ProbeId]> {
+    execute(): Promise<void> {
+        expectTypeOf(this.users).toBeNever();
+        expectTypeOf(this.members).toBeNever();
+        expectTypeOf(this.roles).toBeNever();
+        expectTypeOf(this.channels).toBeNever();
+        return Promise.resolve();
+    }
+}
+
+@SelectMenuRoute(SelectMenuKind.User, ProbeId)
+class UserProbe extends SelectMenuHandler<SelectMenuKind.User, [typeof ProbeId]> {
+    execute(): Promise<void> {
+        expectTypeOf(this.users).toEqualTypeOf<UserSelectMenuInteraction<'cached'>['users']>();
+        expectTypeOf(this.members).toEqualTypeOf<UserSelectMenuInteraction<'cached'>['members']>();
+        expectTypeOf(this.roles).toBeNever();
+        expectTypeOf(this.channels).toBeNever();
+        return Promise.resolve();
+    }
+}
+
+@SelectMenuRoute(SelectMenuKind.Channel, ProbeId)
+class ChannelProbe extends SelectMenuHandler<SelectMenuKind.Channel, [typeof ProbeId]> {
+    execute(): Promise<void> {
+        expectTypeOf(this.channels).toEqualTypeOf<ChannelSelectMenuInteraction<'cached'>['channels']>();
+        expectTypeOf(this.users).toBeNever();
+        return Promise.resolve();
+    }
+}
+
+export type Probes = [StringProbe, UserProbe, ChannelProbe];

--- a/packages/gateway/tests/handlers/select-resolved.types-test.ts
+++ b/packages/gateway/tests/handlers/select-resolved.types-test.ts
@@ -3,7 +3,11 @@ import { expectTypeOf } from 'vitest';
 
 import { SelectMenuHandler } from '#handlers/interaction/components';
 
-import type { ChannelSelectMenuInteraction, UserSelectMenuInteraction } from 'discord.js';
+import type {
+    ChannelSelectMenuInteraction,
+    MentionableSelectMenuInteraction,
+    UserSelectMenuInteraction
+} from 'discord.js';
 
 const ProbeId = new CustomId('selectprobe').str('x');
 
@@ -38,4 +42,23 @@ class ChannelProbe extends SelectMenuHandler<SelectMenuKind.Channel, [typeof Pro
     }
 }
 
-export type Probes = [StringProbe, UserProbe, ChannelProbe];
+@SelectMenuRoute(SelectMenuKind.Mentionable, ProbeId)
+class MentionableProbe extends SelectMenuHandler<SelectMenuKind.Mentionable, [typeof ProbeId]> {
+    execute(): Promise<void> {
+        expectTypeOf(this.users).toEqualTypeOf<MentionableSelectMenuInteraction<'cached'>['users']>();
+        expectTypeOf(this.roles).toEqualTypeOf<MentionableSelectMenuInteraction<'cached'>['roles']>();
+        expectTypeOf(this.channels).toBeNever();
+        return Promise.resolve();
+    }
+}
+
+// a union kind carries only what every arm of it resolves, the same as http
+class UnionProbe extends SelectMenuHandler<SelectMenuKind.String | SelectMenuKind.User, [typeof ProbeId]> {
+    execute(): Promise<void> {
+        expectTypeOf(this.users).toBeNever();
+        expectTypeOf(this.members).toBeNever();
+        return Promise.resolve();
+    }
+}
+
+export type Probes = [StringProbe, UserProbe, ChannelProbe, MentionableProbe, UnionProbe];

--- a/packages/http/src/edge.index.ts
+++ b/packages/http/src/edge.index.ts
@@ -11,6 +11,9 @@ export type { HttpConfig, HttpEdgeConfig, HttpServerConfig } from '#interfaces/C
 
 export type { SlashOptions } from '#inputs/SlashOptions';
 
+export { ModalFields } from '#inputs/ModalFields';
+export type { SelectedMentionables } from '#inputs/ModalFields';
+
 export { Emojis } from '#src/emojis/EmojiInjector';
 export type { InjectedEmojiMap } from '#src/emojis/EmojiInjector';
 

--- a/packages/http/src/handlers/interaction/components/ModalHandler.ts
+++ b/packages/http/src/handlers/interaction/components/ModalHandler.ts
@@ -60,7 +60,7 @@ export abstract class ModalHandler<Defs extends readonly AnyCustomId[]> extends 
         return super.deferUpdate();
     }
 
-    // discord omits the message when a command opened the modal, so update and deferUpdate have no target
+    // discord omits the message when a command opened the modal
     private ensureSourceMessage(method: string): void {
         if (this.event.message) return;
         throw new SeedcordError(SeedcordErrorCode.ReplyUpdateWithoutSource, [method, this.routeId]);

--- a/packages/http/src/handlers/interaction/components/ModalHandler.ts
+++ b/packages/http/src/handlers/interaction/components/ModalHandler.ts
@@ -2,6 +2,8 @@ import { ComponentKindBrand } from '@seedcord/core/internal';
 import { SeedcordErrorCode } from '@seedcord/errors';
 import { SeedcordError } from '@seedcord/errors/internal';
 
+import { ModalFields } from '#inputs/ModalFields';
+
 import { ComponentHandler } from './ComponentHandler';
 
 import type { SentMessage } from '#reply/ReplySender';
@@ -13,10 +15,22 @@ import type { APIModalSubmitInteraction } from 'discord-api-types/v10';
  * Base class for a modal submit handler on the HTTP transport.
  *
  * Register the customId definitions this handler decodes with `@ModalRoute` and list the same ones in the
- * generic. Read the submitted inputs off `this.event.data.components`. Reply through the handler members.
- * Discord forbids opening a modal in response to a modal, so `showModal` fails compilation on this kind.
+ * generic. Read the submitted inputs from `this.fields`. Reply through the handler members. `showModal`
+ * fails compilation on this kind, because Discord forbids opening a modal in response to a modal.
  *
  * @typeParam Defs - The customId definitions this handler decodes, e.g. `[typeof ConfigId]`.
+ *
+ * @example
+ * ```ts
+ * \@ModalRoute(ConfigId)
+ * class ConfigModal extends ModalHandler<[typeof ConfigId]> {
+ *     async execute() {
+ *         const { guildId } = this.params;
+ *         const name = this.fields.getTextInputValue('name');
+ *         await this.reply(`saved ${name} for ${guildId}`);
+ *     }
+ * }
+ * ```
  */
 export abstract class ModalHandler<Defs extends readonly AnyCustomId[]> extends ComponentHandler<
     APIModalSubmitInteraction,
@@ -25,6 +39,14 @@ export abstract class ModalHandler<Defs extends readonly AnyCustomId[]> extends 
     // phantom, never set at runtime.
     /** @internal */
     declare readonly [ComponentKindBrand]?: 'modal';
+
+    private reader?: ModalFields;
+
+    /** The fields this modal submitted, read by custom id. */
+    protected get fields(): ModalFields {
+        this.reader ??= new ModalFields(this.event.data);
+        return this.reader;
+    }
 
     /** Rewrite the message this modal was opened from. Throws when a command opened the modal. */
     protected override update(response: ReplyResponse | string): Promise<SentMessage> {

--- a/packages/http/src/handlers/interaction/components/SelectMenuHandler.ts
+++ b/packages/http/src/handlers/interaction/components/SelectMenuHandler.ts
@@ -23,7 +23,8 @@ import type {
 type UserKinds = SelectMenuKind.User | SelectMenuKind.Mentionable;
 type RoleKinds = SelectMenuKind.Role | SelectMenuKind.Mentionable;
 
-type ResolvedFor<Kind extends SelectMenuKind, Allowed extends SelectMenuKind, Value> = Kind extends Allowed
+// use tuple form so mixed kinds don't resolve to empty maps
+type ResolvedFor<Kind extends SelectMenuKind, Allowed extends SelectMenuKind, Value> = [Kind] extends [Allowed]
     ? Map<string, Value>
     : never;
 

--- a/packages/http/src/handlers/interaction/components/SelectMenuHandler.ts
+++ b/packages/http/src/handlers/interaction/components/SelectMenuHandler.ts
@@ -85,7 +85,8 @@ export abstract class SelectMenuHandler<
 
     /** The ids this select picked. */
     protected get values(): string[] {
-        return this.selection.values;
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- discord.js defaults this key to an empty array
+        return this.selection.values ?? [];
     }
 
     /** The users this select picked. */

--- a/packages/http/src/handlers/interaction/components/SelectMenuHandler.ts
+++ b/packages/http/src/handlers/interaction/components/SelectMenuHandler.ts
@@ -1,17 +1,31 @@
 import { ComponentKindBrand } from '@seedcord/core/internal';
 
+import { pick } from '#inputs/pick';
+
 import { ComponentHandler } from './ComponentHandler';
 
 import type { SelectMenuKind } from '@seedcord/core';
 import type { AnyCustomId } from '@seedcord/core/internal';
 import type {
+    APIInteractionDataResolved,
+    APIInteractionDataResolvedChannel,
+    APIInteractionDataResolvedGuildMember,
     APIMessageChannelSelectInteractionData,
     APIMessageComponentSelectMenuInteraction,
     APIMessageMentionableSelectInteractionData,
     APIMessageRoleSelectInteractionData,
     APIMessageStringSelectInteractionData,
-    APIMessageUserSelectInteractionData
+    APIMessageUserSelectInteractionData,
+    APIRole,
+    APIUser
 } from 'discord-api-types/v10';
+
+type UserKinds = SelectMenuKind.User | SelectMenuKind.Mentionable;
+type RoleKinds = SelectMenuKind.Role | SelectMenuKind.Mentionable;
+
+type ResolvedFor<Kind extends SelectMenuKind, Allowed extends SelectMenuKind, Value> = Kind extends Allowed
+    ? Map<string, Value>
+    : never;
 
 type SelectMenuInteractionFor<Kind extends SelectMenuKind> = APIMessageComponentSelectMenuInteraction & {
     data: Kind extends SelectMenuKind.String
@@ -30,13 +44,26 @@ type SelectMenuInteractionFor<Kind extends SelectMenuKind> = APIMessageComponent
 /**
  * Base class for a select menu handler on the HTTP transport.
  *
- * Pass the select kind first and the customId definitions second, the same order as `@SelectMenuRoute`,
- * so `this.event.data` and its `values`/`resolved` are narrowed to that kind. Read `this.params` for a
- * single route or `this.match` for several, and reply through the handler members or rewrite the source
- * message with `this.update`.
+ * Pass the select kind first and the customId definitions second, the same order as `@SelectMenuRoute`.
+ * Read the picked ids from `this.values`. The kind decides which of `this.users`, `this.members`,
+ * `this.roles`, and `this.channels` this handler carries. The rest are `never`.
+ *
+ * Read `this.params` for a single route or `this.match` for several. Reply through the handler members, or
+ * rewrite the source message with `this.update`.
  *
  * @typeParam Kind - The select kind from {@link SelectMenuKind}, e.g. `SelectMenuKind.User`.
  * @typeParam Defs - The customId definitions this handler decodes, e.g. `[typeof AssignId]`.
+ *
+ * @example
+ * ```ts
+ * \@SelectMenuRoute(SelectMenuKind.User, AssignId)
+ * class AssignSelect extends SelectMenuHandler<SelectMenuKind.User, [typeof AssignId]> {
+ *     async execute() {
+ *         const { roleId } = this.params;
+ *         await this.reply(`assigning ${this.users.size} member(s) to <@&${roleId}>`);
+ *     }
+ * }
+ * ```
  */
 export abstract class SelectMenuHandler<
     Kind extends SelectMenuKind,
@@ -45,4 +72,38 @@ export abstract class SelectMenuHandler<
     // phantom, never set at runtime.
     /** @internal */
     declare readonly [ComponentKindBrand]?: Kind;
+
+    private get selection(): { values: string[]; resolved?: APIInteractionDataResolved } {
+        return this.event.data;
+    }
+
+    // Out is never on a kind whose payload carries no such bucket
+    private resolvedMap<Value, Out>(bucket: Record<string, Value> | undefined): Out {
+        return pick(this.selection.values, bucket) as Out;
+    }
+
+    /** The ids this select picked. */
+    protected get values(): string[] {
+        return this.selection.values;
+    }
+
+    /** The users this select picked. */
+    protected get users(): ResolvedFor<Kind, UserKinds, APIUser> {
+        return this.resolvedMap(this.selection.resolved?.users);
+    }
+
+    /** The guild members behind the picked users. Discord resolves these only inside a guild. */
+    protected get members(): ResolvedFor<Kind, UserKinds, APIInteractionDataResolvedGuildMember> {
+        return this.resolvedMap(this.selection.resolved?.members);
+    }
+
+    /** The roles this select picked. */
+    protected get roles(): ResolvedFor<Kind, RoleKinds, APIRole> {
+        return this.resolvedMap(this.selection.resolved?.roles);
+    }
+
+    /** The channels this select picked. */
+    protected get channels(): ResolvedFor<Kind, SelectMenuKind.Channel, APIInteractionDataResolvedChannel> {
+        return this.resolvedMap(this.selection.resolved?.channels);
+    }
 }

--- a/packages/http/src/inputs/ModalFields.ts
+++ b/packages/http/src/inputs/ModalFields.ts
@@ -123,6 +123,8 @@ export class ModalFields {
         return listOf(this.field(customId, [ComponentType.StringSelect]).values);
     }
 
+    getSelectedUsers(customId: string, required: true): Map<string, APIUser>;
+    getSelectedUsers(customId: string, required?: boolean): Map<string, APIUser> | null;
     getSelectedUsers(customId: string, required = false): Map<string, APIUser> | null {
         const kinds = [ComponentType.UserSelect, ComponentType.MentionableSelect] as const;
         return this.selected(customId, kinds, this.resolved?.users, required);
@@ -134,12 +136,24 @@ export class ModalFields {
         return this.selected(customId, kinds, this.resolved?.members, false);
     }
 
+    getSelectedRoles(customId: string, required: true): Map<string, APIRole>;
+    getSelectedRoles(customId: string, required?: boolean): Map<string, APIRole> | null;
     getSelectedRoles(customId: string, required = false): Map<string, APIRole> | null {
         const kinds = [ComponentType.RoleSelect, ComponentType.MentionableSelect] as const;
         return this.selected(customId, kinds, this.resolved?.roles, required);
     }
 
     /** Pass `channelTypes` to throw when a pick falls outside those types. */
+    getSelectedChannels(
+        customId: string,
+        required: true,
+        channelTypes?: readonly ChannelType[]
+    ): Map<string, APIInteractionDataResolvedChannel>;
+    getSelectedChannels(
+        customId: string,
+        required?: boolean,
+        channelTypes?: readonly ChannelType[]
+    ): Map<string, APIInteractionDataResolvedChannel> | null;
     getSelectedChannels(
         customId: string,
         required = false,
@@ -160,6 +174,8 @@ export class ModalFields {
         return picked;
     }
 
+    getSelectedMentionables(customId: string, required: true): SelectedMentionables;
+    getSelectedMentionables(customId: string, required?: boolean): SelectedMentionables | null;
     getSelectedMentionables(customId: string, required = false): SelectedMentionables | null {
         const { values } = this.field(customId, [ComponentType.MentionableSelect]);
         const resolved = this.resolved;
@@ -173,11 +189,15 @@ export class ModalFields {
         return null;
     }
 
+    getUploadedFiles(customId: string, required: true): Map<string, APIAttachment>;
+    getUploadedFiles(customId: string, required?: boolean): Map<string, APIAttachment> | null;
     getUploadedFiles(customId: string, required = false): Map<string, APIAttachment> | null {
         const kinds = [ComponentType.FileUpload] as const;
         return this.selected(customId, kinds, this.resolved?.attachments, required);
     }
 
+    getRadioGroup(customId: string, required: true): string;
+    getRadioGroup(customId: string, required?: boolean): string | null;
     getRadioGroup(customId: string, required = false): string | null {
         // discord.js guards this key against an absent value
         const value = this.field(customId, [ComponentType.RadioGroup]).value ?? null;

--- a/packages/http/src/inputs/ModalFields.ts
+++ b/packages/http/src/inputs/ModalFields.ts
@@ -18,7 +18,12 @@ import type {
 type FieldKind = ModalSubmitComponent['type'];
 type KindWithValues = Extract<ModalSubmitComponent, { values: string[] }>['type'];
 
-const FIELD_KINDS: Record<FieldKind, { label: string; getter: string }> = {
+interface KindLabel {
+    label: string;
+    getter: string;
+}
+
+const FIELD_KINDS: Record<FieldKind, KindLabel> = {
     [ComponentType.TextInput]: { label: 'a text input', getter: 'getTextInputValue' },
     [ComponentType.StringSelect]: { label: 'a string select', getter: 'getStringSelectValues' },
     [ComponentType.UserSelect]: { label: 'a user select', getter: 'getSelectedUsers' },
@@ -30,6 +35,11 @@ const FIELD_KINDS: Record<FieldKind, { label: string; getter: string }> = {
     [ComponentType.CheckboxGroup]: { label: 'a checkbox group', getter: 'getCheckboxGroup' },
     [ComponentType.Checkbox]: { label: 'a checkbox', getter: 'getCheckbox' }
 };
+
+function nameOfChannelType(type: ChannelType): string {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- ChannelType doesn't have a member for a type discord adds later
+    return ChannelType[type] ?? String(type);
+}
 
 function isKind<Kind extends FieldKind>(
     entry: ModalSubmitComponent,
@@ -60,7 +70,8 @@ export class ModalFields {
 
     constructor(data: APIModalSubmission) {
         this.resolved = data.resolved;
-        for (const component of data.components) {
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- the wire can omit components even though the typing requires it
+        for (const component of data.components ?? []) {
             // discord nests each field under an action row or a label
             if ('components' in component) {
                 for (const child of component.components) this.entries.set(child.custom_id, child);
@@ -76,8 +87,12 @@ export class ModalFields {
         const entry = this.entries.get(customId);
         if (!entry) throw new SeedcordTypeError(SeedcordErrorCode.ModalFieldNotFound, [customId]);
         if (!isKind(entry, kinds)) {
-            const { label, getter } = FIELD_KINDS[entry.type];
-            throw new SeedcordTypeError(SeedcordErrorCode.ModalFieldWrongKind, [customId, label, getter]);
+            // a modal can carry a component type newer than this enum
+            const known = (FIELD_KINDS as Partial<Record<ComponentType, KindLabel>>)[entry.type];
+            const args = known
+                ? ([customId, known.label, known.getter] as const)
+                : ([customId, `component type ${entry.type}`] as const);
+            throw new SeedcordTypeError(SeedcordErrorCode.ModalFieldWrongKind, [...args]);
         }
         return entry;
     }
@@ -130,10 +145,10 @@ export class ModalFields {
         if (!picked || channelTypes.length === 0) return picked;
         for (const found of picked.values()) {
             if (channelTypes.includes(found.type)) continue;
-            const allowed = channelTypes.map((type) => ChannelType[type]).join(', ');
+            const allowed = channelTypes.map(nameOfChannelType).join(', ');
             throw new SeedcordTypeError(SeedcordErrorCode.ModalFieldChannelType, [
                 customId,
-                ChannelType[found.type],
+                nameOfChannelType(found.type),
                 allowed
             ]);
         }
@@ -159,7 +174,8 @@ export class ModalFields {
     }
 
     getRadioGroup(customId: string, required = false): string | null {
-        const { value } = this.field(customId, [ComponentType.RadioGroup]);
+        // discord.js guards this key against an absent value
+        const value = this.field(customId, [ComponentType.RadioGroup]).value ?? null;
         if (value !== null) return value;
         if (required) throw new SeedcordTypeError(SeedcordErrorCode.ModalFieldEmpty, [customId]);
         return null;

--- a/packages/http/src/inputs/ModalFields.ts
+++ b/packages/http/src/inputs/ModalFields.ts
@@ -1,0 +1,175 @@
+import { SeedcordErrorCode } from '@seedcord/errors';
+import { SeedcordTypeError } from '@seedcord/errors/internal';
+import { ChannelType, ComponentType } from 'discord-api-types/v10';
+
+import { pick } from '#inputs/pick';
+
+import type {
+    APIAttachment,
+    APIInteractionDataResolved,
+    APIInteractionDataResolvedChannel,
+    APIInteractionDataResolvedGuildMember,
+    APIModalSubmission,
+    APIRole,
+    APIUser,
+    ModalSubmitComponent
+} from 'discord-api-types/v10';
+
+type FieldKind = ModalSubmitComponent['type'];
+type KindWithValues = Extract<ModalSubmitComponent, { values: string[] }>['type'];
+
+const FIELD_KINDS: Record<FieldKind, { label: string; getter: string }> = {
+    [ComponentType.TextInput]: { label: 'a text input', getter: 'getTextInputValue' },
+    [ComponentType.StringSelect]: { label: 'a string select', getter: 'getStringSelectValues' },
+    [ComponentType.UserSelect]: { label: 'a user select', getter: 'getSelectedUsers' },
+    [ComponentType.RoleSelect]: { label: 'a role select', getter: 'getSelectedRoles' },
+    [ComponentType.MentionableSelect]: { label: 'a mentionable select', getter: 'getSelectedMentionables' },
+    [ComponentType.ChannelSelect]: { label: 'a channel select', getter: 'getSelectedChannels' },
+    [ComponentType.FileUpload]: { label: 'a file upload', getter: 'getUploadedFiles' },
+    [ComponentType.RadioGroup]: { label: 'a radio group', getter: 'getRadioGroup' },
+    [ComponentType.CheckboxGroup]: { label: 'a checkbox group', getter: 'getCheckboxGroup' },
+    [ComponentType.Checkbox]: { label: 'a checkbox', getter: 'getCheckbox' }
+};
+
+function isKind<Kind extends FieldKind>(
+    entry: ModalSubmitComponent,
+    kinds: readonly Kind[]
+): entry is Extract<ModalSubmitComponent, { type: Kind }> {
+    return (kinds as readonly FieldKind[]).includes(entry.type);
+}
+
+/** The users, members, and roles a mentionable select picked. */
+export interface SelectedMentionables {
+    users: Map<string, APIUser>;
+    members: Map<string, APIInteractionDataResolvedGuildMember>;
+    roles: Map<string, APIRole>;
+}
+
+/**
+ * The fields a modal carries, read by custom id.
+ *
+ * Every getter throws when no field in the modal has that custom id. It also throws when the field holds a
+ * kind that getter does not read. The message names the getter that does.
+ *
+ * A select getter resolves the ids its field picked against the interaction's `resolved` data and returns a
+ * `Map` keyed by id. A field that picked nothing returns null. Pass `required` to throw there instead.
+ */
+export class ModalFields {
+    private readonly entries = new Map<string, ModalSubmitComponent>();
+    private readonly resolved: APIInteractionDataResolved | undefined;
+
+    constructor(data: APIModalSubmission) {
+        this.resolved = data.resolved;
+        for (const component of data.components) {
+            // discord nests each field under an action row or a label
+            if ('components' in component) {
+                for (const child of component.components) this.entries.set(child.custom_id, child);
+            }
+            if ('component' in component) this.entries.set(component.component.custom_id, component.component);
+        }
+    }
+
+    private field<Kind extends FieldKind>(
+        customId: string,
+        kinds: readonly Kind[]
+    ): Extract<ModalSubmitComponent, { type: Kind }> {
+        const entry = this.entries.get(customId);
+        if (!entry) throw new SeedcordTypeError(SeedcordErrorCode.ModalFieldNotFound, [customId]);
+        if (!isKind(entry, kinds)) {
+            const { label, getter } = FIELD_KINDS[entry.type];
+            throw new SeedcordTypeError(SeedcordErrorCode.ModalFieldWrongKind, [customId, label, getter]);
+        }
+        return entry;
+    }
+
+    private selected<Value>(
+        customId: string,
+        kinds: readonly KindWithValues[],
+        bucket: Record<string, Value> | undefined,
+        required: boolean
+    ): Map<string, Value> | null {
+        const { values } = this.field(customId, kinds);
+        const found = pick(values, bucket);
+        if (found.size > 0) return found;
+        if (required) throw new SeedcordTypeError(SeedcordErrorCode.ModalFieldEmpty, [customId]);
+        return null;
+    }
+
+    getTextInputValue(customId: string): string {
+        return this.field(customId, [ComponentType.TextInput]).value;
+    }
+
+    getStringSelectValues(customId: string): string[] {
+        return this.field(customId, [ComponentType.StringSelect]).values;
+    }
+
+    getSelectedUsers(customId: string, required = false): Map<string, APIUser> | null {
+        const kinds = [ComponentType.UserSelect, ComponentType.MentionableSelect] as const;
+        return this.selected(customId, kinds, this.resolved?.users, required);
+    }
+
+    /** The guild members behind the picked users. Discord resolves these only inside a guild. */
+    getSelectedMembers(customId: string): Map<string, APIInteractionDataResolvedGuildMember> | null {
+        const kinds = [ComponentType.UserSelect, ComponentType.MentionableSelect] as const;
+        return this.selected(customId, kinds, this.resolved?.members, false);
+    }
+
+    getSelectedRoles(customId: string, required = false): Map<string, APIRole> | null {
+        const kinds = [ComponentType.RoleSelect, ComponentType.MentionableSelect] as const;
+        return this.selected(customId, kinds, this.resolved?.roles, required);
+    }
+
+    /** Pass `channelTypes` to throw when a pick falls outside those types. */
+    getSelectedChannels(
+        customId: string,
+        required = false,
+        channelTypes: readonly ChannelType[] = []
+    ): Map<string, APIInteractionDataResolvedChannel> | null {
+        const kinds = [ComponentType.ChannelSelect] as const;
+        const picked = this.selected(customId, kinds, this.resolved?.channels, required);
+        if (!picked || channelTypes.length === 0) return picked;
+        for (const found of picked.values()) {
+            if (channelTypes.includes(found.type)) continue;
+            const allowed = channelTypes.map((type) => ChannelType[type]).join(', ');
+            throw new SeedcordTypeError(SeedcordErrorCode.ModalFieldChannelType, [
+                customId,
+                ChannelType[found.type],
+                allowed
+            ]);
+        }
+        return picked;
+    }
+
+    getSelectedMentionables(customId: string, required = false): SelectedMentionables | null {
+        const { values } = this.field(customId, [ComponentType.MentionableSelect]);
+        const resolved = this.resolved;
+        const picked: SelectedMentionables = {
+            users: pick(values, resolved?.users),
+            members: pick(values, resolved?.members),
+            roles: pick(values, resolved?.roles)
+        };
+        if (picked.users.size + picked.members.size + picked.roles.size > 0) return picked;
+        if (required) throw new SeedcordTypeError(SeedcordErrorCode.ModalFieldEmpty, [customId]);
+        return null;
+    }
+
+    getUploadedFiles(customId: string, required = false): Map<string, APIAttachment> | null {
+        const kinds = [ComponentType.FileUpload] as const;
+        return this.selected(customId, kinds, this.resolved?.attachments, required);
+    }
+
+    getRadioGroup(customId: string, required = false): string | null {
+        const { value } = this.field(customId, [ComponentType.RadioGroup]);
+        if (value !== null) return value;
+        if (required) throw new SeedcordTypeError(SeedcordErrorCode.ModalFieldEmpty, [customId]);
+        return null;
+    }
+
+    getCheckboxGroup(customId: string): string[] {
+        return this.field(customId, [ComponentType.CheckboxGroup]).values;
+    }
+
+    getCheckbox(customId: string): boolean {
+        return this.field(customId, [ComponentType.Checkbox]).value;
+    }
+}

--- a/packages/http/src/inputs/ModalFields.ts
+++ b/packages/http/src/inputs/ModalFields.ts
@@ -41,6 +41,11 @@ function nameOfChannelType(type: ChannelType): string {
     return ChannelType[type] ?? String(type);
 }
 
+function listOf(values: string[]): string[] {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- discord.js guards this key on every select kind
+    return values ?? [];
+}
+
 function isKind<Kind extends FieldKind>(
     entry: ModalSubmitComponent,
     kinds: readonly Kind[]
@@ -115,7 +120,7 @@ export class ModalFields {
     }
 
     getStringSelectValues(customId: string): string[] {
-        return this.field(customId, [ComponentType.StringSelect]).values;
+        return listOf(this.field(customId, [ComponentType.StringSelect]).values);
     }
 
     getSelectedUsers(customId: string, required = false): Map<string, APIUser> | null {
@@ -182,7 +187,7 @@ export class ModalFields {
     }
 
     getCheckboxGroup(customId: string): string[] {
-        return this.field(customId, [ComponentType.CheckboxGroup]).values;
+        return listOf(this.field(customId, [ComponentType.CheckboxGroup]).values);
     }
 
     getCheckbox(customId: string): boolean {

--- a/packages/http/src/inputs/pick.ts
+++ b/packages/http/src/inputs/pick.ts
@@ -1,6 +1,10 @@
-export function pick<Value>(ids: readonly string[], bucket: Record<string, Value> | undefined): Map<string, Value> {
+// discord.js guards the values key on every select kind
+export function pick<Value>(
+    ids: readonly string[] | undefined,
+    bucket: Record<string, Value> | undefined
+): Map<string, Value> {
     const found = new Map<string, Value>();
-    if (!bucket) return found;
+    if (!ids || !bucket) return found;
     for (const id of ids) if (Object.hasOwn(bucket, id)) found.set(id, bucket[id] as Value);
     return found;
 }

--- a/packages/http/src/inputs/pick.ts
+++ b/packages/http/src/inputs/pick.ts
@@ -1,0 +1,11 @@
+export function pick<Value>(
+    ids: readonly string[],
+    bucket: Record<string, Value> | undefined
+): Map<string, Value> {
+    const found = new Map<string, Value>();
+    for (const id of ids) {
+        const value = bucket?.[id];
+        if (value !== undefined) found.set(id, value);
+    }
+    return found;
+}

--- a/packages/http/src/inputs/pick.ts
+++ b/packages/http/src/inputs/pick.ts
@@ -1,11 +1,6 @@
-export function pick<Value>(
-    ids: readonly string[],
-    bucket: Record<string, Value> | undefined
-): Map<string, Value> {
+export function pick<Value>(ids: readonly string[], bucket: Record<string, Value> | undefined): Map<string, Value> {
     const found = new Map<string, Value>();
-    for (const id of ids) {
-        const value = bucket?.[id];
-        if (value !== undefined) found.set(id, value);
-    }
+    if (!bucket) return found;
+    for (const id of ids) if (Object.hasOwn(bucket, id)) found.set(id, bucket[id] as Value);
     return found;
 }

--- a/packages/http/tests/inputs/modal-fields-workerd.test.ts
+++ b/packages/http/tests/inputs/modal-fields-workerd.test.ts
@@ -1,0 +1,36 @@
+import { ComponentType } from 'discord-api-types/v10';
+import { describe, expect, it } from 'vitest';
+
+import { ModalFields } from '#inputs/ModalFields';
+
+import type { APIUser } from 'discord-api-types/v10';
+
+const ada: APIUser = { id: 'u1', username: 'ada', discriminator: '0', global_name: 'ada', avatar: null };
+
+// the pool's cjs interop can resolve discord-api-types enums to undefined at import time
+describe('modal fields on workerd', () => {
+    const fields = new ModalFields({
+        custom_id: 'form',
+        resolved: { users: { u1: ada } },
+        components: [
+            {
+                type: ComponentType.Label,
+                id: 1,
+                component: { type: ComponentType.TextInput, id: 2, custom_id: 'name', value: 'seedcord' }
+            },
+            {
+                type: ComponentType.Label,
+                id: 3,
+                component: { type: ComponentType.UserSelect, id: 4, custom_id: 'owners', values: ['u1'] }
+            }
+        ]
+    });
+
+    it('reads a text input', () => {
+        expect(fields.getTextInputValue('name')).toBe('seedcord');
+    });
+
+    it('resolves a user select against the payload', () => {
+        expect(fields.getSelectedUsers('owners')).toEqual(new Map([['u1', ada]]));
+    });
+});

--- a/packages/http/tests/node/handlers/modal-fields.test.ts
+++ b/packages/http/tests/node/handlers/modal-fields.test.ts
@@ -1,0 +1,71 @@
+import { CustomId } from '@seedcord/core';
+import { ComponentType } from 'discord-api-types/v10';
+import { describe, expect, it } from 'vitest';
+
+import { ModalHandler } from '#handlers/interaction/components/ModalHandler';
+import { ModalFields } from '#inputs/ModalFields';
+import { ModalRoute } from '#src/index';
+
+import type { Core } from '#interfaces/Core';
+import type { APIModalSubmitInteraction } from 'discord-api-types/v10';
+
+const ConfigId = new CustomId('config').str('guildId');
+
+// justified: reading the fields never reaches core
+const core = {} as unknown as Core;
+
+function modalEvent(customId: string): APIModalSubmitInteraction {
+    return {
+        application_id: 'app-1',
+        id: 'int-1',
+        token: 'tok',
+        type: 5,
+        data: {
+            custom_id: customId,
+            components: [
+                {
+                    type: ComponentType.Label,
+                    id: 1,
+                    component: { type: ComponentType.TextInput, id: 2, custom_id: 'name', value: 'seedcord' }
+                }
+            ]
+        }
+    } as unknown as APIModalSubmitInteraction;
+}
+
+describe('modal fields on the http handler', () => {
+    it('reads a submitted input through this.fields', async () => {
+        let seen = '';
+
+        @ModalRoute(ConfigId)
+        class ConfigModal extends ModalHandler<[typeof ConfigId]> {
+            async execute(): Promise<void> {
+                seen = this.fields.getTextInputValue('name');
+                await Promise.resolve();
+            }
+        }
+
+        await new ConfigModal(modalEvent(ConfigId.encode({ guildId: 'g1' })), core).execute();
+
+        expect(seen).toBe('seedcord');
+    });
+
+    it('builds the reader once and reuses it', async () => {
+        let first: unknown;
+        let second: unknown;
+
+        @ModalRoute(ConfigId)
+        class ConfigModal extends ModalHandler<[typeof ConfigId]> {
+            execute(): Promise<void> {
+                first = this.fields;
+                second = this.fields;
+                return Promise.resolve();
+            }
+        }
+
+        await new ConfigModal(modalEvent(ConfigId.encode({ guildId: 'g1' })), core).execute();
+
+        expect(first).toBeInstanceOf(ModalFields);
+        expect(first).toBe(second);
+    });
+});

--- a/packages/http/tests/node/handlers/select-resolved.test.ts
+++ b/packages/http/tests/node/handlers/select-resolved.test.ts
@@ -70,6 +70,31 @@ describe('picked ids', () => {
     });
 });
 
+describe('a payload carrying no values key', () => {
+    it('reads as an empty pick, the same as gateway', async () => {
+        let values: unknown;
+        let users: unknown;
+
+        @SelectMenuRoute(SelectMenuKind.User, AssignId)
+        class Assign extends SelectMenuHandler<SelectMenuKind.User, [typeof AssignId]> {
+            async execute(): Promise<void> {
+                values = this.values;
+                users = this.users;
+                await Promise.resolve();
+            }
+        }
+
+        const event = selectEvent<UserSelectEvent>(AssignId.encode({ roleId: 'r1' }), {
+            component_type: 5,
+            resolved: { users: { u1: ada } }
+        });
+        await new Assign(event, core).execute();
+
+        expect(values).toEqual([]);
+        expect(users).toEqual(new Map());
+    });
+});
+
 describe('user select', () => {
     it('resolves the picked users and members', async () => {
         let users: unknown;

--- a/packages/http/tests/node/handlers/select-resolved.test.ts
+++ b/packages/http/tests/node/handlers/select-resolved.test.ts
@@ -1,0 +1,194 @@
+import { CustomId, SelectMenuKind } from '@seedcord/core';
+import { describe, expect, it } from 'vitest';
+
+import { SelectMenuHandler } from '#handlers/interaction/components/SelectMenuHandler';
+import { SelectMenuRoute } from '#src/index';
+
+import type { Core } from '#interfaces/Core';
+import type {
+    APIInteractionDataResolvedChannel,
+    APIInteractionDataResolvedGuildMember,
+    APIMessageChannelSelectInteractionData,
+    APIMessageComponentSelectMenuInteraction,
+    APIMessageMentionableSelectInteractionData,
+    APIMessageRoleSelectInteractionData,
+    APIMessageStringSelectInteractionData,
+    APIMessageUserSelectInteractionData,
+    APIRole,
+    APIUser
+} from 'discord-api-types/v10';
+
+const AssignId = new CustomId('assign').str('roleId');
+
+// justified: reading resolved data never reaches core
+const core = {} as unknown as Core;
+
+const ada: APIUser = { id: 'u1', username: 'ada', discriminator: '0', global_name: 'ada', avatar: null };
+
+// justified: each fixture carries only the fields the assertions read
+const boss = { nick: 'boss', roles: [], permissions: '0' } as unknown as APIInteractionDataResolvedGuildMember;
+const mods = { id: 'r1', name: 'mods' } as unknown as APIRole;
+const general = { id: 'c1', name: 'general', type: 0, permissions: '0' } as APIInteractionDataResolvedChannel;
+
+type SelectEvent<Data> = APIMessageComponentSelectMenuInteraction & { data: Data };
+type StringSelectEvent = SelectEvent<APIMessageStringSelectInteractionData>;
+type UserSelectEvent = SelectEvent<APIMessageUserSelectInteractionData>;
+type RoleSelectEvent = SelectEvent<APIMessageRoleSelectInteractionData>;
+type ChannelSelectEvent = SelectEvent<APIMessageChannelSelectInteractionData>;
+type MentionableSelectEvent = SelectEvent<APIMessageMentionableSelectInteractionData>;
+
+// justified: the bases touch data alone on this event
+function selectEvent<Event extends APIMessageComponentSelectMenuInteraction>(
+    customId: string,
+    data: object
+): Event {
+    return {
+        application_id: 'app-1',
+        id: 'int-1',
+        token: 'tok',
+        type: 3,
+        data: { custom_id: customId, ...data }
+    } as unknown as Event;
+}
+
+describe('picked ids', () => {
+    it('reads the raw values off any kind', async () => {
+        let values: unknown;
+
+        @SelectMenuRoute(SelectMenuKind.String, AssignId)
+        class Assign extends SelectMenuHandler<SelectMenuKind.String, [typeof AssignId]> {
+            async execute(): Promise<void> {
+                values = this.values;
+                await Promise.resolve();
+            }
+        }
+
+        const event = selectEvent<StringSelectEvent>(AssignId.encode({ roleId: 'r1' }), {
+            component_type: 3,
+            values: ['red', 'blue']
+        });
+        await new Assign(event, core).execute();
+
+        expect(values).toEqual(['red', 'blue']);
+    });
+});
+
+describe('user select', () => {
+    it('resolves the picked users and members', async () => {
+        let users: unknown;
+        let members: unknown;
+
+        @SelectMenuRoute(SelectMenuKind.User, AssignId)
+        class Assign extends SelectMenuHandler<SelectMenuKind.User, [typeof AssignId]> {
+            async execute(): Promise<void> {
+                users = this.users;
+                members = this.members;
+                await Promise.resolve();
+            }
+        }
+
+        const event = selectEvent<UserSelectEvent>(AssignId.encode({ roleId: 'r1' }), {
+            component_type: 5,
+            values: ['u1'],
+            resolved: { users: { u1: ada }, members: { u1: boss } }
+        });
+        await new Assign(event, core).execute();
+
+        expect(users).toEqual(new Map([['u1', ada]]));
+        expect(members).toEqual(new Map([['u1', boss]]));
+    });
+
+    it('returns an empty map when the guild resolved no member', async () => {
+        let members: unknown;
+
+        @SelectMenuRoute(SelectMenuKind.User, AssignId)
+        class Assign extends SelectMenuHandler<SelectMenuKind.User, [typeof AssignId]> {
+            async execute(): Promise<void> {
+                members = this.members;
+                await Promise.resolve();
+            }
+        }
+
+        const event = selectEvent<UserSelectEvent>(AssignId.encode({ roleId: 'r1' }), {
+            component_type: 5,
+            values: ['u1'],
+            resolved: { users: { u1: ada } }
+        });
+        await new Assign(event, core).execute();
+
+        expect(members).toEqual(new Map());
+    });
+});
+
+describe('role and channel selects', () => {
+    it('resolves the picked roles', async () => {
+        let roles: unknown;
+
+        @SelectMenuRoute(SelectMenuKind.Role, AssignId)
+        class Assign extends SelectMenuHandler<SelectMenuKind.Role, [typeof AssignId]> {
+            async execute(): Promise<void> {
+                roles = this.roles;
+                await Promise.resolve();
+            }
+        }
+
+        const event = selectEvent<RoleSelectEvent>(AssignId.encode({ roleId: 'r1' }), {
+            component_type: 6,
+            values: ['r1'],
+            resolved: { roles: { r1: mods } }
+        });
+        await new Assign(event, core).execute();
+
+        expect(roles).toEqual(new Map([['r1', mods]]));
+    });
+
+    it('resolves the picked channels', async () => {
+        let channels: unknown;
+
+        @SelectMenuRoute(SelectMenuKind.Channel, AssignId)
+        class Assign extends SelectMenuHandler<SelectMenuKind.Channel, [typeof AssignId]> {
+            async execute(): Promise<void> {
+                channels = this.channels;
+                await Promise.resolve();
+            }
+        }
+
+        const event = selectEvent<ChannelSelectEvent>(AssignId.encode({ roleId: 'r1' }), {
+            component_type: 8,
+            values: ['c1'],
+            resolved: { channels: { c1: general } }
+        });
+        await new Assign(event, core).execute();
+
+        expect(channels).toEqual(new Map([['c1', general]]));
+    });
+});
+
+describe('mentionable select', () => {
+    it('splits one field into its users, members, and roles', async () => {
+        let users: unknown;
+        let members: unknown;
+        let roles: unknown;
+
+        @SelectMenuRoute(SelectMenuKind.Mentionable, AssignId)
+        class Assign extends SelectMenuHandler<SelectMenuKind.Mentionable, [typeof AssignId]> {
+            async execute(): Promise<void> {
+                users = this.users;
+                members = this.members;
+                roles = this.roles;
+                await Promise.resolve();
+            }
+        }
+
+        const event = selectEvent<MentionableSelectEvent>(AssignId.encode({ roleId: 'r1' }), {
+            component_type: 7,
+            values: ['u1', 'r1'],
+            resolved: { users: { u1: ada }, members: { u1: boss }, roles: { r1: mods } }
+        });
+        await new Assign(event, core).execute();
+
+        expect(users).toEqual(new Map([['u1', ada]]));
+        expect(members).toEqual(new Map([['u1', boss]]));
+        expect(roles).toEqual(new Map([['r1', mods]]));
+    });
+});

--- a/packages/http/tests/node/handlers/select-resolved.test.ts
+++ b/packages/http/tests/node/handlers/select-resolved.test.ts
@@ -38,10 +38,7 @@ type ChannelSelectEvent = SelectEvent<APIMessageChannelSelectInteractionData>;
 type MentionableSelectEvent = SelectEvent<APIMessageMentionableSelectInteractionData>;
 
 // justified: the bases touch data alone on this event
-function selectEvent<Event extends APIMessageComponentSelectMenuInteraction>(
-    customId: string,
-    data: object
-): Event {
+function selectEvent<Event extends APIMessageComponentSelectMenuInteraction>(customId: string, data: object): Event {
     return {
         application_id: 'app-1',
         id: 'int-1',

--- a/packages/http/tests/node/handlers/select-resolved.types-test.ts
+++ b/packages/http/tests/node/handlers/select-resolved.types-test.ts
@@ -1,0 +1,57 @@
+import { CustomId, SelectMenuKind } from '@seedcord/core';
+import { expectTypeOf } from 'vitest';
+
+import { SelectMenuHandler } from '#handlers/interaction/components/SelectMenuHandler';
+import { SelectMenuRoute } from '#src/index';
+
+import type {
+    APIInteractionDataResolvedChannel,
+    APIInteractionDataResolvedGuildMember,
+    APIRole,
+    APIUser
+} from 'discord-api-types/v10';
+
+const ProbeId = new CustomId('selectprobe').str('x');
+
+@SelectMenuRoute(SelectMenuKind.String, ProbeId)
+class StringProbe extends SelectMenuHandler<SelectMenuKind.String, [typeof ProbeId]> {
+    execute(): Promise<void> {
+        expectTypeOf(this.users).toBeNever();
+        expectTypeOf(this.members).toBeNever();
+        expectTypeOf(this.roles).toBeNever();
+        expectTypeOf(this.channels).toBeNever();
+        return Promise.resolve();
+    }
+}
+
+@SelectMenuRoute(SelectMenuKind.User, ProbeId)
+class UserProbe extends SelectMenuHandler<SelectMenuKind.User, [typeof ProbeId]> {
+    execute(): Promise<void> {
+        expectTypeOf(this.users).toEqualTypeOf<Map<string, APIUser>>();
+        expectTypeOf(this.members).toEqualTypeOf<Map<string, APIInteractionDataResolvedGuildMember>>();
+        expectTypeOf(this.roles).toBeNever();
+        expectTypeOf(this.channels).toBeNever();
+        return Promise.resolve();
+    }
+}
+
+@SelectMenuRoute(SelectMenuKind.Channel, ProbeId)
+class ChannelProbe extends SelectMenuHandler<SelectMenuKind.Channel, [typeof ProbeId]> {
+    execute(): Promise<void> {
+        expectTypeOf(this.channels).toEqualTypeOf<Map<string, APIInteractionDataResolvedChannel>>();
+        expectTypeOf(this.users).toBeNever();
+        return Promise.resolve();
+    }
+}
+
+@SelectMenuRoute(SelectMenuKind.Mentionable, ProbeId)
+class MentionableProbe extends SelectMenuHandler<SelectMenuKind.Mentionable, [typeof ProbeId]> {
+    execute(): Promise<void> {
+        expectTypeOf(this.users).toEqualTypeOf<Map<string, APIUser>>();
+        expectTypeOf(this.roles).toEqualTypeOf<Map<string, APIRole>>();
+        expectTypeOf(this.channels).toBeNever();
+        return Promise.resolve();
+    }
+}
+
+export type Probes = [StringProbe, UserProbe, ChannelProbe, MentionableProbe];

--- a/packages/http/tests/node/handlers/select-resolved.types-test.ts
+++ b/packages/http/tests/node/handlers/select-resolved.types-test.ts
@@ -54,4 +54,13 @@ class MentionableProbe extends SelectMenuHandler<SelectMenuKind.Mentionable, [ty
     }
 }
 
-export type Probes = [StringProbe, UserProbe, ChannelProbe, MentionableProbe];
+// a union kind carries only what every arm of it resolves, the same as gateway
+class UnionProbe extends SelectMenuHandler<SelectMenuKind.String | SelectMenuKind.User, [typeof ProbeId]> {
+    execute(): Promise<void> {
+        expectTypeOf(this.users).toBeNever();
+        expectTypeOf(this.members).toBeNever();
+        return Promise.resolve();
+    }
+}
+
+export type Probes = [StringProbe, UserProbe, ChannelProbe, MentionableProbe, UnionProbe];

--- a/packages/http/tests/node/inputs/ModalFields.test.ts
+++ b/packages/http/tests/node/inputs/ModalFields.test.ts
@@ -1,0 +1,354 @@
+import { isSeedcordError, SeedcordErrorCode } from '@seedcord/errors';
+import { ChannelType, ComponentType } from 'discord-api-types/v10';
+import { describe, expect, it } from 'vitest';
+
+import { ModalFields } from '#inputs/ModalFields';
+
+import type {
+    APIAttachment,
+    APIInteractionDataResolvedChannel,
+    APIInteractionDataResolvedGuildMember,
+    APIModalSubmission,
+    APIModalSubmissionComponent,
+    APIRole,
+    APIUser,
+    ModalSubmitComponent
+} from 'discord-api-types/v10';
+
+function submission(components: APIModalSubmissionComponent[]): APIModalSubmission {
+    return { custom_id: 'form', components };
+}
+
+function labelled(id: number, component: ModalSubmitComponent): APIModalSubmissionComponent {
+    return { type: ComponentType.Label, id, component };
+}
+
+function user(id: string, username: string): APIUser {
+    return { id, username, discriminator: '0', global_name: username, avatar: null };
+}
+
+// justified: each fixture carries only the fields the assertions read
+function member(nick: string): APIInteractionDataResolvedGuildMember {
+    return { nick, roles: [], permissions: '0' } as unknown as APIInteractionDataResolvedGuildMember;
+}
+
+function role(id: string, name: string): APIRole {
+    return { id, name } as unknown as APIRole;
+}
+
+function channel(id: string, type: ChannelType): APIInteractionDataResolvedChannel {
+    return { id, name: id, type, permissions: '0' };
+}
+
+function attachment(id: string, filename: string): APIAttachment {
+    return { id, filename } as unknown as APIAttachment;
+}
+
+function codeFrom(fn: () => unknown): SeedcordErrorCode {
+    try {
+        fn();
+    } catch (error) {
+        if (isSeedcordError(error)) return error.code;
+        throw error;
+    }
+    throw new Error('expected a throw');
+}
+
+describe('text inputs', () => {
+    const fields = new ModalFields(
+        submission([
+            {
+                type: ComponentType.ActionRow,
+                id: 1,
+                components: [{ type: ComponentType.TextInput, id: 2, custom_id: 'name', value: 'dhruv' }]
+            },
+            {
+                type: ComponentType.Label,
+                id: 3,
+                component: { type: ComponentType.TextInput, id: 4, custom_id: 'bio', value: 'writes bots' }
+            }
+        ])
+    );
+
+    it('reads a value out of an action row', () => {
+        expect(fields.getTextInputValue('name')).toBe('dhruv');
+    });
+
+    it('reads a value out of a label', () => {
+        expect(fields.getTextInputValue('bio')).toBe('writes bots');
+    });
+
+    it('throws when the modal carries no field with that custom id', () => {
+        expect(codeFrom(() => fields.getTextInputValue('nope'))).toBe(SeedcordErrorCode.ModalFieldNotFound);
+    });
+});
+
+describe('kind mismatch', () => {
+    const fields = new ModalFields(
+        submission([
+            {
+                type: ComponentType.Label,
+                id: 1,
+                component: { type: ComponentType.Checkbox, id: 2, custom_id: 'agree', value: true }
+            }
+        ])
+    );
+
+    it('throws when the field holds another kind', () => {
+        expect(codeFrom(() => fields.getTextInputValue('agree'))).toBe(SeedcordErrorCode.ModalFieldWrongKind);
+    });
+
+    it('names the getter reading the kind the field holds', () => {
+        let message = '';
+        try {
+            fields.getTextInputValue('agree');
+        } catch (error) {
+            message = (error as Error).message;
+        }
+        expect(message).toContain('getCheckbox');
+    });
+});
+
+describe('string select', () => {
+    const fields = new ModalFields(
+        submission([
+            {
+                type: ComponentType.Label,
+                id: 1,
+                component: {
+                    type: ComponentType.StringSelect,
+                    id: 2,
+                    custom_id: 'colors',
+                    values: ['red', 'blue']
+                }
+            }
+        ])
+    );
+
+    it('returns every picked value', () => {
+        expect(fields.getStringSelectValues('colors')).toEqual(['red', 'blue']);
+    });
+
+    it('returns an empty list when nothing was picked', () => {
+        const empty = new ModalFields(
+            submission([
+                {
+                    type: ComponentType.Label,
+                    id: 1,
+                    component: { type: ComponentType.StringSelect, id: 2, custom_id: 'colors', values: [] }
+                }
+            ])
+        );
+        expect(empty.getStringSelectValues('colors')).toEqual([]);
+    });
+});
+
+describe('user select', () => {
+    const ada = user('u1', 'ada');
+    const grace = user('u2', 'grace');
+    const linus = user('u3', 'linus');
+
+    const fields = new ModalFields({
+        custom_id: 'form',
+        resolved: { users: { u1: ada, u2: grace, u3: linus } },
+        components: [
+            labelled(1, { type: ComponentType.UserSelect, id: 2, custom_id: 'owners', values: ['u1', 'u3'] }),
+            labelled(3, { type: ComponentType.UserSelect, id: 4, custom_id: 'reviewers', values: ['u2'] })
+        ]
+    });
+
+    it('resolves the ids the field picked', () => {
+        expect(fields.getSelectedUsers('owners')).toEqual(
+            new Map([
+                ['u1', ada],
+                ['u3', linus]
+            ])
+        );
+    });
+
+    it('keeps two fields in one modal apart', () => {
+        expect(fields.getSelectedUsers('reviewers')).toEqual(new Map([['u2', grace]]));
+    });
+});
+
+describe('an empty pick beside a filled one', () => {
+    const ada = user('u1', 'ada');
+    const fields = new ModalFields({
+        custom_id: 'form',
+        resolved: { users: { u1: ada } },
+        components: [
+            labelled(1, { type: ComponentType.UserSelect, id: 2, custom_id: 'owners', values: ['u1'] }),
+            labelled(3, { type: ComponentType.UserSelect, id: 4, custom_id: 'reviewers', values: [] })
+        ]
+    });
+
+    it('returns null', () => {
+        expect(fields.getSelectedUsers('reviewers')).toBeNull();
+    });
+
+    it('throws when the read asked for a selection', () => {
+        expect(codeFrom(() => fields.getSelectedUsers('reviewers', true))).toBe(SeedcordErrorCode.ModalFieldEmpty);
+    });
+});
+
+describe('mentionable select', () => {
+    const ada = user('u1', 'ada');
+    const boss = member('boss');
+    const mods = role('r1', 'mods');
+
+    const fields = new ModalFields({
+        custom_id: 'form',
+        resolved: { users: { u1: ada }, members: { u1: boss }, roles: { r1: mods } },
+        components: [
+            labelled(1, {
+                type: ComponentType.MentionableSelect,
+                id: 2,
+                custom_id: 'targets',
+                values: ['u1', 'r1']
+            })
+        ]
+    });
+
+    it('splits one field into its users, members, and roles', () => {
+        expect(fields.getSelectedUsers('targets')).toEqual(new Map([['u1', ada]]));
+        expect(fields.getSelectedMembers('targets')).toEqual(new Map([['u1', boss]]));
+        expect(fields.getSelectedRoles('targets')).toEqual(new Map([['r1', mods]]));
+    });
+
+    it('groups the picks into users, members, and roles', () => {
+        expect(fields.getSelectedMentionables('targets')).toEqual({
+            users: new Map([['u1', ada]]),
+            members: new Map([['u1', boss]]),
+            roles: new Map([['r1', mods]])
+        });
+    });
+
+    it('returns null for a bucket the payload left out', () => {
+        const rolesOnly = new ModalFields({
+            custom_id: 'form',
+            resolved: { roles: { r1: mods } },
+            components: [
+                labelled(1, {
+                    type: ComponentType.MentionableSelect,
+                    id: 2,
+                    custom_id: 'targets',
+                    values: ['r1']
+                })
+            ]
+        });
+        expect(rolesOnly.getSelectedMembers('targets')).toBeNull();
+    });
+
+    it('throws when a required role read finds nothing', () => {
+        const empty = new ModalFields({
+            custom_id: 'form',
+            components: [
+                labelled(1, { type: ComponentType.RoleSelect, id: 2, custom_id: 'ping', values: [] })
+            ]
+        });
+        expect(codeFrom(() => empty.getSelectedRoles('ping', true))).toBe(SeedcordErrorCode.ModalFieldEmpty);
+    });
+
+    it('returns null for a mentionable field that picked nothing', () => {
+        const empty = new ModalFields({
+            custom_id: 'form',
+            components: [
+                labelled(1, { type: ComponentType.MentionableSelect, id: 2, custom_id: 'targets', values: [] })
+            ]
+        });
+        expect(empty.getSelectedMentionables('targets')).toBeNull();
+        expect(codeFrom(() => empty.getSelectedMentionables('targets', true))).toBe(
+            SeedcordErrorCode.ModalFieldEmpty
+        );
+    });
+});
+
+describe('channel select', () => {
+    const general = channel('c1', ChannelType.GuildText);
+    const lounge = channel('c2', ChannelType.GuildVoice);
+
+    const fields = new ModalFields({
+        custom_id: 'form',
+        resolved: { channels: { c1: general, c2: lounge } },
+        components: [
+            labelled(1, { type: ComponentType.ChannelSelect, id: 2, custom_id: 'where', values: ['c1', 'c2'] })
+        ]
+    });
+
+    it('resolves every picked channel', () => {
+        expect(fields.getSelectedChannels('where')).toEqual(
+            new Map([
+                ['c1', general],
+                ['c2', lounge]
+            ])
+        );
+    });
+
+    it('throws when a pick falls outside the allowed types', () => {
+        expect(codeFrom(() => fields.getSelectedChannels('where', false, [ChannelType.GuildText]))).toBe(
+            SeedcordErrorCode.ModalFieldChannelType
+        );
+    });
+
+    it('names the type that failed', () => {
+        let message = '';
+        try {
+            fields.getSelectedChannels('where', false, [ChannelType.GuildText]);
+        } catch (error) {
+            message = (error as Error).message;
+        }
+        expect(message).toContain('GuildVoice');
+    });
+});
+
+describe('file upload', () => {
+    const shot = attachment('a1', 'screenshot.png');
+
+    const fields = new ModalFields({
+        custom_id: 'form',
+        resolved: { attachments: { a1: shot } },
+        components: [labelled(1, { type: ComponentType.FileUpload, id: 2, custom_id: 'proof', values: ['a1'] })]
+    });
+
+    it('resolves the uploaded attachments', () => {
+        expect(fields.getUploadedFiles('proof')).toEqual(new Map([['a1', shot]]));
+    });
+
+    it('throws when a required read finds no upload', () => {
+        const empty = new ModalFields({
+            custom_id: 'form',
+            components: [labelled(1, { type: ComponentType.FileUpload, id: 2, custom_id: 'proof', values: [] })]
+        });
+        expect(codeFrom(() => empty.getUploadedFiles('proof', true))).toBe(SeedcordErrorCode.ModalFieldEmpty);
+    });
+});
+
+describe('radio groups and checkboxes', () => {
+    const fields = new ModalFields(
+        submission([
+            labelled(1, { type: ComponentType.RadioGroup, id: 2, custom_id: 'plan', value: 'pro' }),
+            labelled(3, { type: ComponentType.CheckboxGroup, id: 4, custom_id: 'extras', values: ['sso'] }),
+            labelled(5, { type: ComponentType.Checkbox, id: 6, custom_id: 'agree', value: false })
+        ])
+    );
+
+    it('reads the picked radio option', () => {
+        expect(fields.getRadioGroup('plan')).toBe('pro');
+    });
+
+    it('reads the checked boxes of a group', () => {
+        expect(fields.getCheckboxGroup('extras')).toEqual(['sso']);
+    });
+
+    it('keeps an unchecked box false', () => {
+        expect(fields.getCheckbox('agree')).toBe(false);
+    });
+
+    it('throws when a required radio read finds nothing picked', () => {
+        const empty = new ModalFields(
+            submission([labelled(1, { type: ComponentType.RadioGroup, id: 2, custom_id: 'plan', value: null })])
+        );
+        expect(empty.getRadioGroup('plan')).toBeNull();
+        expect(codeFrom(() => empty.getRadioGroup('plan', true))).toBe(SeedcordErrorCode.ModalFieldEmpty);
+    });
+});

--- a/packages/http/tests/node/inputs/ModalFields.test.ts
+++ b/packages/http/tests/node/inputs/ModalFields.test.ts
@@ -286,6 +286,14 @@ describe('channel select', () => {
         );
     });
 
+    it('throws when a required channel read finds nothing picked', () => {
+        const empty = new ModalFields(
+            submission([labelled(1, { type: ComponentType.ChannelSelect, id: 2, custom_id: 'where', values: [] })])
+        );
+        expect(empty.getSelectedChannels('where')).toBeNull();
+        expect(codeFrom(() => empty.getSelectedChannels('where', true))).toBe(SeedcordErrorCode.ModalFieldEmpty);
+    });
+
     it('names the type that failed', () => {
         let message = '';
         try {
@@ -365,6 +373,15 @@ describe('payloads the pinned types forbid', () => {
         const fields = new ModalFields(submission([labelled(1, future)]));
 
         expect(codeFrom(() => fields.getTextInputValue('weird'))).toBe(SeedcordErrorCode.ModalFieldWrongKind);
+
+        let message = '';
+        try {
+            fields.getTextInputValue('weird');
+        } catch (error) {
+            message = (error as Error).message;
+        }
+        expect(message).toContain('component type 99');
+        expect(message).toContain('No getter reads that kind');
     });
 
     it('names a channel type the pinned enum does not carry', () => {
@@ -391,6 +408,51 @@ describe('payloads the pinned types forbid', () => {
         const fields = new ModalFields(bare);
 
         expect(codeFrom(() => fields.getTextInputValue('name'))).toBe(SeedcordErrorCode.ModalFieldNotFound);
+    });
+
+    it('reads a select field that carries no values key', () => {
+        // justified: discord.js guards this key on every select kind
+        const bare = { type: ComponentType.UserSelect, id: 2, custom_id: 'owners' } as unknown as ModalSubmitComponent;
+        const fields = new ModalFields({
+            custom_id: 'form',
+            resolved: { users: { u1: user('u1', 'ada') } },
+            components: [labelled(1, bare)]
+        });
+
+        expect(fields.getSelectedUsers('owners')).toBeNull();
+        expect(codeFrom(() => fields.getSelectedUsers('owners', true))).toBe(SeedcordErrorCode.ModalFieldEmpty);
+    });
+
+    it('reads a mentionable field that carries no values key', () => {
+        const bare = {
+            type: ComponentType.MentionableSelect,
+            id: 2,
+            custom_id: 'targets'
+        } as unknown as ModalSubmitComponent;
+        const fields = new ModalFields({
+            custom_id: 'form',
+            resolved: { users: { u1: user('u1', 'ada') }, roles: { r1: role('r1', 'mods') } },
+            components: [labelled(1, bare)]
+        });
+
+        expect(fields.getSelectedMentionables('targets')).toBeNull();
+    });
+
+    it('returns an empty list for a string select carrying no values key', () => {
+        const bare = {
+            type: ComponentType.StringSelect,
+            id: 2,
+            custom_id: 'colors'
+        } as unknown as ModalSubmitComponent;
+        const group = {
+            type: ComponentType.CheckboxGroup,
+            id: 4,
+            custom_id: 'extras'
+        } as unknown as ModalSubmitComponent;
+        const fields = new ModalFields(submission([labelled(1, bare), labelled(3, group)]));
+
+        expect(fields.getStringSelectValues('colors')).toEqual([]);
+        expect(fields.getCheckboxGroup('extras')).toEqual([]);
     });
 
     it('ignores ids that name an Object prototype member', () => {

--- a/packages/http/tests/node/inputs/ModalFields.test.ts
+++ b/packages/http/tests/node/inputs/ModalFields.test.ts
@@ -242,9 +242,7 @@ describe('mentionable select', () => {
     it('throws when a required role read finds nothing', () => {
         const empty = new ModalFields({
             custom_id: 'form',
-            components: [
-                labelled(1, { type: ComponentType.RoleSelect, id: 2, custom_id: 'ping', values: [] })
-            ]
+            components: [labelled(1, { type: ComponentType.RoleSelect, id: 2, custom_id: 'ping', values: [] })]
         });
         expect(codeFrom(() => empty.getSelectedRoles('ping', true))).toBe(SeedcordErrorCode.ModalFieldEmpty);
     });
@@ -257,9 +255,7 @@ describe('mentionable select', () => {
             ]
         });
         expect(empty.getSelectedMentionables('targets')).toBeNull();
-        expect(codeFrom(() => empty.getSelectedMentionables('targets', true))).toBe(
-            SeedcordErrorCode.ModalFieldEmpty
-        );
+        expect(codeFrom(() => empty.getSelectedMentionables('targets', true))).toBe(SeedcordErrorCode.ModalFieldEmpty);
     });
 });
 
@@ -350,5 +346,67 @@ describe('radio groups and checkboxes', () => {
         );
         expect(empty.getRadioGroup('plan')).toBeNull();
         expect(codeFrom(() => empty.getRadioGroup('plan', true))).toBe(SeedcordErrorCode.ModalFieldEmpty);
+    });
+
+    it('treats an absent radio value the same as a null one', () => {
+        // justified: discord.js guards this key against an absent value
+        const bare = { type: ComponentType.RadioGroup, id: 2, custom_id: 'plan' } as unknown as ModalSubmitComponent;
+        const empty = new ModalFields(submission([labelled(1, bare)]));
+
+        expect(empty.getRadioGroup('plan')).toBeNull();
+        expect(codeFrom(() => empty.getRadioGroup('plan', true))).toBe(SeedcordErrorCode.ModalFieldEmpty);
+    });
+});
+
+describe('payloads the pinned types forbid', () => {
+    it('reports a component kind newer than the pinned discord-api-types', () => {
+        // justified: no arm of the union covers an unknown type
+        const future = { type: 99, id: 2, custom_id: 'weird', value: 'z' } as unknown as ModalSubmitComponent;
+        const fields = new ModalFields(submission([labelled(1, future)]));
+
+        expect(codeFrom(() => fields.getTextInputValue('weird'))).toBe(SeedcordErrorCode.ModalFieldWrongKind);
+    });
+
+    it('names a channel type the pinned enum does not carry', () => {
+        const odd = channel('c1', 999 as ChannelType);
+        const fields = new ModalFields({
+            custom_id: 'form',
+            resolved: { channels: { c1: odd } },
+            components: [labelled(1, { type: ComponentType.ChannelSelect, id: 2, custom_id: 'where', values: ['c1'] })]
+        });
+
+        let message = '';
+        try {
+            fields.getSelectedChannels('where', false, [ChannelType.GuildText]);
+        } catch (error) {
+            message = (error as Error).message;
+        }
+        expect(message).not.toContain('undefined');
+        expect(message).toContain('999');
+    });
+
+    it('reads an empty modal when the payload carries no components', () => {
+        // justified: the test omits a key the typing marks required
+        const bare = { custom_id: 'form' } as unknown as APIModalSubmission;
+        const fields = new ModalFields(bare);
+
+        expect(codeFrom(() => fields.getTextInputValue('name'))).toBe(SeedcordErrorCode.ModalFieldNotFound);
+    });
+
+    it('ignores ids that name an Object prototype member', () => {
+        const fields = new ModalFields({
+            custom_id: 'form',
+            resolved: { users: {} },
+            components: [
+                labelled(1, {
+                    type: ComponentType.UserSelect,
+                    id: 2,
+                    custom_id: 'owners',
+                    values: ['constructor', 'toString']
+                })
+            ]
+        });
+
+        expect(fields.getSelectedUsers('owners')).toBeNull();
     });
 });

--- a/packages/http/tests/node/inputs/ModalFields.types-test.ts
+++ b/packages/http/tests/node/inputs/ModalFields.types-test.ts
@@ -1,0 +1,39 @@
+import { ComponentType } from 'discord-api-types/v10';
+import { expectTypeOf } from 'vitest';
+
+import { ModalFields } from '#inputs/ModalFields';
+
+import type { SelectedMentionables } from '#inputs/ModalFields';
+import type { APIAttachment, APIInteractionDataResolvedChannel, APIRole, APIUser } from 'discord-api-types/v10';
+
+const fields = new ModalFields({
+    custom_id: 'form',
+    components: [
+        {
+            type: ComponentType.Label,
+            id: 1,
+            component: { type: ComponentType.UserSelect, id: 2, custom_id: 'owners', values: [] }
+        }
+    ]
+});
+
+expectTypeOf(fields.getSelectedUsers('owners', true)).toEqualTypeOf<Map<string, APIUser>>();
+expectTypeOf(fields.getSelectedUsers('owners')).toEqualTypeOf<Map<string, APIUser> | null>();
+expectTypeOf(fields.getSelectedUsers('owners', false)).toEqualTypeOf<Map<string, APIUser> | null>();
+
+expectTypeOf(fields.getSelectedRoles('r', true)).toEqualTypeOf<Map<string, APIRole>>();
+expectTypeOf(fields.getSelectedRoles('r')).toEqualTypeOf<Map<string, APIRole> | null>();
+
+expectTypeOf(fields.getSelectedChannels('c', true)).toEqualTypeOf<Map<string, APIInteractionDataResolvedChannel>>();
+expectTypeOf(fields.getSelectedChannels('c')).toEqualTypeOf<Map<string, APIInteractionDataResolvedChannel> | null>();
+
+expectTypeOf(fields.getUploadedFiles('f', true)).toEqualTypeOf<Map<string, APIAttachment>>();
+expectTypeOf(fields.getUploadedFiles('f')).toEqualTypeOf<Map<string, APIAttachment> | null>();
+
+expectTypeOf(fields.getSelectedMentionables('m', true)).toEqualTypeOf<SelectedMentionables>();
+expectTypeOf(fields.getSelectedMentionables('m')).toEqualTypeOf<SelectedMentionables | null>();
+
+expectTypeOf(fields.getRadioGroup('p', true)).toEqualTypeOf<string>();
+expectTypeOf(fields.getRadioGroup('p')).toEqualTypeOf<string | null>();
+
+expectTypeOf(fields.getSelectedMembers('owners')).toBeNullable();


### PR DESCRIPTION
## Checklist

- [x] Tests cover the change
- [x] `pnpm prePush` is green
- [x] Changeset added with `pnpm cs`, for any change to a published package


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent modal input access through `this.fields`, including text inputs, selects, uploads, radio groups, and checkboxes.
  * Added typed select-menu accessors for selected values, users, members, roles, and channels.
  * Added resolved selection data across supported interaction transports.
  * Exported modal field types for HTTP edge applications.

* **Bug Fixes**
  * Standardized component input handling between gateway and HTTP transports.
  * Added clearer validation for missing, invalid, empty, and unsupported modal fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->