### PR TITLE
feat: pagination custom id improvements

### DIFF
--- a/.changeset/custom-id-nullable-fields.md
+++ b/.changeset/custom-id-nullable-fields.md
@@ -1,0 +1,5 @@
+---
+'@seedcord/core': minor
+---
+
+Every `CustomId` field now also takes `{ nullable: true }` and decodes to `T | null`, at one extra slot on the wire. Marking a live field nullable will change its layout hash as well.

--- a/.changeset/paginator-page-and-start-page.md
+++ b/.changeset/paginator-page-and-start-page.md
@@ -4,6 +4,6 @@
 '@seedcord/core': minor
 ---
 
-`start(handler, n)` opens a paginator on any page, and `page(handler, n)` renders one without sending it.
+`start(handler, n)` opens a paginator on any page. `page(handler, n)` renders one without sending it. A source you write yourself takes the new `PageSource<Item>` each transport exports.
 
 **BREAKING:** `Paginator.page` takes the handler in place of a page context, matching `start`. `PaginatorBase.page` is now `protected buildPage`.

--- a/.changeset/paginator-page-and-start-page.md
+++ b/.changeset/paginator-page-and-start-page.md
@@ -1,0 +1,9 @@
+---
+'@seedcord/gateway': minor
+'@seedcord/http': minor
+'@seedcord/core': minor
+---
+
+`start(handler, n)` opens a paginator on any page, and `page(handler, n)` renders one without sending it.
+
+**BREAKING:** `Paginator.page` takes the handler in place of a page context, matching `start`. `PaginatorBase.page` is now `protected buildPage`.

--- a/.changeset/paginator-page-and-start-page.md
+++ b/.changeset/paginator-page-and-start-page.md
@@ -4,6 +4,6 @@
 '@seedcord/core': minor
 ---
 
-`start(handler, n)` opens a paginator on any page. `page(handler, n)` renders one without sending it. A source you write yourself takes the new `PageSource<Item>` each transport exports.
+`start(handler, n)` opens a paginator on any page, and `page(handler, n)` renders one without sending it. A source you write yourself takes `PageSource<Item>`, which each transport exports with its page context already bound.
 
-**BREAKING:** `Paginator.page` takes the handler in place of a page context, matching `start`. `PaginatorBase.page` is now `protected buildPage`.
+**BREAKING:** `Paginator.page` now takes the handler. `PaginatorBase.page` is `protected buildPage`, and core's three source symbols gained a `Base` suffix so the plain names belong to the transports.

--- a/packages/core/src/customId/CustomId.ts
+++ b/packages/core/src/customId/CustomId.ts
@@ -101,7 +101,7 @@ export class CustomId<Prefix extends string, Shape extends CustomIdShape = {}> {
         name: Name,
         opts?: FieldOptions<Nullable>
     ): CustomId<Prefix, Shape & Record<Name, CustomIdField<Nullish<Snowflake, Nullable>>>> {
-        return this.add<Name, Nullish<Snowflake, Nullable>>(name, { kind: 'snowflake', ...opts });
+        return this.add<Name, Nullish<Snowflake, Nullable>>(name, { ...opts, kind: 'snowflake' });
     }
 
     /**
@@ -116,7 +116,7 @@ export class CustomId<Prefix extends string, Shape extends CustomIdShape = {}> {
         name: Name,
         opts?: FieldOptions<Nullable>
     ): CustomId<Prefix, Shape & Record<Name, CustomIdField<Nullish<string, Nullable>>>> {
-        return this.add<Name, Nullish<string, Nullable>>(name, { kind: 'uuid', ...opts });
+        return this.add<Name, Nullish<string, Nullable>>(name, { ...opts, kind: 'uuid' });
     }
 
     /**
@@ -157,7 +157,7 @@ export class CustomId<Prefix extends string, Shape extends CustomIdShape = {}> {
         }
         const options = typeof minOrOpts === 'number' ? opts : minOrOpts;
         const bounds = min === undefined || max === undefined ? {} : { min, max };
-        return this.add<Name, Nullish<number, Nullable>>(name, { kind: 'int', ...bounds, ...options });
+        return this.add<Name, Nullish<number, Nullable>>(name, { ...options, kind: 'int', ...bounds });
     }
 
     /**
@@ -172,7 +172,7 @@ export class CustomId<Prefix extends string, Shape extends CustomIdShape = {}> {
         name: Name,
         opts?: FieldOptions<Nullable>
     ): CustomId<Prefix, Shape & Record<Name, CustomIdField<Nullish<boolean, Nullable>>>> {
-        return this.add<Name, Nullish<boolean, Nullable>>(name, { kind: 'bool', ...opts });
+        return this.add<Name, Nullish<boolean, Nullable>>(name, { ...opts, kind: 'bool' });
     }
 
     /**
@@ -189,7 +189,7 @@ export class CustomId<Prefix extends string, Shape extends CustomIdShape = {}> {
         opts?: FieldOptions<Nullable>
     ): CustomId<Prefix, Shape & Record<Name, CustomIdField<Nullish<Choices[number], Nullable>>>> {
         if (choices.length === 0) throw new SeedcordError(SeedcordErrorCode.CustomIdEmptyChoices, [name]);
-        return this.add<Name, Nullish<Choices[number], Nullable>>(name, { kind: 'oneOf', choices, ...opts });
+        return this.add<Name, Nullish<Choices[number], Nullable>>(name, { ...opts, kind: 'oneOf', choices });
     }
 
     /**
@@ -205,7 +205,7 @@ export class CustomId<Prefix extends string, Shape extends CustomIdShape = {}> {
         name: Name,
         opts?: FieldOptions<Nullable>
     ): CustomId<Prefix, Shape & Record<Name, CustomIdField<Nullish<string, Nullable>>>> {
-        return this.add<Name, Nullish<string, Nullable>>(name, { kind: 'string', ...opts });
+        return this.add<Name, Nullish<string, Nullable>>(name, { ...opts, kind: 'string' });
     }
 
     /**

--- a/packages/core/src/customId/CustomId.ts
+++ b/packages/core/src/customId/CustomId.ts
@@ -11,6 +11,18 @@ import type { NonEmptyTuple } from 'type-fest';
 // discord caps a customId at 100 chars.
 const MAX_WIRE_LENGTH = 100;
 
+/** Per-field options every {@link CustomId} chain method takes. */
+export interface FieldOptions<Nullable extends boolean = boolean> {
+    /**
+     * Whether the field also carries null. A nullable field costs one extra slot on the wire.
+     *
+     * @defaultValue `false`
+     */
+    nullable?: Nullable;
+}
+
+type Nullish<Decoded, Nullable extends boolean> = Nullable extends true ? Decoded | null : Decoded;
+
 function routeKeyOf(wire: string): string {
     const colon = wire.indexOf(':');
     return colon === -1 ? '' : wire.slice(0, colon);
@@ -85,8 +97,11 @@ export class CustomId<Prefix extends string, Shape extends CustomIdShape = {}> {
      * new CustomId('ban').snowflake('userId');
      * ```
      */
-    snowflake<Name extends string>(name: Name): CustomId<Prefix, Shape & Record<Name, CustomIdField<Snowflake>>> {
-        return this.add<Name, Snowflake>(name, { kind: 'snowflake' });
+    snowflake<Name extends string, const Nullable extends boolean = false>(
+        name: Name,
+        opts?: FieldOptions<Nullable>
+    ): CustomId<Prefix, Shape & Record<Name, CustomIdField<Nullish<Snowflake, Nullable>>>> {
+        return this.add<Name, Nullish<Snowflake, Nullable>>(name, { kind: 'snowflake', ...opts });
     }
 
     /**
@@ -97,8 +112,11 @@ export class CustomId<Prefix extends string, Shape extends CustomIdShape = {}> {
      * new CustomId('ticket').uuid('ticketId');
      * ```
      */
-    uuid<Name extends string>(name: Name): CustomId<Prefix, Shape & Record<Name, CustomIdField<string>>> {
-        return this.add<Name, string>(name, { kind: 'uuid' });
+    uuid<Name extends string, const Nullable extends boolean = false>(
+        name: Name,
+        opts?: FieldOptions<Nullable>
+    ): CustomId<Prefix, Shape & Record<Name, CustomIdField<Nullish<string, Nullable>>>> {
+        return this.add<Name, Nullish<string, Nullable>>(name, { kind: 'uuid', ...opts });
     }
 
     /**
@@ -109,7 +127,10 @@ export class CustomId<Prefix extends string, Shape extends CustomIdShape = {}> {
      * new CustomId('shop').int('amount');
      * ```
      */
-    int<Name extends string>(name: Name): CustomId<Prefix, Shape & Record<Name, CustomIdField<number>>>;
+    int<Name extends string, const Nullable extends boolean = false>(
+        name: Name,
+        opts?: FieldOptions<Nullable>
+    ): CustomId<Prefix, Shape & Record<Name, CustomIdField<Nullish<number, Nullable>>>>;
     /**
      * Add an integer field bounded by min and max, so it packs into fewer characters on the wire.
      *
@@ -118,22 +139,25 @@ export class CustomId<Prefix extends string, Shape extends CustomIdShape = {}> {
      * new CustomId('paginate').int('page', 1, 50);
      * ```
      */
-    int<Name extends string>(
+    int<Name extends string, const Nullable extends boolean = false>(
         name: Name,
         min: number,
-        max: number
-    ): CustomId<Prefix, Shape & Record<Name, CustomIdField<number>>>;
-    int<Name extends string>(
+        max: number,
+        opts?: FieldOptions<Nullable>
+    ): CustomId<Prefix, Shape & Record<Name, CustomIdField<Nullish<number, Nullable>>>>;
+    int<Name extends string, const Nullable extends boolean = false>(
         name: Name,
-        min?: number,
-        max?: number
-    ): CustomId<Prefix, Shape & Record<Name, CustomIdField<number>>> {
+        minOrOpts?: number | FieldOptions<Nullable>,
+        max?: number,
+        opts?: FieldOptions<Nullable>
+    ): CustomId<Prefix, Shape & Record<Name, CustomIdField<Nullish<number, Nullable>>>> {
+        const min = typeof minOrOpts === 'number' ? minOrOpts : undefined;
         if (min !== undefined && max !== undefined && min > max) {
             throw new SeedcordError(SeedcordErrorCode.CustomIdInvalidBounds, [name, min, max]);
         }
-        const field: CustomIdField<number> =
-            min === undefined || max === undefined ? { kind: 'int' } : { kind: 'int', min, max };
-        return this.add<Name, number>(name, field);
+        const options = typeof minOrOpts === 'number' ? opts : minOrOpts;
+        const bounds = min === undefined || max === undefined ? {} : { min, max };
+        return this.add<Name, Nullish<number, Nullable>>(name, { kind: 'int', ...bounds, ...options });
     }
 
     /**
@@ -144,8 +168,11 @@ export class CustomId<Prefix extends string, Shape extends CustomIdShape = {}> {
      * new CustomId('settings').bool('silent');
      * ```
      */
-    bool<Name extends string>(name: Name): CustomId<Prefix, Shape & Record<Name, CustomIdField<boolean>>> {
-        return this.add<Name, boolean>(name, { kind: 'bool' });
+    bool<Name extends string, const Nullable extends boolean = false>(
+        name: Name,
+        opts?: FieldOptions<Nullable>
+    ): CustomId<Prefix, Shape & Record<Name, CustomIdField<Nullish<boolean, Nullable>>>> {
+        return this.add<Name, Nullish<boolean, Nullable>>(name, { kind: 'bool', ...opts });
     }
 
     /**
@@ -156,12 +183,13 @@ export class CustomId<Prefix extends string, Shape extends CustomIdShape = {}> {
      * new CustomId('poll').oneOf('choice', ['yes', 'no', 'abstain']);
      * ```
      */
-    oneOf<Name extends string, const Choices extends NonEmptyTuple<string>>(
+    oneOf<Name extends string, const Choices extends NonEmptyTuple<string>, const Nullable extends boolean = false>(
         name: Name,
-        choices: Choices
-    ): CustomId<Prefix, Shape & Record<Name, CustomIdField<Choices[number]>>> {
+        choices: Choices,
+        opts?: FieldOptions<Nullable>
+    ): CustomId<Prefix, Shape & Record<Name, CustomIdField<Nullish<Choices[number], Nullable>>>> {
         if (choices.length === 0) throw new SeedcordError(SeedcordErrorCode.CustomIdEmptyChoices, [name]);
-        return this.add<Name, Choices[number]>(name, { kind: 'oneOf', choices });
+        return this.add<Name, Nullish<Choices[number], Nullable>>(name, { kind: 'oneOf', choices, ...opts });
     }
 
     /**
@@ -173,8 +201,11 @@ export class CustomId<Prefix extends string, Shape extends CustomIdShape = {}> {
      * new CustomId('note').str('message');
      * ```
      */
-    str<Name extends string>(name: Name): CustomId<Prefix, Shape & Record<Name, CustomIdField<string>>> {
-        return this.add<Name, string>(name, { kind: 'string' });
+    str<Name extends string, const Nullable extends boolean = false>(
+        name: Name,
+        opts?: FieldOptions<Nullable>
+    ): CustomId<Prefix, Shape & Record<Name, CustomIdField<Nullish<string, Nullable>>>> {
+        return this.add<Name, Nullish<string, Nullable>>(name, { kind: 'string', ...opts });
     }
 
     /**

--- a/packages/core/src/customId/Field.ts
+++ b/packages/core/src/customId/Field.ts
@@ -14,6 +14,8 @@ export interface CustomIdField<Decoded> {
     readonly max?: number;
     /** The allowed values, for a oneOf field. */
     readonly choices?: readonly string[];
+    /** Whether this field also carries null. */
+    readonly nullable?: boolean;
     /** Phantom only, carries the decoded type and is never set at runtime. */
     readonly decoded?: Decoded;
 }

--- a/packages/core/src/customId/codec.ts
+++ b/packages/core/src/customId/codec.ts
@@ -99,7 +99,12 @@ function isBounded(field: CustomIdField<unknown>): boolean {
     return field.kind === 'snowflake' || field.kind === 'uuid' || field.kind === 'bool' || field.kind === 'oneOf';
 }
 
+// slot 0 is the null on a nullable field. every other value shifts up one.
 function radixOf(field: CustomIdField<unknown>): bigint {
+    return kindRadix(field) + (field.nullable === true ? 1n : 0n);
+}
+
+function kindRadix(field: CustomIdField<unknown>): bigint {
     switch (field.kind) {
         case 'snowflake': {
             return 1n << 64n;
@@ -130,6 +135,10 @@ function radixOf(field: CustomIdField<unknown>): bigint {
 }
 
 function boundedToBigint(field: CustomIdField<unknown>, name: string, value: unknown): bigint {
+    if (field.nullable === true) {
+        if (value === null) return 0n;
+        return boundedToBigint({ ...field, nullable: false }, name, value) + 1n;
+    }
     const slot = boundedSlot(field, name, value);
     // out of range would carry into the neighbouring field on decode.
     if (slot < 0n || slot >= radixOf(field)) outOfRange(name, value);
@@ -175,6 +184,13 @@ function outOfRange(name: string, value: unknown): never {
 
 // inverse of boundedSlot.
 function bigintToBoundedValue(field: CustomIdField<unknown>, slot: bigint): unknown {
+    if (field.nullable === true) {
+        return slot === 0n ? null : bigintToBoundedValue({ ...field, nullable: false }, slot - 1n);
+    }
+    return kindValue(field, slot);
+}
+
+function kindValue(field: CustomIdField<unknown>, slot: bigint): unknown {
     switch (field.kind) {
         case 'snowflake': {
             return slot.toString();
@@ -202,7 +218,16 @@ function bigintToUuid(value: bigint): string {
     return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
 }
 
+// an unbounded field trails as its own token, where an empty string is already a legal str value. a
+// nullable one carries one leading char to tell the two apart.
+const ABSENT = '0';
+const PRESENT = '1';
+
 function encodeUnboundedToken(field: CustomIdField<unknown>, name: string, value: unknown): string {
+    if (field.nullable === true) {
+        if (value === null) return ABSENT;
+        return PRESENT + encodeUnboundedToken({ ...field, nullable: false }, name, value);
+    }
     if (field.kind === 'int') {
         if (!Number.isSafeInteger(value)) outOfRange(name, value);
         return bigintToBase64(zigzagEncode(value as number));
@@ -210,6 +235,12 @@ function encodeUnboundedToken(field: CustomIdField<unknown>, name: string, value
     return escapeToken(value as string);
 }
 function decodeUnboundedToken(field: CustomIdField<unknown>, piece: string): unknown {
+    if (field.nullable === true) {
+        const marker = piece.charAt(0);
+        if (marker === ABSENT && piece.length === 1) return null;
+        if (marker !== PRESENT) throw new InvalidCustomId(`bad presence marker ${JSON.stringify(marker)}`);
+        return decodeUnboundedToken({ ...field, nullable: false }, piece.slice(1));
+    }
     if (field.kind !== 'int') return unescapeToken(piece);
     // an empty piece means a truncated wire
     if (piece === '') throw new InvalidCustomId('empty integer token');
@@ -227,6 +258,7 @@ export function computeLayoutHash(shape: CustomIdShape): string {
             name,
             field.kind,
             isBounded(field),
+            field.nullable === true,
             field.kind === 'oneOf' ? (field.choices ?? []) : null,
             field.kind === 'int' ? [field.min ?? null, field.max ?? null] : null
         ])

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -57,6 +57,7 @@ export { Fault } from '#stops/Fault';
 export { Silence } from '#stops/Silence';
 
 export { CustomId } from '#customId/CustomId';
+export type { FieldOptions } from '#customId/CustomId';
 
 export { ResolvedEmoji } from '#src/miscellaneous/emoji';
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -66,8 +66,8 @@ export { paginate } from '#pagination/paginate';
 export { type PageView } from '#pagination/PageView';
 export { PaginatorBase } from '#pagination/PaginatorBase';
 export type { PaginatorConfig } from '#pagination/PaginatorBase';
-export { ArraySource, CursorSource } from '#pagination/sources';
-export type { PageSource } from '#pagination/sources';
+export { ArraySourceBase, CursorSourceBase } from '#pagination/sources';
+export type { PageSourceBase } from '#pagination/sources';
 export type { ControlCosmetics, ControlKey, PaginatorControls } from '#pagination/controls';
 export type { ItemRender, PageRender } from '#pagination/render';
 

--- a/packages/core/src/pagination/PaginatorBase.ts
+++ b/packages/core/src/pagination/PaginatorBase.ts
@@ -48,8 +48,8 @@ export abstract class PaginatorBase<Item, Prefix extends string, Ctx> {
         this.config = config;
     }
 
-    /** Render a page as a {@link ReplyResponse}. To post it elsewhere, add `flags: MessageFlags.IsComponentsV2`. */
-    async page(ctx: Ctx, n: number): Promise<ReplyResponse> {
+    /** Build one page as a {@link ReplyResponse}. Each transport wraps this in a `page()` taking its handler. */
+    protected async buildPage(ctx: Ctx, n: number): Promise<ReplyResponse> {
         const view = await this.config.source.page(ctx, n);
         return renderPage(view, this.cursor, this.config);
     }

--- a/packages/core/src/pagination/PaginatorBase.ts
+++ b/packages/core/src/pagination/PaginatorBase.ts
@@ -3,7 +3,7 @@ import { renderPage } from '#pagination/render';
 
 import type { PageCursor } from '#pagination/cursor';
 import type { ItemRender, PageRender } from '#pagination/render';
-import type { PageSource } from '#pagination/sources';
+import type { PageSourceBase } from '#pagination/sources';
 import type { ReplyResponse } from '@seedcord/types';
 
 /**
@@ -16,7 +16,7 @@ import type { ReplyResponse } from '@seedcord/types';
 export interface PaginatorConfig<Item, Prefix extends string, Ctx> {
     /** The route prefix used to build the page cursor on the nav buttons. */
     prefix: Prefix;
-    source: PageSource<Item, Ctx>;
+    source: PageSourceBase<Item, Ctx>;
     /** Render one item, `index` is its absolute position across pages. Ignored when `render` is set. */
     renderItem?: ItemRender<Item>;
     /** Take over the whole page tree. Receives the page data and the controls factory. */

--- a/packages/core/src/pagination/paginate.ts
+++ b/packages/core/src/pagination/paginate.ts
@@ -18,7 +18,9 @@ export function paginate<Item>(items: readonly Item[], page: number, perPage: nu
     }
 
     const totalPages = Math.max(1, Math.ceil(items.length / perPage));
-    const clamped = Math.min(Math.max(Math.trunc(page), 0), totalPages - 1);
+    // NaN comes back out of Math.trunc, Math.max, and Math.min unchanged.
+    const requested = Number.isNaN(page) ? 0 : Math.trunc(page);
+    const clamped = Math.min(Math.max(requested, 0), totalPages - 1);
     const start = clamped * perPage;
 
     return {

--- a/packages/core/src/pagination/sources.ts
+++ b/packages/core/src/pagination/sources.ts
@@ -73,8 +73,8 @@ export class CursorSourceBase<Item, Ctx> implements PageSourceBase<Item, Ctx> {
     }
 
     async page(ctx: Ctx, n: number): Promise<PageView<Item>> {
-        // NaN comes back out of Math.trunc and Math.max unchanged, then reaches the fetcher as an offset.
-        const page = Number.isNaN(n) ? 0 : Math.max(0, Math.trunc(n));
+        // a cursor source has no total to clamp against. Infinity and NaN both fall back to 0.
+        const page = Number.isFinite(n) ? Math.max(0, Math.trunc(n)) : 0;
         const { items, hasNext } = await this.fetch(ctx, page, this.perPage);
         return { items: [...items], page, perPage: this.perPage, hasPrev: page > 0, hasNext };
     }

--- a/packages/core/src/pagination/sources.ts
+++ b/packages/core/src/pagination/sources.ts
@@ -73,7 +73,8 @@ export class CursorSourceBase<Item, Ctx> implements PageSourceBase<Item, Ctx> {
     }
 
     async page(ctx: Ctx, n: number): Promise<PageView<Item>> {
-        const page = Math.max(0, Math.trunc(n));
+        // NaN comes back out of Math.trunc and Math.max unchanged, then reaches the fetcher as an offset.
+        const page = Number.isNaN(n) ? 0 : Math.max(0, Math.trunc(n));
         const { items, hasNext } = await this.fetch(ctx, page, this.perPage);
         return { items: [...items], page, perPage: this.perPage, hasPrev: page > 0, hasNext };
     }

--- a/packages/core/src/pagination/sources.ts
+++ b/packages/core/src/pagination/sources.ts
@@ -14,7 +14,7 @@ const DEFAULT_PER_PAGE = 10;
  * @typeParam Item - The item type the source pages over.
  * @typeParam Ctx - The transport's page context, handed to the loader.
  */
-export interface PageSource<Item, Ctx> {
+export interface PageSourceBase<Item, Ctx> {
     page(ctx: Ctx, n: number): Promise<PageView<Item>>;
 }
 
@@ -34,7 +34,7 @@ function perPageOf(opts?: { perPage?: number }): number {
  * @typeParam Item - The item type, inferred from the loader's return.
  * @typeParam Ctx - The transport's page context. Each transport exports a subclass that fixes it.
  */
-export class ArraySource<Item, Ctx> implements PageSource<Item, Ctx> {
+export class ArraySourceBase<Item, Ctx> implements PageSourceBase<Item, Ctx> {
     private readonly perPage: number;
 
     constructor(
@@ -58,7 +58,7 @@ export class ArraySource<Item, Ctx> implements PageSource<Item, Ctx> {
  * @typeParam Item - The item type, inferred from the fetcher's slice.
  * @typeParam Ctx - The transport's page context. Each transport exports a subclass that fixes it.
  */
-export class CursorSource<Item, Ctx> implements PageSource<Item, Ctx> {
+export class CursorSourceBase<Item, Ctx> implements PageSourceBase<Item, Ctx> {
     private readonly perPage: number;
 
     constructor(

--- a/packages/core/tests/customId/codec.test.ts
+++ b/packages/core/tests/customId/codec.test.ts
@@ -16,6 +16,73 @@ function thrownCode(run: () => unknown): SeedcordErrorCode | undefined {
     return undefined;
 }
 
+describe('nullable fields', () => {
+    it('round-trips null and a value for every kind', () => {
+        const Every = new CustomId('every')
+            .snowflake('userId', { nullable: true })
+            .uuid('ticketId', { nullable: true })
+            .int('priority', 0, 5, { nullable: true })
+            .int('reopenCount', { nullable: true })
+            .bool('escalated', { nullable: true })
+            .oneOf('queue', ['billing', 'tech'], { nullable: true })
+            .str('subject', { nullable: true });
+
+        const absent = {
+            userId: null,
+            ticketId: null,
+            priority: null,
+            reopenCount: null,
+            escalated: null,
+            queue: null,
+            subject: null
+        };
+        expect(Every.decode(Every.encode(absent))).toEqual(absent);
+
+        const present = {
+            userId: '853472916483920128',
+            ticketId: '6a1f4c2e-8b3d-4e7a-9c0f-1d2e3f4a5b6c',
+            priority: 4,
+            reopenCount: 12,
+            escalated: false,
+            queue: 'tech' as const,
+            subject: 'cannot log in'
+        };
+        expect(Every.decode(Every.encode(present))).toEqual(present);
+    });
+
+    it('keeps an empty string apart from null on a nullable str', () => {
+        const Note = new CustomId('note').str('body', { nullable: true });
+
+        expect(Note.decode(Note.encode({ body: '' })).body).toBe('');
+        expect(Note.decode(Note.encode({ body: null })).body).toBeNull();
+    });
+
+    it('keeps false apart from null on a nullable bool', () => {
+        const Flag = new CustomId('flag').bool('silent', { nullable: true });
+
+        expect(Flag.decode(Flag.encode({ silent: false })).silent).toBe(false);
+        expect(Flag.decode(Flag.encode({ silent: null })).silent).toBeNull();
+    });
+
+    it('marks a wire stale once a field turns nullable', () => {
+        const before = new CustomId('report').snowflake('claimedBy');
+        const after = new CustomId('report').snowflake('claimedBy', { nullable: true });
+        const wire = before.encode({ claimedBy: '853472916483920128' });
+
+        expect(() => after.decode(wire)).toThrow(StaleCustomId);
+    });
+
+    it('leaves a field alone when nullable is false', () => {
+        const Plain = new CustomId('plain').snowflake('userId', { nullable: false });
+        const Omitted = new CustomId('plain').snowflake('userId');
+
+        expect(Plain.routeKey).toBe(Omitted.routeKey);
+        expect(thrownCode(() => Plain.encode({ userId: null as unknown as string }))).toBe(
+            SeedcordErrorCode.CustomIdValueOutOfRange
+        );
+    });
+});
+
 describe('CustomId round-trips', () => {
     it('round-trips every field kind in one customId', () => {
         // a support-ticket action button that carries one field of every kind at once.

--- a/packages/core/tests/customId/codec.test.ts
+++ b/packages/core/tests/customId/codec.test.ts
@@ -77,9 +77,14 @@ describe('nullable fields', () => {
         const Omitted = new CustomId('plain').snowflake('userId');
 
         expect(Plain.routeKey).toBe(Omitted.routeKey);
-        expect(thrownCode(() => Plain.encode({ userId: null as unknown as string }))).toBe(
-            SeedcordErrorCode.CustomIdValueOutOfRange
-        );
+        expect(
+            thrownCode(() =>
+                Plain.encode({
+                    // @ts-expect-error a non-nullable field rejects null at compile time and at runtime
+                    userId: null
+                })
+            )
+        ).toBe(SeedcordErrorCode.CustomIdValueOutOfRange);
     });
 });
 

--- a/packages/core/tests/customId/nullable.types-test.ts
+++ b/packages/core/tests/customId/nullable.types-test.ts
@@ -1,0 +1,44 @@
+import { CustomId } from '#customId/CustomId';
+
+const Board = new CustomId('board').int('page', 0, 999).snowflake('roleId', { nullable: true });
+type BoardParams = ReturnType<typeof Board.decode>;
+
+const absent: BoardParams['roleId'] = null;
+const present: BoardParams['roleId'] = '123';
+void absent;
+void present;
+
+// @ts-expect-error page took no options and stays a plain number
+const pageIsNotNullable: BoardParams['page'] = null;
+void pageIsNotNullable;
+
+const Note = new CustomId('note').str('body', { nullable: true });
+type NoteParams = ReturnType<typeof Note.decode>;
+
+const emptyBody: NoteParams['body'] = null;
+void emptyBody;
+
+Note.encode({ body: null });
+
+const Plain = new CustomId('plain').snowflake('userId');
+type PlainParams = ReturnType<typeof Plain.decode>;
+
+// @ts-expect-error a field with no options stays non-null
+const plainIsNotNullable: PlainParams['userId'] = null;
+void plainIsNotNullable;
+
+const Explicit = new CustomId('explicit').bool('silent', { nullable: false });
+type ExplicitParams = ReturnType<typeof Explicit.decode>;
+
+// @ts-expect-error nullable false reads the same as leaving it out
+const explicitIsNotNullable: ExplicitParams['silent'] = null;
+void explicitIsNotNullable;
+
+Explicit.encode({ silent: true });
+
+// encode takes the same widening the decode side gets
+Board.encode({ page: 0, roleId: null });
+Plain.encode({
+    // @ts-expect-error null reaches encode only on a nullable field
+    userId: null
+});

--- a/packages/core/tests/pagination/PaginatorBase.test.ts
+++ b/packages/core/tests/pagination/PaginatorBase.test.ts
@@ -2,7 +2,7 @@ import { ComponentType } from 'discord-api-types/v10';
 import { describe, expect, it } from 'vitest';
 
 import { PaginatorBase } from '#pagination/PaginatorBase';
-import { ArraySource } from '#pagination/sources';
+import { ArraySourceBase } from '#pagination/sources';
 
 import type { PaginatorConfig } from '#pagination/PaginatorBase';
 import type { ReplyResponse } from '@seedcord/types';
@@ -41,7 +41,7 @@ const letters = ['a', 'b', 'c', 'd', 'e'];
 function pager(): TestPaginator<string> {
     return new TestPaginator({
         prefix: 'test',
-        source: new ArraySource<string, TestCtx>(() => letters, { perPage: 2 }),
+        source: new ArraySourceBase<string, TestCtx>(() => letters, { perPage: 2 }),
         renderItem: (letter) => letter
     });
 }
@@ -60,7 +60,7 @@ describe('PaginatorBase', () => {
         const seen: TestCtx[] = [];
         const paged = new TestPaginator<string>({
             prefix: 'test',
-            source: new ArraySource<string, TestCtx>((received) => {
+            source: new ArraySourceBase<string, TestCtx>((received) => {
                 seen.push(received);
                 return letters;
             }),

--- a/packages/core/tests/pagination/PaginatorBase.test.ts
+++ b/packages/core/tests/pagination/PaginatorBase.test.ts
@@ -17,6 +17,11 @@ class TestPaginator<Item> extends PaginatorBase<Item, 'test', TestCtx> {
     constructor(config: PaginatorConfig<Item, 'test', TestCtx>) {
         super(config);
     }
+
+    // stands in for the page(handler, n) each transport builds on buildPage
+    public page(ctx: TestCtx, n: number): Promise<ReplyResponse> {
+        return this.buildPage(ctx, n);
+    }
 }
 
 function containerOf(reply: ReplyResponse): APIContainerComponent {

--- a/packages/core/tests/pagination/paginate.test.ts
+++ b/packages/core/tests/pagination/paginate.test.ts
@@ -12,6 +12,16 @@ function InfersItemTypeFromInput(): void {
 void InfersItemTypeFromInput;
 
 describe('paginate', () => {
+    it.each([
+        [Number.NaN, 0],
+        [Number.NEGATIVE_INFINITY, 0],
+        [Number.POSITIVE_INFINITY, 2]
+    ])('clamps %p into range', (page, expected) => {
+        const view = paginate(items, page, 10);
+        expect(view.page).toBe(expected);
+        expect(view.items.length).toBeGreaterThan(0);
+    });
+
     it('slices the requested page and reports the bounds', () => {
         const view = paginate(items, 0, 10);
         expect(view.items).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);

--- a/packages/core/tests/pagination/sources.test.ts
+++ b/packages/core/tests/pagination/sources.test.ts
@@ -58,6 +58,19 @@ describe('ArraySourceBase', () => {
 });
 
 describe('CursorSourceBase', () => {
+    it('hands the fetcher a real page number when the caller passes a non-finite one', async () => {
+        const seen: number[] = [];
+        const source = new CursorSourceBase<string, TestCtx>((_ctx, page) => {
+            seen.push(page);
+            return { items: ['a'], hasNext: false };
+        });
+
+        const view = await source.page(ctx, Number.NaN);
+
+        expect(seen[0]).toBe(0);
+        expect(view.page).toBe(0);
+    });
+
     it('wraps one fetched page with an unknown total', async () => {
         const source = new CursorSourceBase(() => ({ items: ['a', 'b'], hasNext: true }), { perPage: 2 });
         const view = await source.page(ctx, 0);

--- a/packages/core/tests/pagination/sources.test.ts
+++ b/packages/core/tests/pagination/sources.test.ts
@@ -1,7 +1,7 @@
 import { SeedcordRangeError } from '@seedcord/errors/internal';
 import { describe, expect, expectTypeOf, it } from 'vitest';
 
-import { ArraySource, CursorSource } from '#pagination/sources';
+import { ArraySourceBase, CursorSourceBase } from '#pagination/sources';
 
 // the sources only forward ctx to the loader, so a fake shape is enough
 interface TestCtx {
@@ -10,15 +10,15 @@ interface TestCtx {
 const ctx: TestCtx = { tag: 'ctx' };
 
 async function InfersItemTypeFromLoader(): Promise<void> {
-    const source = new ArraySource(() => ['a', 'b']);
+    const source = new ArraySourceBase(() => ['a', 'b']);
     const view = await source.page(ctx, 0);
     expectTypeOf(view.items).toEqualTypeOf<string[]>();
 }
 void InfersItemTypeFromLoader;
 
-describe('ArraySource', () => {
+describe('ArraySourceBase', () => {
     it('pages a loaded array through the pure math', async () => {
-        const source = new ArraySource(() => Array.from({ length: 25 }, (_, i) => i), { perPage: 10 });
+        const source = new ArraySourceBase(() => Array.from({ length: 25 }, (_, i) => i), { perPage: 10 });
         const view = await source.page(ctx, 1);
         expect(view.items).toEqual([10, 11, 12, 13, 14, 15, 16, 17, 18, 19]);
         expect(view.totalPages).toBe(3);
@@ -28,7 +28,7 @@ describe('ArraySource', () => {
 
     it('forwards the context to the loader', async () => {
         const seen: TestCtx[] = [];
-        const source = new ArraySource<number, TestCtx>((received) => {
+        const source = new ArraySourceBase<number, TestCtx>((received) => {
             seen.push(received);
             return [1, 2, 3];
         });
@@ -37,29 +37,29 @@ describe('ArraySource', () => {
     });
 
     it('defaults perPage to 10', async () => {
-        const source = new ArraySource(() => Array.from({ length: 25 }, (_, i) => i));
+        const source = new ArraySourceBase(() => Array.from({ length: 25 }, (_, i) => i));
         const view = await source.page(ctx, 0);
         expect(view.items).toHaveLength(10);
         expect(view.totalPages).toBe(3);
     });
 
     it('awaits an async loader', async () => {
-        const source = new ArraySource(() => Promise.resolve([1, 2, 3]), { perPage: 2 });
+        const source = new ArraySourceBase(() => Promise.resolve([1, 2, 3]), { perPage: 2 });
         const view = await source.page(ctx, 1);
         expect(view.items).toEqual([3]);
     });
 
     it('rejects a non-positive or non-integer perPage at construction', () => {
         const load = (): number[] => [];
-        expect(() => new ArraySource(load, { perPage: 0 })).toThrow(SeedcordRangeError);
-        expect(() => new ArraySource(load, { perPage: -1 })).toThrow(SeedcordRangeError);
-        expect(() => new ArraySource(load, { perPage: 2.5 })).toThrow(SeedcordRangeError);
+        expect(() => new ArraySourceBase(load, { perPage: 0 })).toThrow(SeedcordRangeError);
+        expect(() => new ArraySourceBase(load, { perPage: -1 })).toThrow(SeedcordRangeError);
+        expect(() => new ArraySourceBase(load, { perPage: 2.5 })).toThrow(SeedcordRangeError);
     });
 });
 
-describe('CursorSource', () => {
+describe('CursorSourceBase', () => {
     it('wraps one fetched page with an unknown total', async () => {
-        const source = new CursorSource(() => ({ items: ['a', 'b'], hasNext: true }), { perPage: 2 });
+        const source = new CursorSourceBase(() => ({ items: ['a', 'b'], hasNext: true }), { perPage: 2 });
         const view = await source.page(ctx, 0);
         expect(view.items).toEqual(['a', 'b']);
         expect(view.page).toBe(0);
@@ -70,7 +70,7 @@ describe('CursorSource', () => {
     });
 
     it('reports hasPrev from the page number', async () => {
-        const source = new CursorSource(() => ({ items: ['x'], hasNext: false }));
+        const source = new CursorSourceBase(() => ({ items: ['x'], hasNext: false }));
         const view = await source.page(ctx, 3);
         expect(view.page).toBe(3);
         expect(view.hasPrev).toBe(true);
@@ -79,7 +79,7 @@ describe('CursorSource', () => {
 
     it('forwards ctx, page, and perPage to the fetcher', async () => {
         const calls: [TestCtx, number, number][] = [];
-        const source = new CursorSource<never, TestCtx>(
+        const source = new CursorSourceBase<never, TestCtx>(
             (received, page, perPage) => {
                 calls.push([received, page, perPage]);
                 return { items: [], hasNext: false };
@@ -91,7 +91,7 @@ describe('CursorSource', () => {
     });
 
     it('clamps a negative page to zero', async () => {
-        const source = new CursorSource(() => ({ items: [], hasNext: false }));
+        const source = new CursorSourceBase(() => ({ items: [], hasNext: false }));
         const view = await source.page(ctx, -3);
         expect(view.page).toBe(0);
         expect(view.hasPrev).toBe(false);
@@ -99,8 +99,8 @@ describe('CursorSource', () => {
 
     it('rejects a non-positive or non-integer perPage at construction', () => {
         const fetch = (): { items: number[]; hasNext: boolean } => ({ items: [], hasNext: false });
-        expect(() => new CursorSource(fetch, { perPage: 0 })).toThrow(SeedcordRangeError);
-        expect(() => new CursorSource(fetch, { perPage: -1 })).toThrow(SeedcordRangeError);
-        expect(() => new CursorSource(fetch, { perPage: 2.5 })).toThrow(SeedcordRangeError);
+        expect(() => new CursorSourceBase(fetch, { perPage: 0 })).toThrow(SeedcordRangeError);
+        expect(() => new CursorSourceBase(fetch, { perPage: -1 })).toThrow(SeedcordRangeError);
+        expect(() => new CursorSourceBase(fetch, { perPage: 2.5 })).toThrow(SeedcordRangeError);
     });
 });

--- a/packages/core/tests/pagination/sources.test.ts
+++ b/packages/core/tests/pagination/sources.test.ts
@@ -58,18 +58,21 @@ describe('ArraySourceBase', () => {
 });
 
 describe('CursorSourceBase', () => {
-    it('hands the fetcher a real page number when the caller passes a non-finite one', async () => {
-        const seen: number[] = [];
-        const source = new CursorSourceBase<string, TestCtx>((_ctx, page) => {
-            seen.push(page);
-            return { items: ['a'], hasNext: false };
-        });
+    it.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
+        'hands the fetcher page 0 when the caller passes %p',
+        async (requested) => {
+            const seen: number[] = [];
+            const source = new CursorSourceBase<string, TestCtx>((_ctx, page) => {
+                seen.push(page);
+                return { items: ['a'], hasNext: false };
+            });
 
-        const view = await source.page(ctx, Number.NaN);
+            const view = await source.page(ctx, requested);
 
-        expect(seen[0]).toBe(0);
-        expect(view.page).toBe(0);
-    });
+            expect(seen[0]).toBe(0);
+            expect(view.page).toBe(0);
+        }
+    );
 
     it('wraps one fetched page with an unknown total', async () => {
         const source = new CursorSourceBase(() => ({ items: ['a', 'b'], hasNext: true }), { perPage: 2 });

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -24,9 +24,6 @@ export { ReplySender } from '#bot/ReplySender';
 export type { SentMessage } from '#bot/ReplySender';
 
 export * from '#pagination/index';
-// same reason, core exports its own ArraySource, CursorSource, and PageSource
-export { ArraySource, CursorSource } from '#pagination/sources';
-export type { PageSource } from '#pagination/sources';
 
 export type * from '#inputs/index';
 

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -24,8 +24,9 @@ export { ReplySender } from '#bot/ReplySender';
 export type { SentMessage } from '#bot/ReplySender';
 
 export * from '#pagination/index';
-// same reason, core exports its own ArraySource and CursorSource
+// same reason, core exports its own ArraySource, CursorSource, and PageSource
 export { ArraySource, CursorSource } from '#pagination/sources';
+export type { PageSource } from '#pagination/sources';
 
 export type * from '#inputs/index';
 

--- a/packages/gateway/src/pagination/Paginator.ts
+++ b/packages/gateway/src/pagination/Paginator.ts
@@ -2,6 +2,7 @@ import { PaginatorBase } from '@seedcord/core';
 
 import { ButtonHandler } from '#handlers/interaction/components';
 
+import type { SentMessage } from '#bot/ReplySender';
 import type { RepliableHandler } from '#handlers/RepliableHandler';
 import type { Core } from '#interfaces/Core';
 import type { Repliables } from '#src/handlers/interactionTypes';
@@ -9,7 +10,7 @@ import type { PageContext } from './PageContext';
 import type { PaginatorConfig } from '@seedcord/core';
 import type { PageCursor } from '@seedcord/core/internal';
 import type { ReplyResponse } from '@seedcord/types';
-import type { ButtonInteraction, CacheType, Message } from 'discord.js';
+import type { ButtonInteraction, CacheType } from 'discord.js';
 
 // `& { execute }` concretizes the abstract execute so the empty `extends Bans.Handler {}` stays concrete
 // (no TS2515) and a concrete Nav assigns with no cast.
@@ -50,11 +51,12 @@ export class Paginator<Item, const Prefix extends string> extends PaginatorBase<
         super(config);
 
         // an arrow captures the paginator lexically so Nav.execute can reach it without aliasing `this`.
-        const loadPage = (ctx: PageContext, n: number): Promise<ReplyResponse> => this.page(ctx, n);
+        const pageFor = (handler: RepliableHandler<Repliables>, n: number): Promise<ReplyResponse> =>
+            this.page(handler, n);
         this.Handler = class Nav extends ButtonHandler<[PageCursor<Prefix>], CacheType> {
             async execute(): Promise<void> {
                 await this.deferUpdate();
-                const response = await loadPage(contextOf(this.event, this.core), this.params.page);
+                const response = await pageFor(this, this.params.page);
                 // deferUpdate seeds the sender deferred-update, so update PATCHes @original
                 await this.update(response);
             }
@@ -62,14 +64,23 @@ export class Paginator<Item, const Prefix extends string> extends PaginatorBase<
     }
 
     /**
-     * Render page 0 and send it through the handler's sender, which picks reply, edit, or followUp from its
-     * ack state.
+     * Render a page as a {@link ReplyResponse} without sending anything.
+     *
+     * @param handler - The handler rendering the page, normally `this`.
+     * @param n - The zero-based page.
+     */
+    async page(handler: RepliableHandler<Repliables>, n: number): Promise<ReplyResponse> {
+        return this.buildPage(contextOf(handler.getEvent(), handler.core), n);
+    }
+
+    /**
+     * Send a page through the handler's sender. The sender picks reply, edit, or followUp from its ack state.
      *
      * @param handler - The handler starting the paginator, normally `this`.
+     * @param n - The zero-based page to open on.
      */
-    async start(handler: RepliableHandler<Repliables>): Promise<Message> {
-        const interaction = handler.getEvent();
-        const response = await this.page(contextOf(interaction, handler.core), 0);
+    async start(handler: RepliableHandler<Repliables>, n = 0): Promise<SentMessage> {
+        const response = await this.page(handler, n);
         return handler.sender.send(response, { ephemeral: this.config.ephemeral ?? false });
     }
 }

--- a/packages/gateway/src/pagination/index.ts
+++ b/packages/gateway/src/pagination/index.ts
@@ -2,3 +2,4 @@ export { Paginator } from './Paginator';
 export { ArraySource, CursorSource } from './sources';
 
 export type { PageContext } from './PageContext';
+export type { PageSource } from './sources';

--- a/packages/gateway/src/pagination/sources.ts
+++ b/packages/gateway/src/pagination/sources.ts
@@ -1,7 +1,7 @@
-import { ArraySource as BaseArraySource, CursorSource as BaseCursorSource } from '@seedcord/core';
+import { ArraySourceBase, CursorSourceBase } from '@seedcord/core';
 
 import type { PageContext } from './PageContext';
-import type { PageSource as BasePageSource } from '@seedcord/core';
+import type { PageSourceBase } from '@seedcord/core';
 
 /**
  * The one method a paginator calls on a source, once per click. Implement it for a source neither shipped
@@ -9,7 +9,7 @@ import type { PageSource as BasePageSource } from '@seedcord/core';
  *
  * @typeParam Item - The item type the source pages over.
  */
-export type PageSource<Item> = BasePageSource<Item, PageContext>;
+export type PageSource<Item> = PageSourceBase<Item, PageContext>;
 
 /**
  * A source for a bounded list you can load whole. It loads the full list on every click, then slices the
@@ -18,7 +18,7 @@ export type PageSource<Item> = BasePageSource<Item, PageContext>;
  *
  * @typeParam Item - The item type, inferred from the loader's return.
  */
-export class ArraySource<Item> extends BaseArraySource<Item, PageContext> {}
+export class ArraySource<Item> extends ArraySourceBase<Item, PageContext> {}
 
 /**
  * A source for a large or unknown-length set you fetch one page at a time (SQL LIMIT/OFFSET, a paged API).
@@ -28,4 +28,4 @@ export class ArraySource<Item> extends BaseArraySource<Item, PageContext> {}
  *
  * @typeParam Item - The item type, inferred from the fetcher's slice.
  */
-export class CursorSource<Item> extends BaseCursorSource<Item, PageContext> {}
+export class CursorSource<Item> extends CursorSourceBase<Item, PageContext> {}

--- a/packages/gateway/src/pagination/sources.ts
+++ b/packages/gateway/src/pagination/sources.ts
@@ -1,6 +1,15 @@
 import { ArraySource as BaseArraySource, CursorSource as BaseCursorSource } from '@seedcord/core';
 
 import type { PageContext } from './PageContext';
+import type { PageSource as BasePageSource } from '@seedcord/core';
+
+/**
+ * The one method a paginator calls on a source, once per click. Implement it for a source neither shipped
+ * one covers.
+ *
+ * @typeParam Item - The item type the source pages over.
+ */
+export type PageSource<Item> = BasePageSource<Item, PageContext>;
 
 /**
  * A source for a bounded list you can load whole. It loads the full list on every click, then slices the

--- a/packages/gateway/tests/pagination/paginator.test.ts
+++ b/packages/gateway/tests/pagination/paginator.test.ts
@@ -158,6 +158,14 @@ describe('Paginator.start', () => {
         await expect(pager.start(stubHandler(event))).rejects.toBe(failure);
     });
 
+    it('opens on the page it is given', async () => {
+        const event = startEvent();
+        await pager.start(stubHandler(event), 2);
+
+        const options = event.reply.mock.calls[0]?.[0] as { components: unknown[] };
+        expect(sentContainerText(options.components)).toBe('e');
+    });
+
     it('honors an ephemeral paginator', async () => {
         const ephemeral = new Paginator({
             prefix: 'invites',
@@ -173,11 +181,12 @@ describe('Paginator.start', () => {
 });
 
 describe('Paginator.page', () => {
-    it('renders the requested page as a ReplyResponse', async () => {
-        // justified: page() reads no field off the context, only forwards it to the source loader
-        const ctx = { interaction: {}, user: {}, guild: null } as unknown as PageContext;
-        const reply = await pager.page(ctx, 1);
+    it('renders the requested page and sends nothing', async () => {
+        const event = startEvent();
+        const reply = await pager.page(stubHandler(event), 1);
+
         expect(containerText(reply.components)).toBe('c\nd');
+        expect(event.reply).not.toHaveBeenCalled();
     });
 });
 

--- a/packages/gateway/tests/pagination/paginator.test.ts
+++ b/packages/gateway/tests/pagination/paginator.test.ts
@@ -19,7 +19,9 @@ import { stubBus } from '../utils/stubBus';
 import type { RepliableHandler } from '#handlers/RepliableHandler';
 import type { Core } from '#interfaces/Core';
 import type { PageContext } from '#pagination/PageContext';
+import type { PageSource } from '#pagination/sources';
 import type { Repliables } from '#src/handlers/interactionTypes';
+import type { PageView } from '@seedcord/core';
 import type { APIContainerComponent, ButtonInteraction, Guild } from 'discord.js';
 
 // justified: the paginator reads the interaction and the bus every write reports on
@@ -187,6 +189,33 @@ describe('Paginator.page', () => {
 
         expect(containerText(reply.components)).toBe('c\nd');
         expect(event.reply).not.toHaveBeenCalled();
+    });
+});
+
+describe('Paginator custom source', () => {
+    it('takes a hand-written PageSource with the page context already bound', async () => {
+        class OneItem implements PageSource<string> {
+            public page(_ctx: PageContext, n: number): Promise<PageView<string>> {
+                return Promise.resolve({
+                    items: [letters[n] ?? 'z'],
+                    page: n,
+                    perPage: 1,
+                    hasPrev: n > 0,
+                    hasNext: true
+                });
+            }
+        }
+
+        const custom = new Paginator({
+            prefix: 'custom',
+            source: new OneItem(),
+            renderItem: (letter) => letter
+        });
+        const event = startEvent();
+        await custom.start(stubHandler(event), 3);
+
+        const options = event.reply.mock.calls[0]?.[0] as { components: unknown[] };
+        expect(sentContainerText(options.components)).toBe('d');
     });
 });
 

--- a/packages/http/src/edge.index.ts
+++ b/packages/http/src/edge.index.ts
@@ -36,8 +36,9 @@ export type { InteractionRef, SentMessage } from '#reply/ReplySender';
 export { Subscriber, WebhookLog } from '#subscribers/index';
 
 export * from '#src/pagination/index';
-// same reason, core exports its own ArraySource and CursorSource
+// same reason, core exports its own ArraySource, CursorSource, and PageSource
 export { ArraySource, CursorSource } from '#src/pagination/sources';
+export type { PageSource } from '#src/pagination/sources';
 
 export { Gated } from '#src/gates/Gated';
 export type { InteractionGateContext } from '#src/gates/Gate';

--- a/packages/http/src/edge.index.ts
+++ b/packages/http/src/edge.index.ts
@@ -36,9 +36,6 @@ export type { InteractionRef, SentMessage } from '#reply/ReplySender';
 export { Subscriber, WebhookLog } from '#subscribers/index';
 
 export * from '#src/pagination/index';
-// same reason, core exports its own ArraySource, CursorSource, and PageSource
-export { ArraySource, CursorSource } from '#src/pagination/sources';
-export type { PageSource } from '#src/pagination/sources';
 
 export { Gated } from '#src/gates/Gated';
 export type { InteractionGateContext } from '#src/gates/Gate';

--- a/packages/http/src/pagination/Paginator.ts
+++ b/packages/http/src/pagination/Paginator.ts
@@ -58,11 +58,12 @@ export class Paginator<Item, const Prefix extends string> extends PaginatorBase<
         super(config);
 
         // an arrow captures the paginator lexically so Nav.execute can reach it without aliasing `this`.
-        const loadPage = (ctx: PageContext, n: number): Promise<ReplyResponse> => this.page(ctx, n);
+        const pageFor = (handler: RepliableHandler<Repliables>, n: number): Promise<ReplyResponse> =>
+            this.page(handler, n);
         this.Handler = class Nav extends ButtonHandler<[PageCursor<Prefix>]> {
             async execute(): Promise<void> {
                 await this.deferUpdate();
-                const response = await loadPage(contextOf(this.event, this.core), this.params.page);
+                const response = await pageFor(this, this.params.page);
                 // deferUpdate seeds the sender deferred-update, so update PATCHes @original
                 await this.update(response);
             }
@@ -70,14 +71,23 @@ export class Paginator<Item, const Prefix extends string> extends PaginatorBase<
     }
 
     /**
-     * Render page 0 and send it through the handler's sender, which picks reply, edit, or followUp from its
-     * ack state.
+     * Render a page as a {@link ReplyResponse} without sending anything.
+     *
+     * @param handler - The handler rendering the page, normally `this`.
+     * @param n - The zero-based page.
+     */
+    async page(handler: RepliableHandler<Repliables>, n: number): Promise<ReplyResponse> {
+        return this.buildPage(contextOf(handler.getEvent(), handler.core), n);
+    }
+
+    /**
+     * Send a page through the handler's sender. The sender picks reply, edit, or followUp from its ack state.
      *
      * @param handler - The handler starting the paginator, normally `this`.
+     * @param n - The zero-based page to open on.
      */
-    async start(handler: RepliableHandler<Repliables>): Promise<SentMessage> {
-        const interaction = handler.getEvent();
-        const response = await this.page(contextOf(interaction, handler.core), 0);
+    async start(handler: RepliableHandler<Repliables>, n = 0): Promise<SentMessage> {
+        const response = await this.page(handler, n);
         return handler.sender.send(response, { ephemeral: this.config.ephemeral ?? false });
     }
 }

--- a/packages/http/src/pagination/index.ts
+++ b/packages/http/src/pagination/index.ts
@@ -2,3 +2,4 @@ export { Paginator } from './Paginator';
 export { ArraySource, CursorSource } from './sources';
 
 export type { PageContext } from './PageContext';
+export type { PageSource } from './sources';

--- a/packages/http/src/pagination/sources.ts
+++ b/packages/http/src/pagination/sources.ts
@@ -1,7 +1,7 @@
-import { ArraySource as BaseArraySource, CursorSource as BaseCursorSource } from '@seedcord/core';
+import { ArraySourceBase, CursorSourceBase } from '@seedcord/core';
 
 import type { PageContext } from './PageContext';
-import type { PageSource as BasePageSource } from '@seedcord/core';
+import type { PageSourceBase } from '@seedcord/core';
 
 /**
  * The one method a paginator calls on a source, once per click. Implement it for a source neither shipped
@@ -9,7 +9,7 @@ import type { PageSource as BasePageSource } from '@seedcord/core';
  *
  * @typeParam Item - The item type the source pages over.
  */
-export type PageSource<Item> = BasePageSource<Item, PageContext>;
+export type PageSource<Item> = PageSourceBase<Item, PageContext>;
 
 /**
  * A source for a bounded list you can load whole. It loads the full list on every click, then slices the
@@ -18,7 +18,7 @@ export type PageSource<Item> = BasePageSource<Item, PageContext>;
  *
  * @typeParam Item - The item type, inferred from the loader's return.
  */
-export class ArraySource<Item> extends BaseArraySource<Item, PageContext> {}
+export class ArraySource<Item> extends ArraySourceBase<Item, PageContext> {}
 
 /**
  * A source for a large or unknown-length set you fetch one page at a time (SQL LIMIT/OFFSET, a paged API).
@@ -28,4 +28,4 @@ export class ArraySource<Item> extends BaseArraySource<Item, PageContext> {}
  *
  * @typeParam Item - The item type, inferred from the fetcher's slice.
  */
-export class CursorSource<Item> extends BaseCursorSource<Item, PageContext> {}
+export class CursorSource<Item> extends CursorSourceBase<Item, PageContext> {}

--- a/packages/http/src/pagination/sources.ts
+++ b/packages/http/src/pagination/sources.ts
@@ -1,6 +1,15 @@
 import { ArraySource as BaseArraySource, CursorSource as BaseCursorSource } from '@seedcord/core';
 
 import type { PageContext } from './PageContext';
+import type { PageSource as BasePageSource } from '@seedcord/core';
+
+/**
+ * The one method a paginator calls on a source, once per click. Implement it for a source neither shipped
+ * one covers.
+ *
+ * @typeParam Item - The item type the source pages over.
+ */
+export type PageSource<Item> = BasePageSource<Item, PageContext>;
 
 /**
  * A source for a bounded list you can load whole. It loads the full list on every click, then slices the

--- a/packages/http/tests/node/pagination/paginator.test.ts
+++ b/packages/http/tests/node/pagination/paginator.test.ts
@@ -87,6 +87,14 @@ describe('http Paginator.start', () => {
         expect(textLines(data?.components?.[0])).toEqual(['a\nb']);
     });
 
+    it('opens on the page it is given', async () => {
+        const post = vi.fn().mockResolvedValue({ resource: { message: { id: 'm-1' } } });
+
+        await pagerFor().start(stubHandler(post), 2);
+
+        expect(textLines(callbackBody(post).data?.components?.[0])).toEqual(['e']);
+    });
+
     it('honors an ephemeral paginator', async () => {
         const post = vi.fn().mockResolvedValue({ resource: { message: { id: 'm-1' } } });
 
@@ -100,6 +108,17 @@ describe('http Paginator.start', () => {
         const post = vi.fn().mockRejectedValue(failure);
 
         await expect(pagerFor().start(stubHandler(post))).rejects.toBe(failure);
+    });
+});
+
+describe('http Paginator.page', () => {
+    it('renders the requested page and sends nothing', async () => {
+        const post = vi.fn().mockResolvedValue({ resource: { message: { id: 'm-1' } } });
+
+        const reply = await pagerFor().page(stubHandler(post), 1);
+
+        expect(textLines(reply.components[0]?.toJSON() as APIContainerComponent)).toEqual(['c\nd']);
+        expect(post).not.toHaveBeenCalled();
     });
 });
 

--- a/packages/http/tests/node/pagination/paginator.test.ts
+++ b/packages/http/tests/node/pagination/paginator.test.ts
@@ -13,7 +13,9 @@ import type { Core } from '#interfaces/Core';
 import type { InteractionRef } from '#reply/ReplySender';
 import type { Repliables } from '#src/handlers/interactionTypes';
 import type { PageContext } from '#src/pagination/PageContext';
+import type { PageSource } from '#src/pagination/sources';
 import type { REST } from '@discordjs/rest';
+import type { PageView } from '@seedcord/core';
 import type {
     APIComponentInContainer,
     APIContainerComponent,
@@ -108,6 +110,33 @@ describe('http Paginator.start', () => {
         const post = vi.fn().mockRejectedValue(failure);
 
         await expect(pagerFor().start(stubHandler(post))).rejects.toBe(failure);
+    });
+});
+
+describe('http Paginator custom source', () => {
+    it('takes a hand-written PageSource with the page context already bound', async () => {
+        class OneItem implements PageSource<string> {
+            public page(_ctx: PageContext, n: number): Promise<PageView<string>> {
+                return Promise.resolve({
+                    items: [letters[n] ?? 'z'],
+                    page: n,
+                    perPage: 1,
+                    hasPrev: n > 0,
+                    hasNext: true
+                });
+            }
+        }
+
+        const post = vi.fn().mockResolvedValue({ resource: { message: { id: 'm-1' } } });
+        const custom = new Paginator({
+            prefix: 'custom',
+            source: new OneItem(),
+            renderItem: (letter) => letter
+        });
+
+        await custom.start(stubHandler(post), 3);
+
+        expect(textLines(callbackBody(post).data?.components?.[0])).toEqual(['d']);
     });
 });
 


### PR DESCRIPTION
## Checklist

- [x] Tests cover the change
- [x] `pnpm prePush` is green
- [x] Changeset added with `pnpm cs`, for any change to a published package


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom ID fields can now be marked nullable, preserving `null` distinctly from empty or false values.
  * Paginators can open directly on a selected page.
  * Pages can be rendered without sending a response, enabling previews and custom page sources.
  * Transport-specific page source types are now available.

* **Breaking Changes**
  * Pagination source base exports have been renamed with a `Base` suffix.
  * Update paginator integrations to use the revised `page` and page-source APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->