### PR TITLE
feat: customid `someOf` and int precision fix

### DIFF
--- a/.changeset/eighty-jars-hunt.md
+++ b/.changeset/eighty-jars-hunt.md
@@ -1,0 +1,5 @@
+---
+'@seedcord/custom-id': minor
+---
+
+Added `someOf`. A field holding any subset of a fixed list, decoded as an array of the literal union. It spends one bit per choice, so a five-role picker for example would cost one character in your customId sent to Discord.

--- a/.changeset/lucky-pumas-marry.md
+++ b/.changeset/lucky-pumas-marry.md
@@ -2,7 +2,7 @@
 '@seedcord/custom-id': minor
 ---
 
-- Fixed a bounded `int` field losing precision when its range crosses 2^53, where two values could mint the same wire.
-- Fixed the shape hash reading only half of an emoji, which let a changed emoji `oneOf` pass as unchanged and decode to the wrong choice.
-- Fixed a `bool` field accepting any truthy value and a `str` field throwing a raw `TypeError`. Both now throw `CustomIdValueRejected`.
-- Fixed a rejection claiming a range on fields that have none. Every rejection now names what the field takes, as in `expects a boolean, got "false"`.
+- Fixed a bounded `int` field whose range crosses 2^53. It lost precision, and two values could mint the same wire.
+- Fixed the shape hash, which read only half of an emoji. A changed emoji `oneOf` passed as unchanged and decoded to the wrong choice.
+- Fixed the type guards on `bool` and `str`, which now throw `CustomIdValueRejected`. A `bool` took any truthy value, and a `str` threw a raw `TypeError`.
+- Fixed the rejection message, which named a range on fields that have none. It now names what the field takes, as in `expects a boolean, got "false"`.

--- a/.changeset/lucky-pumas-marry.md
+++ b/.changeset/lucky-pumas-marry.md
@@ -1,0 +1,8 @@
+---
+'@seedcord/custom-id': minor
+---
+
+- Fixed a bounded `int` field losing precision when its range crosses 2^53, where two values could mint the same wire.
+- Fixed the shape hash reading only half of an emoji, which let a changed emoji `oneOf` pass as unchanged and decode to the wrong choice.
+- Fixed a `bool` field accepting any truthy value and a `str` field throwing a raw `TypeError`. Both now throw `CustomIdValueRejected`.
+- Fixed a rejection claiming a range on fields that have none. Every rejection now names what the field takes, as in `expects a boolean, got "false"`.

--- a/.changeset/olive-donkeys-shake.md
+++ b/.changeset/olive-donkeys-shake.md
@@ -1,0 +1,5 @@
+---
+'@seedcord/errors': minor
+---
+
+**BREAKING:** renamed `SeedcordErrorCode.CustomIdValueOutOfRange` to `CustomIdValueRejected` (same error code). It now gives a more accurate description of the error with what's wrong and what was expected.

--- a/apps/guide/content/docs/components/custom-ids.mdx
+++ b/apps/guide/content/docs/components/custom-ids.mdx
@@ -23,7 +23,7 @@ export const TicketAction = new CustomId('ticket')
                         │
                  encode │
                         ▼
-              ticketF3A:o_DDcBfgAB
+              ticketuFh:o_DDcBfgAB
               └──┬─┘└┬┘ └────┬───┘
                  │   │       └ the three values
                  │   └ shape hash
@@ -108,6 +108,7 @@ TicketAction.encode({ ownerId: '123', action: 'archive' });
 | `int(name)` | `number` | its own token |
 | `bool(name)` | `boolean` | packs |
 | `oneOf(name, choices)` | the literal union | packs |
+| `someOf(name, choices)` | an array of the literal union | packs |
 | `str(name)` | `string` | its own token |
 
 {/* prettier-ignore-end */}
@@ -123,6 +124,21 @@ const Vote = new CustomId('vote')
     .int('weight', 1, 10);
 
 const { choice } = Vote.decode('...');
+//      ^?
+```
+
+`someOf` carries any subset of its list, which suits a select menu that allows several picks. A repeat collapses into one entry, and decode returns the picks in the order you declared them.
+
+```ts twoslash
+import { CustomId } from '@seedcord/gateway';
+// ---cut---
+const Assign = new CustomId('assign').someOf('roles', [
+    'reader',
+    'artist',
+    'vip'
+]);
+
+const { roles } = Assign.decode('...');
 //      ^?
 ```
 
@@ -174,7 +190,7 @@ Once a wire runs past 100, `encode` throws `CustomIdWireTooLong`. That happens w
 
 <Callout type="tip">
 
-Bound an integer whenever you know its range. `int('page')` writes its own token. `int('page', 0, 500)` folds into the shared number with everything else and results in a shorter wire. `oneOf` is the same, and `bool` is the cheapest of all.
+Bound an integer whenever you know its range. `int('page')` writes its own token. `int('page', 0, 500)` folds into the shared number with everything else and results in a shorter wire. `oneOf` and `someOf` do the same, and `bool` is the cheapest of all.
 
 </Callout>
 

--- a/apps/guide/content/docs/components/stale.mdx
+++ b/apps/guide/content/docs/components/stale.mdx
@@ -13,21 +13,21 @@ export const TicketAction = new CustomId('ticket')
     .oneOf('action', ['close', 'reopen']);
 ```
 
-`TicketAction.routeKey` reads `ticketMXf`, the prefix `ticket` followed by the hash `MXf`. Every id [`encode`](ref:custom-id/CustomId.encode) mints starts with it.
+`TicketAction.routeKey` reads `ticketVrl`, the prefix `ticket` followed by the hash `Vrl`. Every id [`encode`](ref:custom-id/CustomId.encode) mints starts with it.
 
 ## What changes the hash
 
-The hash covers each field's name, its position in the chain, its kind, a `oneOf`'s choices, and an `int`'s bounds. Change any one of those and every id already in Discord belongs to the old shape.
+The hash covers each field's name, its position in the chain, its kind, the choices on a `oneOf` or a `someOf`, and an `int`'s bounds. Change any one of those and every id already in Discord belongs to the old shape.
 
 {/* prettier-ignore-start */}
 
 | the edit | new routeKey |
 | --- | --- |
-| the shape above | `ticketMXf` |
-| rename `ownerId` to `userId` | `ticketk8r` |
-| add `'escalate'` to the choices | `ticketXWL` |
-| swap the two fields around | `ticketEjh` |
-| append `.bool('notify')` | `ticketF3A` |
+| the shape above | `ticketVrl` |
+| rename `ownerId` to `userId` | `ticketbdx` |
+| add `'escalate'` to the choices | `ticketY1t` |
+| swap the two fields around | `ticketpXF` |
+| append `.bool('notify')` | `ticketuFh` |
 
 {/* prettier-ignore-end */}
 
@@ -53,7 +53,7 @@ A modal and a select menu route by prefix the same way, so both go stale on the 
 [`decode`](ref:custom-id/CustomId.decode) separates two failures. A matching prefix with a different hash is the stale case above. A wire minted by some other `CustomId` refuses with a message naming both route keys.
 
 ```txt output
-Invalid customId. routeKey "pollM4x" is not "ticketF3A"
+Invalid customId. routeKey "pollM4x" is not "ticketVrl"
 ```
 
 That one does report, so seedcord logs it and publishes it to the `handledException` bus, where the report carries the name `InvalidCustomId`. The user sees the generic card.

--- a/packages/custom-id/README.md
+++ b/packages/custom-id/README.md
@@ -58,7 +58,7 @@ client.on(Events.InteractionCreate, (interaction) => {
 });
 ```
 
-Fields come from `snowflake`, `uuid`, `int`, `bool`, `oneOf`, `someOf`, and `str`. Each one takes `{ nullable: true }` to also carry null. A bounded `int('page', 1, 50)` packs into fewer characters than an unbounded one. `someOf('tags', [...])` carries any subset of its list for one bit per choice.
+Fields come from `snowflake`, `uuid`, `int`, `bool`, `oneOf`, `someOf`, and `str`. Each one takes `{ nullable: true }` to also carry null. `int` alone takes a second form with bounds, as `int('page', 1, 50)`.
 
 `prefixOf` recovers the route prefix from a raw wire. The prefix survives a shape change, which makes it what you route on. `decodeFor` takes several definitions at once and returns the matched prefix with its own params.
 

--- a/packages/custom-id/README.md
+++ b/packages/custom-id/README.md
@@ -58,7 +58,7 @@ client.on(Events.InteractionCreate, (interaction) => {
 });
 ```
 
-Fields come from `snowflake`, `uuid`, `int`, `bool`, `oneOf`, and `str`. Each one takes `{ nullable: true }` to also carry null. A bounded `int('page', 1, 50)` packs into fewer characters than an unbounded one.
+Fields come from `snowflake`, `uuid`, `int`, `bool`, `oneOf`, `someOf`, and `str`. Each one takes `{ nullable: true }` to also carry null. A bounded `int('page', 1, 50)` packs into fewer characters than an unbounded one. `someOf('tags', [...])` carries any subset of its list for one bit per choice.
 
 `prefixOf` recovers the route prefix from a raw wire. The prefix survives a shape change, which makes it what you route on. `decodeFor` takes several definitions at once and returns the matched prefix with its own params.
 

--- a/packages/custom-id/src/CustomId.ts
+++ b/packages/custom-id/src/CustomId.ts
@@ -235,19 +235,19 @@ export class CustomId<Prefix extends string, Shape extends CustomIdShape = {}> {
         choices: Choices,
         opts?: FieldOptions<Nullable>
     ): CustomId<Prefix, Shape & Record<Name, CustomIdField<Nullish<Choices[number], Nullable>>>> {
-        if (choices.length === 0) throw new SeedcordRangeError(SeedcordErrorCode.CustomIdEmptyChoices, [name]);
+        if (choices.length === 0) throw new SeedcordRangeError(SeedcordErrorCode.CustomIdEmptyChoices, [name, 'oneOf']);
         return this.add<Name, Nullish<Choices[number], Nullable>>(name, { ...opts, kind: 'oneOf', choices });
     }
 
     /**
-     * Add a field that is any subset of a fixed list, decoded as an array of the literal union.
+     * Add a field that holds any subset of a fixed list, decoded as an array of the literal union.
      *
-     * The field carries which values were picked. A repeat collapses into one entry. Decode returns
-     * the picks in the order you declared them in the CustomId. One choice costs one bit on the wire.
+     * A duplicate collapses into one entry. Decode returns the picks in the order the CustomId declares
+     * them. One choice costs one bit on the wire.
      *
      * @example
      * ```ts
-     * // the roles a member picked in a select menu, carried onto the confirm button
+     * // a member picks roles in a select menu, and the confirm button carries them
      * // roles: ('reader' | 'artist' | 'vip')[]
      * new CustomId('assign').someOf('roles', ['reader', 'artist', 'vip']);
      * ```
@@ -257,7 +257,8 @@ export class CustomId<Prefix extends string, Shape extends CustomIdShape = {}> {
         choices: Choices,
         opts?: FieldOptions<Nullable>
     ): CustomId<Prefix, Shape & Record<Name, CustomIdField<Nullish<Choices[number][], Nullable>>>> {
-        if (choices.length === 0) throw new SeedcordRangeError(SeedcordErrorCode.CustomIdEmptyChoices, [name]);
+        if (choices.length === 0)
+            throw new SeedcordRangeError(SeedcordErrorCode.CustomIdEmptyChoices, [name, 'someOf']);
         return this.add<Name, Nullish<Choices[number][], Nullable>>(name, { ...opts, kind: 'someOf', choices });
     }
 

--- a/packages/custom-id/src/CustomId.ts
+++ b/packages/custom-id/src/CustomId.ts
@@ -240,6 +240,28 @@ export class CustomId<Prefix extends string, Shape extends CustomIdShape = {}> {
     }
 
     /**
+     * Add a field that is any subset of a fixed list, decoded as an array of the literal union.
+     *
+     * The field carries which values were picked. A repeat collapses into one entry. Decode returns
+     * the picks in the order you declared them in the CustomId. One choice costs one bit on the wire.
+     *
+     * @example
+     * ```ts
+     * // the roles a member picked in a select menu, carried onto the confirm button
+     * // roles: ('reader' | 'artist' | 'vip')[]
+     * new CustomId('assign').someOf('roles', ['reader', 'artist', 'vip']);
+     * ```
+     */
+    someOf<Name extends string, const Choices extends NonEmptyTuple<string>, const Nullable extends boolean = false>(
+        name: Name,
+        choices: Choices,
+        opts?: FieldOptions<Nullable>
+    ): CustomId<Prefix, Shape & Record<Name, CustomIdField<Nullish<Choices[number][], Nullable>>>> {
+        if (choices.length === 0) throw new SeedcordRangeError(SeedcordErrorCode.CustomIdEmptyChoices, [name]);
+        return this.add<Name, Nullish<Choices[number][], Nullable>>(name, { ...opts, kind: 'someOf', choices });
+    }
+
+    /**
      * Add a free short text field. Avoid it where possible. It cannot be packed, which makes it the most
      * expensive field on the wire.
      *

--- a/packages/custom-id/src/Field.ts
+++ b/packages/custom-id/src/Field.ts
@@ -8,7 +8,7 @@
  */
 export interface CustomIdField<Decoded> {
     /** Which wire encoding this field uses. */
-    readonly kind: 'snowflake' | 'uuid' | 'int' | 'bool' | 'oneOf' | 'string';
+    readonly kind: 'snowflake' | 'uuid' | 'int' | 'bool' | 'oneOf' | 'someOf' | 'string';
     /** Lower bound, for a bounded int field. */
     readonly min?: number;
     /** Upper bound, for a bounded int field. */

--- a/packages/custom-id/src/codec.ts
+++ b/packages/custom-id/src/codec.ts
@@ -141,45 +141,85 @@ function boundedToBigint(field: CustomIdField<unknown>, name: string, value: unk
     }
     const slot = boundedSlot(field, name, value);
     // out of range would carry into the neighbouring field on decode.
-    if (slot < 0n || slot >= radixOf(field)) outOfRange(name, value);
+    if (slot < 0n || slot >= radixOf(field)) reject(field, name, value);
     return slot;
+}
+
+// a bad value makes BigInt() throw a bare TypeError or SyntaxError. the guard gets ahead of it with
+// the branded error.
+function snowflakeSlot(field: CustomIdField<unknown>, name: string, value: unknown): bigint {
+    if (typeof value !== 'string' || !/^\d+$/.test(value)) return reject(field, name, value);
+    return BigInt(value);
+}
+
+function uuidSlot(field: CustomIdField<unknown>, name: string, value: unknown): bigint {
+    if (typeof value !== 'string') return reject(field, name, value);
+    const hex = value.replaceAll('-', '');
+    if (!/^[0-9a-fA-F]{32}$/.test(hex)) return reject(field, name, value);
+    return BigInt(`0x${hex}`);
 }
 
 // a slot is the value as an integer in [0, radix).
 function boundedSlot(field: CustomIdField<unknown>, name: string, value: unknown): bigint {
     switch (field.kind) {
         case 'snowflake': {
-            // a bad value makes BigInt() throw a bare TypeError or SyntaxError. the guard gets
-            // ahead of it with the branded error.
-            if (typeof value !== 'string' || !/^\d+$/.test(value)) return outOfRange(name, value);
-            return BigInt(value);
+            return snowflakeSlot(field, name, value);
         }
         case 'uuid': {
-            if (typeof value !== 'string') return outOfRange(name, value);
-            const hex = value.replaceAll('-', '');
-            if (!/^[0-9a-fA-F]{32}$/.test(hex)) return outOfRange(name, value);
-            return BigInt(`0x${hex}`);
+            return uuidSlot(field, name, value);
         }
         case 'bool': {
+            if (typeof value !== 'boolean') return reject(field, name, value);
             return value ? 1n : 0n;
         }
         case 'oneOf': {
             const index = (field.choices ?? []).indexOf(value as string);
-            return index === -1 ? outOfRange(name, value) : BigInt(index);
+            return index === -1 ? reject(field, name, value) : BigInt(index);
         }
         case 'int': {
             // eslint-disable-next-line unicorn/prefer-number-is-safe-integer -- a bounded int field may declare max up to 2**53 exactly (a power of two, exact in float64)
-            if (!Number.isInteger(value)) return outOfRange(name, value);
-            return BigInt((value as number) - (field.min ?? 0));
+            if (!Number.isInteger(value)) return reject(field, name, value);
+            // a plain js number cannot hold this subtraction once it passes 2^53.
+            return BigInt(value as number) - BigInt(field.min ?? 0);
         }
         default: {
-            return outOfRange(name, value);
+            return reject(field, name, value);
         }
     }
 }
 
-function outOfRange(name: string, value: unknown): never {
-    throw new SeedcordRangeError(SeedcordErrorCode.CustomIdValueOutOfRange, [name, String(value)]);
+function reject(field: CustomIdField<unknown>, name: string, value: unknown): never {
+    throw new SeedcordRangeError(SeedcordErrorCode.CustomIdValueRejected, [name, expectation(field), show(value)]);
+}
+
+// what the field takes, written to finish the sentence "expects ...".
+function expectation(field: CustomIdField<unknown>): string {
+    switch (field.kind) {
+        case 'snowflake': {
+            return 'a snowflake string below 2^64';
+        }
+        case 'uuid': {
+            return 'a uuid string';
+        }
+        case 'bool': {
+            return 'a boolean';
+        }
+        case 'oneOf': {
+            return `one of ${(field.choices ?? []).map((choice) => JSON.stringify(choice)).join(', ')}`;
+        }
+        case 'int': {
+            if (field.min === undefined || field.max === undefined) return 'a safe integer';
+            return `an integer from ${field.min} to ${field.max}`;
+        }
+        default: {
+            return 'a string';
+        }
+    }
+}
+
+// quoting keeps the string 'false' apart from the boolean.
+function show(value: unknown): string {
+    return typeof value === 'string' ? JSON.stringify(value) : String(value);
 }
 
 // inverse of boundedSlot.
@@ -205,7 +245,7 @@ function kindValue(field: CustomIdField<unknown>, slot: bigint): unknown {
             return (field.choices ?? [])[Number(slot)];
         }
         case 'int': {
-            return Number(slot) + (field.min ?? 0);
+            return Number(slot + BigInt(field.min ?? 0));
         }
         default: {
             throw invalidError(`field kind ${field.kind} is not bounded`);
@@ -229,10 +269,11 @@ function encodeUnboundedToken(field: CustomIdField<unknown>, name: string, value
         return PRESENT + encodeUnboundedToken({ ...field, nullable: false }, name, value);
     }
     if (field.kind === 'int') {
-        if (!Number.isSafeInteger(value)) outOfRange(name, value);
+        if (!Number.isSafeInteger(value)) reject(field, name, value);
         return bigintToBase64(zigzagEncode(value as number));
     }
-    return escapeToken(value as string);
+    if (typeof value !== 'string') return reject(field, name, value);
+    return escapeToken(value);
 }
 function decodeUnboundedToken(field: CustomIdField<unknown>, piece: string): unknown {
     if (field.nullable === true) {
@@ -265,7 +306,8 @@ export function computeLayoutHash(shape: CustomIdShape): string {
     );
     const modulus = BASE ** BigInt(HASH_LENGTH);
     let hash = 0n;
-    for (const char of signature) hash = (hash * 131n + BigInt(char.charCodeAt(0))) % modulus;
+    // js stores an emoji as two halves. reading only the first half hashes 1024 emoji to one value.
+    for (let i = 0; i < signature.length; i++) hash = (hash * 131n + BigInt(signature.charCodeAt(i))) % modulus;
 
     let text = '';
     for (let i = 0; i < HASH_LENGTH; i++) {

--- a/packages/custom-id/src/codec.ts
+++ b/packages/custom-id/src/codec.ts
@@ -1,9 +1,7 @@
 /* eslint-disable no-magic-numbers -- lots of bigints */
 
-import { SeedcordErrorCode } from '@seedcord/errors';
-import { SeedcordRangeError } from '@seedcord/errors/internal';
-
 import { invalidError } from './errors';
+import { bigintToBoundedValue, boundedToBigint, isBounded, radixOf, reject } from './values';
 
 import type { CustomIdField, CustomIdShape } from './Field';
 
@@ -93,171 +91,6 @@ function splitTokens(body: string): string[] {
     return pieces;
 }
 
-// bounded means the full range is known. those fold into the shared packed integer.
-function isBounded(field: CustomIdField<unknown>): boolean {
-    if (field.kind === 'int') return field.min !== undefined && field.max !== undefined;
-    return field.kind === 'snowflake' || field.kind === 'uuid' || field.kind === 'bool' || field.kind === 'oneOf';
-}
-
-// slot 0 is the null on a nullable field. every other value shifts up one.
-function radixOf(field: CustomIdField<unknown>): bigint {
-    return kindRadix(field) + (field.nullable === true ? 1n : 0n);
-}
-
-function kindRadix(field: CustomIdField<unknown>): bigint {
-    switch (field.kind) {
-        case 'snowflake': {
-            return 1n << 64n;
-        }
-        case 'uuid': {
-            return 1n << 128n;
-        }
-        case 'bool': {
-            return 2n;
-        }
-        case 'oneOf': {
-            // oneOf() rejects an empty list at define time, so an empty one here came from a
-            // hand-built shape.
-            if (!field.choices?.length) throw invalidError('oneOf field has no choices');
-            return BigInt(field.choices.length);
-        }
-        case 'int': {
-            // isBounded only lets a min-and-max int through. a missing bound means the shape is corrupt.
-            if (field.min === undefined || field.max === undefined)
-                throw invalidError('bounded int field is missing a bound');
-            // bigint before the math, max - min + 1 in float64 drops the +1 at 2^53.
-            return BigInt(field.max) - BigInt(field.min) + 1n;
-        }
-        default: {
-            throw invalidError(`field kind ${field.kind} has no radix`);
-        }
-    }
-}
-
-function boundedToBigint(field: CustomIdField<unknown>, name: string, value: unknown): bigint {
-    if (field.nullable === true) {
-        if (value === null) return 0n;
-        return boundedToBigint({ ...field, nullable: false }, name, value) + 1n;
-    }
-    const slot = boundedSlot(field, name, value);
-    // out of range would carry into the neighbouring field on decode.
-    if (slot < 0n || slot >= radixOf(field)) reject(field, name, value);
-    return slot;
-}
-
-// a bad value makes BigInt() throw a bare TypeError or SyntaxError. the guard gets ahead of it with
-// the branded error.
-function snowflakeSlot(field: CustomIdField<unknown>, name: string, value: unknown): bigint {
-    if (typeof value !== 'string' || !/^\d+$/.test(value)) return reject(field, name, value);
-    return BigInt(value);
-}
-
-function uuidSlot(field: CustomIdField<unknown>, name: string, value: unknown): bigint {
-    if (typeof value !== 'string') return reject(field, name, value);
-    const hex = value.replaceAll('-', '');
-    if (!/^[0-9a-fA-F]{32}$/.test(hex)) return reject(field, name, value);
-    return BigInt(`0x${hex}`);
-}
-
-// a slot is the value as an integer in [0, radix).
-function boundedSlot(field: CustomIdField<unknown>, name: string, value: unknown): bigint {
-    switch (field.kind) {
-        case 'snowflake': {
-            return snowflakeSlot(field, name, value);
-        }
-        case 'uuid': {
-            return uuidSlot(field, name, value);
-        }
-        case 'bool': {
-            if (typeof value !== 'boolean') return reject(field, name, value);
-            return value ? 1n : 0n;
-        }
-        case 'oneOf': {
-            const index = (field.choices ?? []).indexOf(value as string);
-            return index === -1 ? reject(field, name, value) : BigInt(index);
-        }
-        case 'int': {
-            // eslint-disable-next-line unicorn/prefer-number-is-safe-integer -- a bounded int field may declare max up to 2**53 exactly (a power of two, exact in float64)
-            if (!Number.isInteger(value)) return reject(field, name, value);
-            // a plain js number cannot hold this subtraction once it passes 2^53.
-            return BigInt(value as number) - BigInt(field.min ?? 0);
-        }
-        default: {
-            return reject(field, name, value);
-        }
-    }
-}
-
-function reject(field: CustomIdField<unknown>, name: string, value: unknown): never {
-    throw new SeedcordRangeError(SeedcordErrorCode.CustomIdValueRejected, [name, expectation(field), show(value)]);
-}
-
-// what the field takes, written to finish the sentence "expects ...".
-function expectation(field: CustomIdField<unknown>): string {
-    switch (field.kind) {
-        case 'snowflake': {
-            return 'a snowflake string below 2^64';
-        }
-        case 'uuid': {
-            return 'a uuid string';
-        }
-        case 'bool': {
-            return 'a boolean';
-        }
-        case 'oneOf': {
-            return `one of ${(field.choices ?? []).map((choice) => JSON.stringify(choice)).join(', ')}`;
-        }
-        case 'int': {
-            if (field.min === undefined || field.max === undefined) return 'a safe integer';
-            return `an integer from ${field.min} to ${field.max}`;
-        }
-        default: {
-            return 'a string';
-        }
-    }
-}
-
-// quoting keeps the string 'false' apart from the boolean.
-function show(value: unknown): string {
-    return typeof value === 'string' ? JSON.stringify(value) : String(value);
-}
-
-// inverse of boundedSlot.
-function bigintToBoundedValue(field: CustomIdField<unknown>, slot: bigint): unknown {
-    if (field.nullable === true) {
-        return slot === 0n ? null : bigintToBoundedValue({ ...field, nullable: false }, slot - 1n);
-    }
-    return kindValue(field, slot);
-}
-
-function kindValue(field: CustomIdField<unknown>, slot: bigint): unknown {
-    switch (field.kind) {
-        case 'snowflake': {
-            return slot.toString();
-        }
-        case 'uuid': {
-            return bigintToUuid(slot);
-        }
-        case 'bool': {
-            return slot === 1n;
-        }
-        case 'oneOf': {
-            return (field.choices ?? [])[Number(slot)];
-        }
-        case 'int': {
-            return Number(slot + BigInt(field.min ?? 0));
-        }
-        default: {
-            throw invalidError(`field kind ${field.kind} is not bounded`);
-        }
-    }
-}
-
-function bigintToUuid(value: bigint): string {
-    const hex = value.toString(16).padStart(32, '0');
-    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
-}
-
 // an unbounded field trails as its own token, where an empty string is already a legal str value. a
 // nullable one carries one leading char to tell the two apart.
 const ABSENT = '0';
@@ -300,7 +133,7 @@ export function computeLayoutHash(shape: CustomIdShape): string {
             field.kind,
             isBounded(field),
             field.nullable === true,
-            field.kind === 'oneOf' ? (field.choices ?? []) : null,
+            field.choices ?? null,
             field.kind === 'int' ? [field.min ?? null, field.max ?? null] : null
         ])
     );

--- a/packages/custom-id/src/values.ts
+++ b/packages/custom-id/src/values.ts
@@ -45,7 +45,7 @@ function kindRadix(field: CustomIdField<unknown>): bigint {
         }
         case 'someOf': {
             if (!field.choices?.length) throw invalidError('someOf field has no choices');
-            // one bit per choice, so every subset of n choices gets its own slot.
+            // one bit per choice.
             return 1n << BigInt(field.choices.length);
         }
         case 'int': {
@@ -166,12 +166,14 @@ function listChoices(field: CustomIdField<unknown>): string {
     return (field.choices ?? []).map((choice) => JSON.stringify(choice)).join(', ');
 }
 
-// quoting keeps the string 'false' apart from the boolean.
+// quoting keeps the string 'false' apart from the boolean. JSON.stringify throws on a bigint.
+function quote(value: unknown): string {
+    return typeof value === 'string' ? JSON.stringify(value) : String(value);
+}
+
 function show(value: unknown): string {
-    if (typeof value === 'string') return JSON.stringify(value);
-    // String() over JSON.stringify, which throws on a bigint
-    if (Array.isArray(value)) return `[${value.map((entry) => show(entry)).join(', ')}]`;
-    return String(value);
+    if (Array.isArray(value)) return `[${value.map((entry) => quote(entry)).join(', ')}]`;
+    return quote(value);
 }
 
 // inverse of boundedSlot.
@@ -200,7 +202,11 @@ function kindValue(field: CustomIdField<unknown>, slot: bigint): unknown {
             return (field.choices ?? []).filter((_, index) => ((slot >> BigInt(index)) & 1n) === 1n);
         }
         case 'int': {
-            return Number(slot + BigInt(field.min ?? 0));
+            const value = slot + BigInt(field.min ?? 0);
+            const asNumber = Number(value);
+            // 2^53 is a legal max here. a MAX_SAFE_INTEGER check would reject it.
+            if (BigInt(asNumber) !== value) throw invalidError('bounded integer out of safe range');
+            return asNumber;
         }
         default: {
             throw invalidError(`field kind ${field.kind} is not bounded`);

--- a/packages/custom-id/src/values.ts
+++ b/packages/custom-id/src/values.ts
@@ -1,0 +1,214 @@
+/* eslint-disable no-magic-numbers -- lots of bigints */
+
+import { SeedcordErrorCode } from '@seedcord/errors';
+import { SeedcordRangeError } from '@seedcord/errors/internal';
+
+import { invalidError } from './errors';
+
+import type { CustomIdField } from './Field';
+
+// one field's runtime value as a number and back. codec.ts turns those numbers into the wire string.
+
+// bounded means the full range is known. those fold into the shared packed integer.
+export function isBounded(field: CustomIdField<unknown>): boolean {
+    if (field.kind === 'int') return field.min !== undefined && field.max !== undefined;
+    return (
+        field.kind === 'snowflake' ||
+        field.kind === 'uuid' ||
+        field.kind === 'bool' ||
+        field.kind === 'oneOf' ||
+        field.kind === 'someOf'
+    );
+}
+
+// slot 0 is the null on a nullable field. every other value shifts up one.
+export function radixOf(field: CustomIdField<unknown>): bigint {
+    return kindRadix(field) + (field.nullable === true ? 1n : 0n);
+}
+
+function kindRadix(field: CustomIdField<unknown>): bigint {
+    switch (field.kind) {
+        case 'snowflake': {
+            return 1n << 64n;
+        }
+        case 'uuid': {
+            return 1n << 128n;
+        }
+        case 'bool': {
+            return 2n;
+        }
+        case 'oneOf': {
+            // oneOf() rejects an empty list at define time, so an empty one here came from a
+            // hand-built shape.
+            if (!field.choices?.length) throw invalidError('oneOf field has no choices');
+            return BigInt(field.choices.length);
+        }
+        case 'someOf': {
+            if (!field.choices?.length) throw invalidError('someOf field has no choices');
+            // one bit per choice, so every subset of n choices gets its own slot.
+            return 1n << BigInt(field.choices.length);
+        }
+        case 'int': {
+            // isBounded only lets a min-and-max int through. a missing bound means the shape is corrupt.
+            if (field.min === undefined || field.max === undefined)
+                throw invalidError('bounded int field is missing a bound');
+            // bigint before the math, max - min + 1 in float64 drops the +1 at 2^53.
+            return BigInt(field.max) - BigInt(field.min) + 1n;
+        }
+        default: {
+            throw invalidError(`field kind ${field.kind} has no radix`);
+        }
+    }
+}
+
+export function boundedToBigint(field: CustomIdField<unknown>, name: string, value: unknown): bigint {
+    if (field.nullable === true) {
+        if (value === null) return 0n;
+        return boundedToBigint({ ...field, nullable: false }, name, value) + 1n;
+    }
+    const slot = boundedSlot(field, name, value);
+    // out of range would carry into the neighbouring field on decode.
+    if (slot < 0n || slot >= radixOf(field)) reject(field, name, value);
+    return slot;
+}
+
+// a bad value makes BigInt() throw a bare TypeError or SyntaxError. the guard gets ahead of it with
+// the branded error.
+function snowflakeSlot(field: CustomIdField<unknown>, name: string, value: unknown): bigint {
+    if (typeof value !== 'string' || !/^\d+$/.test(value)) return reject(field, name, value);
+    return BigInt(value);
+}
+
+function uuidSlot(field: CustomIdField<unknown>, name: string, value: unknown): bigint {
+    if (typeof value !== 'string') return reject(field, name, value);
+    const hex = value.replaceAll('-', '');
+    if (!/^[0-9a-fA-F]{32}$/.test(hex)) return reject(field, name, value);
+    return BigInt(`0x${hex}`);
+}
+
+function someOfSlot(field: CustomIdField<unknown>, name: string, value: unknown): bigint {
+    if (!Array.isArray(value)) return reject(field, name, value);
+    const choices = field.choices ?? [];
+    let mask = 0n;
+    for (const picked of value) {
+        const index = choices.indexOf(picked as string);
+        if (index === -1) return reject(field, name, value);
+        mask |= 1n << BigInt(index);
+    }
+    return mask;
+}
+
+// a slot is the value as an integer in [0, radix).
+function boundedSlot(field: CustomIdField<unknown>, name: string, value: unknown): bigint {
+    switch (field.kind) {
+        case 'snowflake': {
+            return snowflakeSlot(field, name, value);
+        }
+        case 'uuid': {
+            return uuidSlot(field, name, value);
+        }
+        case 'bool': {
+            if (typeof value !== 'boolean') return reject(field, name, value);
+            return value ? 1n : 0n;
+        }
+        case 'oneOf': {
+            const index = (field.choices ?? []).indexOf(value as string);
+            return index === -1 ? reject(field, name, value) : BigInt(index);
+        }
+        case 'someOf': {
+            return someOfSlot(field, name, value);
+        }
+        case 'int': {
+            // eslint-disable-next-line unicorn/prefer-number-is-safe-integer -- a bounded int field may declare max up to 2**53 exactly (a power of two, exact in float64)
+            if (!Number.isInteger(value)) return reject(field, name, value);
+            // a plain js number cannot hold this subtraction once it passes 2^53.
+            return BigInt(value as number) - BigInt(field.min ?? 0);
+        }
+        default: {
+            return reject(field, name, value);
+        }
+    }
+}
+
+export function reject(field: CustomIdField<unknown>, name: string, value: unknown): never {
+    throw new SeedcordRangeError(SeedcordErrorCode.CustomIdValueRejected, [name, expectation(field), show(value)]);
+}
+
+// what the field takes, written to finish the sentence "expects ...".
+function expectation(field: CustomIdField<unknown>): string {
+    switch (field.kind) {
+        case 'snowflake': {
+            return 'a snowflake string below 2^64';
+        }
+        case 'uuid': {
+            return 'a uuid string';
+        }
+        case 'bool': {
+            return 'a boolean';
+        }
+        case 'oneOf': {
+            return `one of ${listChoices(field)}`;
+        }
+        case 'someOf': {
+            return `an array of values from ${listChoices(field)}`;
+        }
+        case 'int': {
+            if (field.min === undefined || field.max === undefined) return 'a safe integer';
+            return `an integer from ${field.min} to ${field.max}`;
+        }
+        default: {
+            return 'a string';
+        }
+    }
+}
+
+function listChoices(field: CustomIdField<unknown>): string {
+    return (field.choices ?? []).map((choice) => JSON.stringify(choice)).join(', ');
+}
+
+// quoting keeps the string 'false' apart from the boolean.
+function show(value: unknown): string {
+    if (typeof value === 'string') return JSON.stringify(value);
+    // String() over JSON.stringify, which throws on a bigint
+    if (Array.isArray(value)) return `[${value.map((entry) => show(entry)).join(', ')}]`;
+    return String(value);
+}
+
+// inverse of boundedSlot.
+export function bigintToBoundedValue(field: CustomIdField<unknown>, slot: bigint): unknown {
+    if (field.nullable === true) {
+        return slot === 0n ? null : bigintToBoundedValue({ ...field, nullable: false }, slot - 1n);
+    }
+    return kindValue(field, slot);
+}
+
+function kindValue(field: CustomIdField<unknown>, slot: bigint): unknown {
+    switch (field.kind) {
+        case 'snowflake': {
+            return slot.toString();
+        }
+        case 'uuid': {
+            return bigintToUuid(slot);
+        }
+        case 'bool': {
+            return slot === 1n;
+        }
+        case 'oneOf': {
+            return (field.choices ?? [])[Number(slot)];
+        }
+        case 'someOf': {
+            return (field.choices ?? []).filter((_, index) => ((slot >> BigInt(index)) & 1n) === 1n);
+        }
+        case 'int': {
+            return Number(slot + BigInt(field.min ?? 0));
+        }
+        default: {
+            throw invalidError(`field kind ${field.kind} is not bounded`);
+        }
+    }
+}
+
+function bigintToUuid(value: bigint): string {
+    const hex = value.toString(16).padStart(32, '0');
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}

--- a/packages/custom-id/tests/codec.test.ts
+++ b/packages/custom-id/tests/codec.test.ts
@@ -15,6 +15,15 @@ function thrownCode(run: () => unknown): SeedcordErrorCode | undefined {
     return undefined;
 }
 
+function thrownMessage(run: () => unknown): string {
+    try {
+        run();
+    } catch (error) {
+        return (error as Error).message; // fixture cast, read the message off whatever was thrown
+    }
+    return '';
+}
+
 describe('nullable fields', () => {
     it('round-trips null and a value for every kind', () => {
         const Every = new CustomId('every')
@@ -83,7 +92,7 @@ describe('nullable fields', () => {
                     userId: null
                 })
             )
-        ).toBe(SeedcordErrorCode.CustomIdValueOutOfRange);
+        ).toBe(SeedcordErrorCode.CustomIdValueRejected);
     });
 });
 
@@ -132,6 +141,17 @@ describe('CustomId round-trips', () => {
         expect(Big.decode(Big.encode({ n: 2 ** 53 })).n).toBe(2 ** 53);
     });
 
+    it('round-trips a bounded int whose slot lands past 2^53', () => {
+        // a negative min pushes the stored number past 2^53, where js numbers start skipping.
+        const Big = new CustomId('big').int('n', -2, Number.MAX_SAFE_INTEGER);
+        expect(Big.decode(Big.encode({ n: Number.MAX_SAFE_INTEGER })).n).toBe(Number.MAX_SAFE_INTEGER);
+    });
+
+    it('gives two bounded ints past 2^53 two different wires', () => {
+        const Big = new CustomId('big').int('n', -2, Number.MAX_SAFE_INTEGER);
+        expect(Big.encode({ n: Number.MAX_SAFE_INTEGER })).not.toBe(Big.encode({ n: Number.MAX_SAFE_INTEGER - 1 }));
+    });
+
     it('round-trips a customId with no fields', () => {
         const Refresh = new CustomId('refresh');
         expect(Refresh.decode(Refresh.encode({}))).toEqual({});
@@ -162,6 +182,20 @@ describe('CustomId stale detection', () => {
         const v1 = new CustomId('page').int('index');
         const v2 = new CustomId('page').int('index', 0, 100);
         expect(thrownCode(() => v2.decode(v1.encode({ index: 3 })))).toBe(SeedcordErrorCode.CustomIdWireStale);
+    });
+
+    it('flags a swapped emoji oneOf as stale', () => {
+        const v1 = new CustomId('react').oneOf('emoji', ['\u{1F44D}', '\u{1F44E}']);
+        const v2 = new CustomId('react').oneOf('emoji', ['\u{1F44F}', '\u{1F440}']);
+        expect(thrownCode(() => v2.decode(v1.encode({ emoji: '\u{1F44E}' })))).toBe(
+            SeedcordErrorCode.CustomIdWireStale
+        );
+    });
+
+    it('hashes two emoji from one surrogate block apart', () => {
+        const grin = new CustomId('e').oneOf('c', ['\u{1F600}']);
+        const beam = new CustomId('e').oneOf('c', ['\u{1F601}']);
+        expect(grin.routeKey).not.toBe(beam.routeKey);
     });
 });
 
@@ -208,20 +242,20 @@ describe('CustomId corruption is rejected', () => {
 describe('CustomId encode guards', () => {
     it('rejects a bounded int outside its range', () => {
         const Page = new CustomId('page').int('index', 0, 7);
-        expect(thrownCode(() => Page.encode({ index: 50 }))).toBe(SeedcordErrorCode.CustomIdValueOutOfRange);
+        expect(thrownCode(() => Page.encode({ index: 50 }))).toBe(SeedcordErrorCode.CustomIdValueRejected);
     });
 
     it('rejects a snowflake at or above 2^64', () => {
         const Ban = new CustomId('ban').snowflake('userId');
         expect(thrownCode(() => Ban.encode({ userId: (1n << 64n).toString() }))).toBe(
-            SeedcordErrorCode.CustomIdValueOutOfRange
+            SeedcordErrorCode.CustomIdValueRejected
         );
     });
 
     it('rejects a snowflake that is not a numeric string', () => {
         const Ban = new CustomId('ban').snowflake('userId');
         expect(thrownCode(() => Ban.encode({ userId: 'not-a-snowflake' }))).toBe(
-            SeedcordErrorCode.CustomIdValueOutOfRange
+            SeedcordErrorCode.CustomIdValueRejected
         );
     });
 
@@ -234,7 +268,98 @@ describe('CustomId encode guards', () => {
 
     it('rejects an unbounded int beyond the safe-integer range at encode time', () => {
         const Counter = new CustomId('counter').int('total');
-        expect(thrownCode(() => Counter.encode({ total: 2 ** 53 }))).toBe(SeedcordErrorCode.CustomIdValueOutOfRange);
+        expect(thrownCode(() => Counter.encode({ total: 2 ** 53 }))).toBe(SeedcordErrorCode.CustomIdValueRejected);
+    });
+
+    it('rejects a str that is not a string', () => {
+        const Note = new CustomId('note').str('body');
+        expect(
+            thrownCode(() =>
+                Note.encode({
+                    // @ts-expect-error a str field rejects a number at compile time and at runtime
+                    body: 42
+                })
+            )
+        ).toBe(SeedcordErrorCode.CustomIdValueRejected);
+    });
+
+    it('rejects null on a non-nullable str', () => {
+        const Note = new CustomId('note').str('body');
+        expect(
+            thrownCode(() =>
+                Note.encode({
+                    // @ts-expect-error a non-nullable field rejects null at compile time and at runtime
+                    body: null
+                })
+            )
+        ).toBe(SeedcordErrorCode.CustomIdValueRejected);
+    });
+
+    it('rejects null on a non-nullable bool', () => {
+        const Flag = new CustomId('flag').bool('silent');
+        expect(
+            thrownCode(() =>
+                Flag.encode({
+                    // @ts-expect-error a non-nullable field rejects null at compile time and at runtime
+                    silent: null
+                })
+            )
+        ).toBe(SeedcordErrorCode.CustomIdValueRejected);
+    });
+
+    it('rejects a bool that is not a boolean', () => {
+        const Flag = new CustomId('flag').bool('silent');
+        expect(
+            thrownCode(() =>
+                Flag.encode({
+                    // @ts-expect-error a bool field rejects a string at compile time and at runtime
+                    silent: 'false'
+                })
+            )
+        ).toBe(SeedcordErrorCode.CustomIdValueRejected);
+    });
+});
+
+describe('CustomId rejection messages', () => {
+    it('names the type a bool expects and quotes the string it got', () => {
+        const Flag = new CustomId('flag').bool('silent');
+        const message = thrownMessage(() =>
+            Flag.encode({
+                // @ts-expect-error a bool field rejects a string at compile time and at runtime
+                silent: 'false'
+            })
+        );
+        expect(message).toContain('expects a boolean');
+        expect(message).toContain('"false"');
+    });
+
+    it('names the declared bounds an int expects', () => {
+        const Page = new CustomId('page').int('index', 0, 7);
+        expect(thrownMessage(() => Page.encode({ index: 50 }))).toContain('expects an integer from 0 to 7');
+    });
+
+    it('names the choices a oneOf expects', () => {
+        const Poll = new CustomId('poll').oneOf('choice', ['yes', 'no']);
+        expect(
+            thrownMessage(() =>
+                Poll.encode({
+                    // @ts-expect-error a oneOf field rejects an unlisted value at compile time and at runtime
+                    choice: 'maybe'
+                })
+            )
+        ).toContain('expects one of "yes", "no"');
+    });
+
+    it('names what a str expects', () => {
+        const Note = new CustomId('note').str('body');
+        expect(
+            thrownMessage(() =>
+                Note.encode({
+                    // @ts-expect-error a str field rejects a number at compile time and at runtime
+                    body: 42
+                })
+            )
+        ).toContain('expects a string');
     });
 });
 

--- a/packages/custom-id/tests/codec.test.ts
+++ b/packages/custom-id/tests/codec.test.ts
@@ -244,6 +244,20 @@ describe('someOf fields', () => {
             )
         ).toBe(SeedcordErrorCode.CustomIdValueRejected);
     });
+
+    it('rejects an array that holds itself', () => {
+        // formatting the value for the message must not follow the cycle.
+        const cyclic: unknown[] = [];
+        cyclic.push(cyclic);
+        expect(
+            thrownCode(() =>
+                Assign.encode({
+                    // @ts-expect-error a someOf field rejects a nested array at compile time and at runtime
+                    roles: cyclic
+                })
+            )
+        ).toBe(SeedcordErrorCode.CustomIdValueRejected);
+    });
 });
 
 describe('CustomId stale detection', () => {
@@ -299,7 +313,7 @@ describe('CustomId stale detection', () => {
 });
 
 describe('routeKey stability', () => {
-    // the guide prints these in components/custom-ids.mdx and components/stale.mdx. a hash change edits both.
+    // the guide prints these in components/custom-ids.mdx and components/stale.mdx. changing the hash edits both.
     const Ticket = new CustomId('ticket').snowflake('ownerId').oneOf('action', ['close', 'reopen']);
 
     it('pins the routeKeys the guide documents', () => {
@@ -348,6 +362,14 @@ describe('CustomId corruption is rejected', () => {
         expect(thrownCode(() => Counter.decode(`${Counter.routeKey}:${oversized}`))).toBe(
             SeedcordErrorCode.CustomIdWireInvalid
         );
+    });
+
+    it('rejects a bounded int wire past what a js number holds', () => {
+        // 2^53 + 1 sits inside the declared range, and no js number holds it exactly.
+        const Ban = new CustomId('ban').snowflake('userId');
+        const body = Ban.encode({ userId: (2n ** 53n + 1n).toString() }).split(':')[1] ?? '';
+        const Big = new CustomId('big').int('v', 0, 2 ** 60);
+        expect(thrownCode(() => Big.decode(`${Big.routeKey}:${body}`))).toBe(SeedcordErrorCode.CustomIdWireInvalid);
     });
 
     it('rejects a packed block with leftover bits after unpacking', () => {
@@ -506,6 +528,19 @@ describe('CustomId definition guards', () => {
         expect(thrownCode(() => new CustomId('poll').oneOf('choice', empty))).toBe(
             SeedcordErrorCode.CustomIdEmptyChoices
         );
+    });
+
+    it('rejects a someOf with no choices', () => {
+        const empty = [] as unknown as [string]; // fixture cast, bypass NonEmptyTuple to reach the runtime guard
+        expect(thrownCode(() => new CustomId('assign').someOf('roles', empty))).toBe(
+            SeedcordErrorCode.CustomIdEmptyChoices
+        );
+    });
+
+    it('names the method that was called with no choices', () => {
+        const empty = [] as unknown as [string]; // fixture cast, bypass NonEmptyTuple to reach the runtime guard
+        expect(thrownMessage(() => new CustomId('assign').someOf('roles', empty))).toContain('someOf()');
+        expect(thrownMessage(() => new CustomId('poll').oneOf('choice', empty))).toContain('oneOf()');
     });
 
     it('rejects an int with min over max', () => {

--- a/packages/custom-id/tests/codec.test.ts
+++ b/packages/custom-id/tests/codec.test.ts
@@ -298,6 +298,25 @@ describe('CustomId stale detection', () => {
     });
 });
 
+describe('routeKey stability', () => {
+    // the guide prints these in components/custom-ids.mdx and components/stale.mdx. a hash change edits both.
+    const Ticket = new CustomId('ticket').snowflake('ownerId').oneOf('action', ['close', 'reopen']);
+
+    it('pins the routeKeys the guide documents', () => {
+        expect(Ticket.routeKey).toBe('ticketVrl');
+        expect(new CustomId('ticket').snowflake('userId').oneOf('action', ['close', 'reopen']).routeKey).toBe(
+            'ticketbdx'
+        );
+        expect(
+            new CustomId('ticket').snowflake('ownerId').oneOf('action', ['close', 'reopen', 'escalate']).routeKey
+        ).toBe('ticketY1t');
+        expect(new CustomId('ticket').oneOf('action', ['close', 'reopen']).snowflake('ownerId').routeKey).toBe(
+            'ticketpXF'
+        );
+        expect(Ticket.bool('notify').routeKey).toBe('ticketuFh');
+    });
+});
+
 describe('CustomId corruption is rejected', () => {
     it('rejects an appended junk piece', () => {
         const Tag = new CustomId('tag').str('label');

--- a/packages/custom-id/tests/codec.test.ts
+++ b/packages/custom-id/tests/codec.test.ts
@@ -171,6 +171,81 @@ describe('CustomId round-trips', () => {
     });
 });
 
+describe('someOf fields', () => {
+    // a self-assign role menu, where the confirm button carries what the member picked.
+    const ROLES = ['reader', 'artist', 'streamer', 'events', 'vip'] as const;
+    const Assign = new CustomId('assign').someOf('roles', ROLES);
+
+    it('round-trips a subset', () => {
+        expect(Assign.decode(Assign.encode({ roles: ['artist', 'events'] })).roles).toEqual(['artist', 'events']);
+    });
+
+    it('collapses a repeated choice into one entry', () => {
+        expect(Assign.decode(Assign.encode({ roles: ['artist', 'events', 'artist', 'events'] })).roles).toEqual([
+            'artist',
+            'events'
+        ]);
+    });
+
+    it('round-trips the empty set', () => {
+        expect(Assign.decode(Assign.encode({ roles: [] })).roles).toEqual([]);
+    });
+
+    it('round-trips every choice at once', () => {
+        expect(Assign.decode(Assign.encode({ roles: [...ROLES] })).roles).toEqual([...ROLES]);
+    });
+
+    it('returns the choices in declaration order', () => {
+        expect(Assign.decode(Assign.encode({ roles: ['vip', 'reader', 'events'] })).roles).toEqual([
+            'reader',
+            'events',
+            'vip'
+        ]);
+    });
+
+    it('mints one wire for the same set in either order', () => {
+        expect(Assign.encode({ roles: ['streamer', 'reader'] })).toBe(Assign.encode({ roles: ['reader', 'streamer'] }));
+    });
+
+    it('spends one bit per choice', () => {
+        // five choices pack into a radix-32 slot, which is one base64 character.
+        const body = Assign.encode({ roles: [...ROLES] }).split(':')[1];
+        expect(body).toHaveLength(1);
+    });
+
+    it('keeps null apart from the empty set when nullable', () => {
+        const Optional = new CustomId('assign').someOf('roles', ROLES, { nullable: true });
+        expect(Optional.decode(Optional.encode({ roles: [] })).roles).toEqual([]);
+        expect(Optional.decode(Optional.encode({ roles: null })).roles).toBeNull();
+    });
+
+    it('mints one wire whether a choice repeats or not', () => {
+        expect(Assign.encode({ roles: ['vip', 'vip'] })).toBe(Assign.encode({ roles: ['vip'] }));
+    });
+
+    it('rejects a choice that is not on the list', () => {
+        expect(
+            thrownCode(() =>
+                Assign.encode({
+                    // @ts-expect-error a someOf field rejects an unlisted value at compile time and at runtime
+                    roles: ['reader', 'admin']
+                })
+            )
+        ).toBe(SeedcordErrorCode.CustomIdValueRejected);
+    });
+
+    it('rejects a value that is not an array', () => {
+        expect(
+            thrownCode(() =>
+                Assign.encode({
+                    // @ts-expect-error a someOf field rejects a bare string at compile time and at runtime
+                    roles: 'reader'
+                })
+            )
+        ).toBe(SeedcordErrorCode.CustomIdValueRejected);
+    });
+});
+
 describe('CustomId stale detection', () => {
     it('flags a reordered oneOf as stale', () => {
         const v1 = new CustomId('poll').oneOf('choice', ['yes', 'no']);
@@ -184,6 +259,30 @@ describe('CustomId stale detection', () => {
         expect(thrownCode(() => v2.decode(v1.encode({ index: 3 })))).toBe(SeedcordErrorCode.CustomIdWireStale);
     });
 
+    it('flags a someOf that gained a choice as stale', () => {
+        const v1 = new CustomId('assign').someOf('roles', ['reader', 'artist']);
+        const v2 = new CustomId('assign').someOf('roles', ['reader', 'artist', 'vip']);
+        expect(thrownCode(() => v2.decode(v1.encode({ roles: ['artist'] })))).toBe(SeedcordErrorCode.CustomIdWireStale);
+    });
+
+    it('flags a reordered someOf as stale', () => {
+        const v1 = new CustomId('assign').someOf('roles', ['reader', 'artist']);
+        const v2 = new CustomId('assign').someOf('roles', ['artist', 'reader']);
+        expect(thrownCode(() => v2.decode(v1.encode({ roles: ['artist'] })))).toBe(SeedcordErrorCode.CustomIdWireStale);
+    });
+
+    it('flags a someOf that lost a choice as stale', () => {
+        const v1 = new CustomId('assign').someOf('roles', ['reader', 'artist', 'vip']);
+        const v2 = new CustomId('assign').someOf('roles', ['reader', 'artist']);
+        expect(thrownCode(() => v2.decode(v1.encode({ roles: ['reader'] })))).toBe(SeedcordErrorCode.CustomIdWireStale);
+    });
+
+    it('flags a oneOf swapped for a someOf as stale', () => {
+        const v1 = new CustomId('assign').oneOf('roles', ['reader', 'artist']);
+        const v2 = new CustomId('assign').someOf('roles', ['reader', 'artist']);
+        expect(thrownCode(() => v2.decode(v1.encode({ roles: 'artist' })))).toBe(SeedcordErrorCode.CustomIdWireStale);
+    });
+
     it('flags a swapped emoji oneOf as stale', () => {
         const v1 = new CustomId('react').oneOf('emoji', ['\u{1F44D}', '\u{1F44E}']);
         const v2 = new CustomId('react').oneOf('emoji', ['\u{1F44F}', '\u{1F440}']);
@@ -193,8 +292,8 @@ describe('CustomId stale detection', () => {
     });
 
     it('hashes two emoji from one surrogate block apart', () => {
-        const grin = new CustomId('e').oneOf('c', ['\u{1F600}']);
-        const beam = new CustomId('e').oneOf('c', ['\u{1F601}']);
+        const grin = new CustomId('react').oneOf('emoji', ['\u{1F600}']);
+        const beam = new CustomId('react').oneOf('emoji', ['\u{1F601}']);
         expect(grin.routeKey).not.toBe(beam.routeKey);
     });
 });

--- a/packages/custom-id/tests/nullable.types-test.ts
+++ b/packages/custom-id/tests/nullable.types-test.ts
@@ -42,3 +42,30 @@ Plain.encode({
     // @ts-expect-error null reaches encode only on a nullable field
     userId: null
 });
+
+const Assign = new CustomId('assign').someOf('roles', ['reader', 'artist', 'vip']);
+type AssignParams = ReturnType<typeof Assign.decode>;
+
+const picked: AssignParams['roles'] = ['reader', 'vip'];
+void picked;
+
+// @ts-expect-error someOf decodes to an array of the literal union
+const unlisted: AssignParams['roles'] = ['admin'];
+void unlisted;
+
+// @ts-expect-error a someOf with no options stays non-null
+const rolesAreNotNullable: AssignParams['roles'] = null;
+void rolesAreNotNullable;
+
+const Optional = new CustomId('optional').someOf('roles', ['reader', 'artist'], { nullable: true });
+type OptionalParams = ReturnType<typeof Optional.decode>;
+
+const noRoles: OptionalParams['roles'] = null;
+void noRoles;
+
+Optional.encode({ roles: null });
+
+Assign.encode({
+    // @ts-expect-error an unlisted choice never reaches encode
+    roles: ['admin']
+});

--- a/packages/errors/src/ErrorCodes.ts
+++ b/packages/errors/src/ErrorCodes.ts
@@ -106,8 +106,8 @@ export enum SeedcordErrorCode {
     CustomIdEmptyChoices = 1603,
     /** An int() field was declared with min greater than max. */
     CustomIdInvalidBounds = 1604,
-    /** A value passed to encode() is outside its field's allowed range. */
-    CustomIdValueOutOfRange = 1605,
+    /** A value passed to encode() is not one its field can hold. */
+    CustomIdValueRejected = 1605,
     /** An encoded customId exceeds Discord's 100-character limit. */
     CustomIdWireTooLong = 1606,
     /** A field name is declared more than once in the same customId chain. */

--- a/packages/errors/src/ErrorCodes.ts
+++ b/packages/errors/src/ErrorCodes.ts
@@ -102,11 +102,11 @@ export enum SeedcordErrorCode {
     CustomIdInvalidPrefix = 1601,
     /** A customId field name is integer-like, which JS would silently reorder. */
     CustomIdReservedFieldName = 1602,
-    /** A oneOf() field was declared with no choices. */
+    /** A oneOf() or someOf() field was declared with no choices. */
     CustomIdEmptyChoices = 1603,
     /** An int() field was declared with min greater than max. */
     CustomIdInvalidBounds = 1604,
-    /** A value passed to encode() is not one its field can hold. */
+    /** A field rejected the value given to encode(). */
     CustomIdValueRejected = 1605,
     /** An encoded customId exceeds Discord's 100-character limit. */
     CustomIdWireTooLong = 1606,

--- a/packages/errors/src/ErrorMessages.ts
+++ b/packages/errors/src/ErrorMessages.ts
@@ -100,8 +100,8 @@ const messages = {
         `customId prefix ${JSON.stringify(prefix)} must be a non-empty string without a colon or control character.`,
     [SeedcordErrorCode.CustomIdReservedFieldName]: (field: string) =>
         `customId field name ${JSON.stringify(field)} is integer-like, which JS reorders. Use a non-numeric name.`,
-    [SeedcordErrorCode.CustomIdEmptyChoices]: (field: string) =>
-        `customId field ${JSON.stringify(field)} uses oneOf() with no choices.`,
+    [SeedcordErrorCode.CustomIdEmptyChoices]: (field: string, method: string) =>
+        `customId field ${JSON.stringify(field)} uses ${method}() with no choices. Make the field nullable or provide at least one choice.`,
     [SeedcordErrorCode.CustomIdInvalidBounds]: (field: string, min: number, max: number) =>
         `customId field ${JSON.stringify(field)} has min ${min} greater than max ${max}.`,
     [SeedcordErrorCode.CustomIdValueRejected]: (field: string, expected: string, value: string) =>

--- a/packages/errors/src/ErrorMessages.ts
+++ b/packages/errors/src/ErrorMessages.ts
@@ -104,8 +104,8 @@ const messages = {
         `customId field ${JSON.stringify(field)} uses oneOf() with no choices.`,
     [SeedcordErrorCode.CustomIdInvalidBounds]: (field: string, min: number, max: number) =>
         `customId field ${JSON.stringify(field)} has min ${min} greater than max ${max}.`,
-    [SeedcordErrorCode.CustomIdValueOutOfRange]: (field: string, value: string) =>
-        `customId field ${JSON.stringify(field)} got value ${value} outside its allowed range.`,
+    [SeedcordErrorCode.CustomIdValueRejected]: (field: string, expected: string, value: string) =>
+        `customId field ${JSON.stringify(field)} expects ${expected}, got ${value}.`,
     [SeedcordErrorCode.CustomIdWireTooLong]: (length: number) =>
         `Encoded customId is ${length} characters, Discord allows at most 100.`,
     [SeedcordErrorCode.CustomIdDuplicateFieldName]: (field: string) =>


### PR DESCRIPTION
## What and why

Closes #304

## Checklist

- [x] Tests cover the change
- [x] `pnpm prePush` is green
- [x] Changeset added with `pnpm cs`, for any change to a published package


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `someOf` custom ID fields for encoding any subset of predefined choices.
  - Subset values decode in declaration order, with optional nullable support.

- **Bug Fixes**
  - Preserved integer precision beyond the 2⁵³ boundary.
  - Improved shape hashing for emoji and choice-based fields.
  - Strengthened boolean and string validation with clearer rejection messages.

- **Breaking Changes**
  - Renamed the `CustomIdValueOutOfRange` error code to `CustomIdValueRejected`.

- **Documentation**
  - Updated Custom ID guides and README examples to document `someOf` and revised hash examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->