### PR TITLE
fix: settleWithin swallows a rejection from its work

### DIFF
--- a/.changeset/olive-moons-repeat.md
+++ b/.changeset/olive-moons-repeat.md
@@ -1,0 +1,6 @@
+---
+'@seedcord/core': patch
+---
+
+- Fixed the wait that bounds a shutdown step. The shutdown now continues past a failing step.
+- Fixed a lifecycle task or plugin hook that throws before returning a promise. The throw now rejects the returned promise.

--- a/cli/seedcord/src/commands/dev/tunnel/TunnelCoordinator.ts
+++ b/cli/seedcord/src/commands/dev/tunnel/TunnelCoordinator.ts
@@ -101,7 +101,6 @@ export class TunnelCoordinator {
         try {
             await this.deps.endpoint.clear();
         } catch (error: unknown) {
-            // a failed clear must not reject the quit path
             this.deps.logger.warn('Could not clear the interactions endpoint', error);
         }
     }

--- a/packages/core/src/node/Lifecycle/withTimeout.ts
+++ b/packages/core/src/node/Lifecycle/withTimeout.ts
@@ -1,15 +1,16 @@
 import { SeedcordErrorCode } from '@seedcord/errors';
 import { SeedcordError } from '@seedcord/errors/internal';
 
+// calling start() in here turns its synchronous throw into a rejection.
 async function raceTimer(
-    work: Promise<unknown>,
+    start: () => Promise<unknown>,
     timeoutMs: number,
     onTimeout: (resolve: () => void, reject: (error: unknown) => void) => void
 ): Promise<void> {
     let timer: NodeJS.Timeout | undefined;
     try {
         await Promise.race([
-            work,
+            start(),
             new Promise<void>((resolve, reject) => {
                 timer = setTimeout(() => onTimeout(resolve, reject), timeoutMs);
             })
@@ -21,12 +22,20 @@ async function raceTimer(
 
 // rejects with a LifecycleTaskTimeout when run outlasts the bound
 export function withTimeout(name: string, run: () => Promise<void>, timeoutMs: number): Promise<void> {
-    return raceTimer(run(), timeoutMs, (_, reject) => {
+    return raceTimer(run, timeoutMs, (_, reject) => {
         reject(new SeedcordError(SeedcordErrorCode.LifecycleTaskTimeout, [name, timeoutMs]));
     });
 }
 
-// resolves when work settles or the bound elapses, whichever is first
+// resolves when work settles or the bound elapses. a rejection resolves too.
 export function settleWithin(work: Promise<unknown>, timeoutMs: number): Promise<void> {
-    return raceTimer(work, timeoutMs, (resolve) => resolve());
+    return raceTimer(
+        () =>
+            work.then(
+                () => undefined,
+                () => undefined
+            ),
+        timeoutMs,
+        (resolve) => resolve()
+    );
 }

--- a/packages/core/tests/node/lifecycle/settle-within.test.ts
+++ b/packages/core/tests/node/lifecycle/settle-within.test.ts
@@ -1,0 +1,46 @@
+import { SeedcordErrorCode, isSeedcordError } from '@seedcord/errors';
+import { describe, it, expect } from 'vitest';
+
+import { settleWithin, withTimeout } from '#node/Lifecycle/withTimeout';
+
+const BOUND_MS = 500;
+const SHORT_MS = 5;
+
+const never = (): Promise<void> => new Promise<void>(() => undefined);
+const after = (ms: number): Promise<void> => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+describe('settleWithin', () => {
+    it('resolves once the work resolves', async () => {
+        await expect(settleWithin(after(SHORT_MS), BOUND_MS)).resolves.toBeUndefined();
+    });
+
+    it('resolves once the bound elapses', async () => {
+        await expect(settleWithin(never(), SHORT_MS)).resolves.toBeUndefined();
+    });
+
+    it('resolves when the work rejects', async () => {
+        // callers bound a shutdown step with this. a failed step must leave the shutdown running.
+        await expect(settleWithin(Promise.reject(new Error('clear failed')), BOUND_MS)).resolves.toBeUndefined();
+    });
+});
+
+describe('withTimeout', () => {
+    it('rejects with the timeout code once the bound elapses', async () => {
+        const caught: unknown = await withTimeout('slow task', never, SHORT_MS).catch((error: unknown) => error);
+        expect(isSeedcordError(caught) ? caught.code : undefined).toBe(SeedcordErrorCode.LifecycleTaskTimeout);
+    });
+
+    it('rejects with the error the work threw', async () => {
+        const boom = new Error('init failed');
+        await expect(withTimeout('failing task', () => Promise.reject(boom), BOUND_MS)).rejects.toBe(boom);
+    });
+
+    it('rejects when run throws before it returns a promise', async () => {
+        // a plugin can write dispose() without async. the throw has to reach the caller's catch.
+        const boom = new Error('sync throw');
+        const run = (): Promise<void> => {
+            throw boom;
+        };
+        await expect(withTimeout('sync task', run, BOUND_MS)).rejects.toBe(boom);
+    });
+});


### PR DESCRIPTION
## Checklist

- [x] Tests cover the change
- [x] `pnpm prePush` is green
- [x] Changeset added with `pnpm cs`, for any change to a published package


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lifecycle timeout handling for tasks that fail immediately or throw before returning a promise.
  * Shutdown processes can now continue when an individual step fails or exceeds its time limit, while timeout failures remain properly reported where applicable.

* **Tests**
  * Added coverage for successful completion, timeouts, rejected tasks, and synchronous errors during lifecycle operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->