### PR TITLE
feat: consistent dispatch identity

### DIFF
--- a/.changeset/dispatch-id.md
+++ b/.changeset/dispatch-id.md
@@ -1,0 +1,8 @@
+---
+'@seedcord/core': minor
+'@seedcord/gateway': minor
+'@seedcord/http': minor
+'@seedcord/types': minor
+---
+
+Added `dispatchId` to every bus key a dispatch publishes, and `dispatch.id` to the bag behind it. A fault used to carry no way back to the dispatch that raised it, so pairing one with its `interactionDispatched` meant guessing from the route and the clock. Key a store on it to line up a dispatch, its writes, and its faults.

--- a/.changeset/event-dispatched-key.md
+++ b/.changeset/event-dispatched-key.md
@@ -1,0 +1,6 @@
+---
+'@seedcord/gateway': minor
+'@seedcord/core': minor
+---
+
+Added `eventDispatched`, which fires once an event's handlers settle and carries the class name and outcome of each one. An event used to report only that it started, so a handler that failed showed up nowhere. A fire that runs no handler stays quiet, matching `eventDispatching`.

--- a/.changeset/event-dispatching-pairs.md
+++ b/.changeset/event-dispatching-pairs.md
@@ -1,0 +1,5 @@
+---
+'@seedcord/gateway': patch
+---
+
+Fixed `eventDispatching` firing without a matching `eventDispatched` once a `frequency: 'once'` handler has run. seedcord published the first key alone on every later message, so a subscriber pairing them leaked an entry each time.

--- a/.changeset/event-dispatching-pairs.md
+++ b/.changeset/event-dispatching-pairs.md
@@ -1,5 +1,5 @@
 ---
-'@seedcord/gateway': patch
+'@seedcord/gateway': minor
 ---
 
-Fixed `eventDispatching` firing without a matching `eventDispatched` once a `frequency: 'once'` handler has run. seedcord published the first key alone on every later message, so a subscriber pairing them leaked an entry each time.
+**BREAKING:** Fixed `eventDispatching` firing without a matching `eventDispatched` once a `frequency: 'once'` handler has run. seedcord published the first key alone on every later message, so a subscriber pairing them leaked an entry each time.

--- a/.changeset/fault-origin-field.md
+++ b/.changeset/fault-origin-field.md
@@ -1,0 +1,5 @@
+---
+'@seedcord/core': minor
+---
+
+**BREAKING:** Renamed `routeId` on `unknownException` and `handledException` to `origin`, because on an event it carries a third segment naming the handler that threw. A subscriber reading `this.data.routeId` now reads `this.data.origin`. `interactionDispatched` and `responseAttempted` keep theirs.

--- a/.changeset/gate-declared-route.md
+++ b/.changeset/gate-declared-route.md
@@ -2,4 +2,4 @@
 '@seedcord/core': minor
 ---
 
-**BREAKING:** Renamed `routeId` on the gate context to `declaredRoute`, because `ctx.dispatch.routeId` beside it carried a different value under the same name. A gate reading `ctx.routeId` now reads `ctx.declaredRoute`. The bag is unchanged.
+**BREAKING:** Renamed `routeId` on the gate context to `declaredRoute`, because the bag beside it carries a field of the same name, and only the gate context's is null off a route. A gate reading `ctx.routeId` now reads `ctx.declaredRoute`. The bag is unchanged.

--- a/.changeset/gate-declared-route.md
+++ b/.changeset/gate-declared-route.md
@@ -1,0 +1,5 @@
+---
+'@seedcord/core': minor
+---
+
+**BREAKING:** Renamed `routeId` on the gate context to `declaredRoute`, because `ctx.dispatch.routeId` beside it carried a different value under the same name. A gate reading `ctx.routeId` now reads `ctx.declaredRoute`. The bag is unchanged.

--- a/.changeset/matched-route-identity.md
+++ b/.changeset/matched-route-identity.md
@@ -1,0 +1,5 @@
+---
+'@seedcord/gateway': minor
+---
+
+**BREAKING:** Fixed the cooldown on a handler registered on two buttons. Because its route id joined both into `button:confirm,cancel`, clicking either one put both on cooldown. Now it would just be `button:confirm`, for example.

--- a/.claude/commands/comment-audit.md
+++ b/.claude/commands/comment-audit.md
@@ -30,7 +30,7 @@ Strictness for this run: **<LEVEL>**. Apply that level's threshold and ignore th
 
 - **lenient**: fix only unambiguous violations: narrate-then-justify, type-paraphrase, "I'm doing X" wrappers, em-dashes, stale/contradictory comments, and clear writing-voice violations (hype/marketing words, anthropomorphism, `loudly`-style intensifiers). Leave every borderline or judgment-call comment alone.
 - **standard**: the full guidelines as written: also trim decorative TSDoc on internal helpers and per-overload captions, cut any comment that fails "would a careful reader misunderstand this code without it?", and rewrite any surviving comment whose phrasing trips the writing-voice ban-list down to the plain mechanism. Keep genuine guardrails and invariants.
-- **strict**: minimalist. For every comment apply "if someone deleted this AND mechanically refactored, would they reintroduce a bug?", if no, cut it. Collapse multi-line whys to one line. Every surviving comment must earn its place and pass the writing-voice ban-list.
+- **strict**: minimalist. For every comment apply "if someone deleted this AND mechanically refactored, would they reintroduce a bug?", if no, cut it. Collapse multi-line whys to one line. Every surviving comment must earn its place and pass the writing-voice ban-list. Check if the TSDoc is applicable based on whether the function is public or internal, and its importance.
 
 Mode for this run: **<MODE>**.
 

--- a/.github/skills/changeset-guidelines/SKILL.md
+++ b/.github/skills/changeset-guidelines/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: changeset-guidelines
+description: Use this when writing or reviewing a changeset in `.changeset/*.md`. Covers how behavior decides the release type, the opening word for a bug fix, and how much of a mechanism one sentence should carry, drawn from a real review where one changeset needed ten corrections before it shipped.
+---
+
+# Changesets
+
+A changeset becomes a changelog entry, which someone scans while deciding whether an upgrade breaks their bot. Get the release type right first, then say what changed once, in the reader's own case.
+
+This skill decides what a changeset says. `writing-voice` covers how any sentence in this repo sounds. `release-version` covers cutting the release itself.
+
+---
+
+## 1. Behavior decides the release type
+
+Ask whether a running bot behaves differently after the upgrade. Never ask whether the types still compile. Pre-1.0 in this repo, a yes answer means a `minor` bump carrying the bold `**BREAKING:**` prefix.
+
+A durable store keyed on the old behavior changes silently. In the worked example below, every persisted cooldown window reset on upgrade, and nothing in the build said so.
+
+---
+
+## 2. Open with what kind of entry this is
+
+A bug fix opens with `Fixed`. A second fix in the same changeset opens its own sentence with `Also fixed`.
+
+Why: a changelog gets scanned, so the first word has to say what kind of entry this is.
+
+---
+
+## 3. Write the reader's own case
+
+```md
+BAD: "a handler registered on several routes"
+GOOD: "a handler registered on two buttons"
+```
+
+Why: the reader matches the entry against their own code. "Several" makes them do that work themselves.
+
+---
+
+## 4. Name the mechanism once
+
+Never list the fields it touched.
+
+```md
+BAD: "`interactionDispatched.routeId`, `responseAttempted.routeId`, and the dispatch bag used to carry every route the class declares"
+GOOD: "its route id joined both into `button:confirm,cancel`"
+```
+
+Why: a field list restates the diff. One sentence about the mechanism covers all of them.
+
+---
+
+## 5. Run cause into effect
+
+Keep a thread between sentences.
+
+```md
+BAD: "Clicking one used to put both on cooldown. Each gets its own instead."
+GOOD: "Because its route id joined both into `button:confirm,cancel`, clicking either one put both on cooldown."
+```
+
+Why: splitting every clause to dodge connectors leaves stubs, and the reader has to rebuild the relation you dropped.
+
+---
+
+## 6. Match the connector to the relation
+
+```md
+BAD: ", and now each has its own"
+GOOD: "instead", or a fronted "Because ..."
+```
+
+`and` means "also". Here the second half replaces the first.
+
+Why: the wrong connector asserts a relation that is not there.
+
+---
+
+## 7. Give a value a job
+
+```md
+BAD: "Each gets its own instead, `button:confirm`."
+GOOD: "Now it would just be `button:confirm`, for example."
+```
+
+Why: an id hanging off a comma has nothing to attach to, so it reads as debris.
+
+---
+
+## 8. Mark an illustrative value as illustrative
+
+```md
+BAD: "The id now reads `button:confirm`."
+GOOD: "Now it would just be `button:confirm`, for example."
+```
+
+Why: the real value depends on which route matched. Stated flat, it reads as the only value.
+
+---
+
+## 9. Stop once the reader can derive the rest
+
+```md
+BAD: "The id now reads `button:confirm`, so each button keeps its own."
+GOOD: "Now it would just be `button:confirm`, for example."
+```
+
+Why: the previous sentence already said both went on cooldown. Narrowing the id makes the consequence the reader's next thought.
+
+---
+
+## 10. Fix the wording, keep the fact
+
+```md
+BAD: deleting both example ids because the word "instead" appeared twice
+```
+
+Why: the ids are the greppable part. A repeated word is the cheaper thing to change.
+
+---
+
+## The worked example
+
+One real change, a `Cooldown` keyed a route id that a two-button handler shared. First draft through final.
+
+First draft, rejected:
+
+```md
+**BREAKING:** A handler registered on several routes now reports the route that matched. `interactionDispatched.routeId`, `responseAttempted.routeId`, and the dispatch bag used to carry every route the class declares, joined with commas. A `Cooldown` on such a handler runs one window per route.
+```
+
+Middle draft, rejected. The maintainer said "I had to read it multiple times over":
+
+```md
+Fixed one click cooling down every route on a handler that covers several. The dispatch id now names the route that matched, `button:confirm` where it used to read `button:confirm,cancel`.
+```
+
+Accepted:
+
+```md
+**BREAKING:** Fixed the cooldown on a handler registered on two buttons. Because its route id joined both into `button:confirm,cancel`, clicking either one put both on cooldown. Now it would just be `button:confirm`, for example.
+```
+
+---
+
+## Related
+
+- `writing-voice` for word choice and punctuation across every sentence in this repo.
+- `release-version` for cutting the release and the pre-mode flows.
+
+This skill decides what a changeset says. Those two decide how the words sound and how the release runs.

--- a/apps/guide/content/docs/events/default-keys.mdx
+++ b/apps/guide/content/docs/events/default-keys.mdx
@@ -87,7 +87,7 @@ export class Trace extends Subscriber<'eventDispatching'> {
 
 ## The fault keys
 
-`unknownException` carries the `uuid`, the `error`, the `routeId`, and optional `guild`, `user`, and `metadata` fields. `metadata` is typed `unknown`. On a fault from an event handler that metadata holds the event name, the handler, and the args. `handledException` carries the `uuid`, the `routeId`, the `Notice` itself as `denial`, and a [`FaultSource`](ref:core/FaultSource) naming where the throw came from.
+`unknownException` carries the `uuid`, the `error`, the `origin`, and optional `guild`, `user`, and `metadata` fields. `origin` is where the throw came from, `slash:ban` on an interaction and `event:messageCreate:AutoMod` on an event, since one event fire runs several handlers. `metadata` is typed `unknown`. On a fault from an event handler that metadata holds the event name, the handler, and the args. `handledException` carries the `uuid`, the `origin`, the `Notice` itself as `denial`, and a [`FaultSource`](ref:core/FaultSource) naming where the throw came from.
 
 seedcord ships a subscriber for each and registers it for you. Both [post a card to a Discord webhook](/throwing/reporting) once you set `UNKNOWN_EXCEPTION_WEBHOOK_URL` and `HANDLED_EXCEPTION_WEBHOOK_URL`. An unset variable leaves that reporter off, with one line at boot to say so.
 

--- a/apps/guide/content/docs/events/default-keys.mdx
+++ b/apps/guide/content/docs/events/default-keys.mdx
@@ -90,10 +90,38 @@ export class Trace extends Subscriber<'eventDispatching'> {
 
 ## The fault keys
 
-`unknownException` carries the `uuid`, the `error`, the `origin`, and optional `guild`, `user`, and `metadata` fields. `origin` is where the throw came from, `slash:ban` on an interaction and `event:messageCreate:AutoMod` on an event, since one event fire runs several handlers. `metadata` is typed `unknown`. On a fault from an event handler that metadata holds the event name, the handler, and the args. `handledException` carries the `uuid`, the `origin`, the `Notice` itself as `denial`, and a [`FaultSource`](ref:core/FaultSource) naming where the throw came from.
+`unknownException` fires on a raw throw.
 
-seedcord ships a subscriber for each and registers it for you. Both [post a card to a Discord webhook](/throwing/reporting) once you set `UNKNOWN_EXCEPTION_WEBHOOK_URL` and `HANDLED_EXCEPTION_WEBHOOK_URL`. An unset variable leaves that reporter off, with one line at boot to say so.
+{/* prettier-ignore-start */}
 
-## The telemetry keys
+| field | type | what it holds |
+| --- | --- | --- |
+| `uuid` | `UUID` | this fault, and the id the error card shows the user |
+| `dispatchId` | `string \| null` | the dispatch it came from, null on a process-level throw |
+| `error` | `Error` | the throw itself |
+| `origin` | `string` | where it came from, for example `slash:ban` or `event:messageCreate:AutoMod` |
+| `guild` | `{ id, name }` | optional, the guild the dispatch ran in |
+| `user` | `{ id, username }` | optional, whoever ran it |
+| `metadata` | `unknown` | optional. On an event fault it holds the event name, the handler, and the args |
 
-`interactionDispatched` and `responseAttempted` carry timings and an outcome. [Reading the telemetry](/events/telemetry) covers what each field measures on each path.
+{/* prettier-ignore-end */}
+
+A reported `Notice` thrown from an autocomplete publishes here, since [`FaultSource`](ref:core/FaultSource) covers interactions and events only.
+
+`handledException` fires on a [`Notice`](ref:core/Notice) with `report` true.
+
+{/* prettier-ignore-start */}
+
+| field | type | what it holds |
+| --- | --- | --- |
+| `uuid` | `UUID` | this fault, and the id the error card shows the user |
+| `dispatchId` | `string` | the dispatch that reported it |
+| `origin` | `string` | the same shape `unknownException` carries |
+| `denial` | [`Notice`](ref:core/Notice) | the Notice itself |
+| `source` | [`FaultSource`](ref:core/FaultSource) | where the throw came from, typed per transport |
+
+{/* prettier-ignore-end */}
+
+An event `origin` carries a third segment naming the handler, since one fire runs several of them.
+
+seedcord ships a subscriber for each and registers it for you. Both [post a card to a Discord webhook](/throwing/reporting) once you set `UNKNOWN_EXCEPTION_WEBHOOK_URL` and `HANDLED_EXCEPTION_WEBHOOK_URL`. An unset variable leaves that reporter off and warns you about it during boot.

--- a/apps/guide/content/docs/events/default-keys.mdx
+++ b/apps/guide/content/docs/events/default-keys.mdx
@@ -20,6 +20,7 @@ The `where` column names the transport that publishes each one.
 | `anyInteraction` | both | an interaction arrives, before routing |
 | `unhandledEventError` | gateway | an event dispatch throws past the boundary |
 | `eventDispatching` | gateway | before the handlers for an event run |
+| `eventDispatched` | gateway | those handlers settle |
 
 {/* prettier-ignore-end */}
 
@@ -80,6 +81,8 @@ export class Trace extends Subscriber<'eventDispatching'> {
 `eventDispatching` fires only for an event that some handler registered, since seedcord attaches a client listener per registered event. It also fires ahead of your middleware, so an event that a middleware later stops has already published here.
 
 </Callout>
+
+`eventDispatched` closes the pair once the handlers settle. Read it for outcomes, and see [the telemetry page](/events/telemetry) for its fields.
 
 ## The two unhandled errors
 

--- a/apps/guide/content/docs/events/telemetry.mdx
+++ b/apps/guide/content/docs/events/telemetry.mdx
@@ -29,6 +29,7 @@ export class SlowDispatch extends Subscriber<'interactionDispatched'> {
 
 | field | type | what it holds |
 | --- | --- | --- |
+| `dispatchId` | `string` | this dispatch, unique to it |
 | `routeId` | `string` | the route that ran, `slash:ban` shaped |
 | `interactionId` | `string` | Discord's id for this interaction |
 | `kind` | [`InteractionKind`](ref:core/InteractionKind) | `slash`, `button`, `modal`, `autocomplete`, the five `*Menu` kinds, and the two `*ContextMenu` kinds |
@@ -83,6 +84,7 @@ So `queuedMs` is how long the interaction waited before your bot got to it. It g
 
 | field | type | what it holds |
 | --- | --- | --- |
+| `dispatchId` | `string` | the dispatch this write belongs to |
 | `routeId` | `string` | the same route id the dispatch reports |
 | `interactionId` | `string` | the same interaction id |
 | `method` | [`WriteMethod`](ref:core/WriteMethod) | `reply`, `defer`, `deferUpdate`, `update`, `followUp`, `edit`, `delete`, `showModal`, or `respond` |
@@ -97,7 +99,7 @@ So `queuedMs` is how long the interaction waited before your bot got to it. It g
 
 `messageId` carries an id for `reply`, `update`, `followUp`, and `edit`. Every other verb reports `null`, and so does any failed write.
 
-Both keys carry `interactionId`. Keying a store on it lines one dispatch up with all of its writes.
+Both keys carry `interactionId`, which is Discord's own id for the interaction.
 
 ## Catching a failed write
 
@@ -130,6 +132,7 @@ One event fire runs every handler you registered for it, each behind its own fau
 
 | field | type | what it holds |
 | --- | --- | --- |
+| `dispatchId` | `string` | this fire, the same id `eventDispatching` published |
 | `name` | `keyof ClientEvents` | the event, `messageCreate` shaped |
 | `outcome` | [`DispatchOutcome`](ref:core/DispatchOutcome) | how the middleware chain ended |
 | `handlers` | [`HandlerOutcome[]`](ref:core/HandlerOutcome) | one entry per handler that ran, in order |
@@ -137,7 +140,7 @@ One event fire runs every handler you registered for it, each behind its own fau
 
 {/* prettier-ignore-end */}
 
-`outcome` describes the middleware chain alone. A chain that refuses the event reads `refused` and leaves `handlers` empty, because no handler ran. Each entry in `handlers` carries the class name and its own outcome, so one failing handler shows up without hiding the ones that succeeded.
+`outcome` describes the middleware chain alone. Where the chain refuses the event, it reads `refused` and leaves `handlers` empty, since the handlers never started. Each entry in `handlers` carries its own class name and outcome, which surfaces one failing handler while the ones beside it still report success.
 
 ```ts twoslash title="src/subscribers/FlakyHandlers.ts"
 import { Subscribe, Subscriber } from '@seedcord/gateway';
@@ -157,13 +160,101 @@ export class FlakyHandlers extends Subscriber<'eventDispatched'> {
 }
 ```
 
-The thrown value stays off this key. `unknownException` already carries it, under an `origin` of `event:messageCreate:AutoMod`, so joining on that string pairs a failed entry here with the throw that caused it.
+The thrown value stays off this key. `unknownException` already carries it under an `origin` of `event:messageCreate:AutoMod`, and joining on that string pairs a failed entry here with the throw behind it.
 
 <Callout type="warning">
 
-An event carries no snowflake, so there is no `queuedMs` to read. A fire that runs no handler publishes nothing, and neither does `eventDispatching`, so the pair stays even.
+`queuedMs` comes from the interaction's snowflake. An event does not carry one, so this key omits the field. Both keys publish only when at least one handler is about to run, which keeps them paired.
 
 </Callout>
+
+## Joining the keys
+
+Every key above carries a `dispatchId`. Two runs of the same route get two different ones, so keying a store on it lines up a single dispatch with everything it published.
+
+Your handlers, your gates, and your error cards read that same string off the bag, before any of these keys fire.
+
+```ts twoslash title="src/handlers/middlewares/Trace.ts"
+import {
+    InteractionMiddleware,
+    RegisterInteractionMiddleware
+} from '@seedcord/gateway';
+declare const audit: {
+    record(row: { trace: string; route: string }): Promise<void>;
+};
+// ---cut---
+@RegisterInteractionMiddleware()
+export class Trace extends InteractionMiddleware {
+    public async execute(): Promise<void> {
+        await audit.record({
+            trace: this.dispatch.id,
+            route: this.dispatch.routeId
+        });
+    }
+}
+```
+
+A handler reaches it through `this.dispatch.id`, a gate through `ctx.dispatch.id`, and an error card through its render context. Whatever you write from inside the dispatch already shares a key with what seedcord publishes about it.
+
+Across subscribers, write that column and query on it.
+
+```ts twoslash title="src/subscribers/Trace.ts"
+import { Subscribe, Subscriber } from '@seedcord/gateway';
+declare const db: { insert(row: object): Promise<void> };
+// ---cut---
+@Subscribe('interactionDispatched')
+export class Dispatches extends Subscriber<'interactionDispatched'> {
+    public async execute(): Promise<void> {
+        const { dispatchId, routeId, outcome, durationMs } =
+            this.data;
+        await db.insert({
+            dispatchId,
+            routeId,
+            outcome,
+            durationMs
+        });
+    }
+}
+
+@Subscribe('unknownException')
+export class Faults extends Subscriber<'unknownException'> {
+    public async execute(): Promise<void> {
+        const { dispatchId, uuid, error } = this.data;
+        await db.insert({
+            dispatchId,
+            uuid,
+            message: error.message
+        });
+    }
+}
+```
+
+<Callout type="warning">
+
+`unknownException.dispatchId` is `string | null`. An unhandled rejection reaches Node outside any dispatch, which is the case that reports `null`.
+
+</Callout>
+
+## Typing a payload yourself
+
+[`SubscriptionData`](ref:core/SubscriptionData) takes a key and gives back that key's payload type. Use it to type a function that receives one.
+
+```ts twoslash title="src/subscribers/rows.ts"
+import type { SubscriptionData } from '@seedcord/gateway';
+declare const db: { insert(row: object): Promise<void> };
+// ---cut---
+function rowFor(
+    data: SubscriptionData<'interactionDispatched'>
+): object {
+    return {
+        id: data.dispatchId,
+        route: data.routeId,
+        ms: data.durationMs
+    };
+}
+```
+
+Since `AllSubscriptions` merges the framework's keys with yours, a key you declared yourself types the same way.
 
 ## Storing them yourself
 

--- a/apps/guide/content/docs/events/telemetry.mdx
+++ b/apps/guide/content/docs/events/telemetry.mdx
@@ -160,7 +160,7 @@ export class FlakyHandlers extends Subscriber<'eventDispatched'> {
 }
 ```
 
-The thrown value stays off this key. `unknownException` already carries it under an `origin` of `event:messageCreate:AutoMod`, and joining on that string pairs a failed entry here with the throw behind it.
+The thrown value stays off this key, since `unknownException` carries it under an `origin` like `event:messageCreate:AutoMod`. Pairing a failed entry here with its throw takes both `dispatchId` and that origin. The id picks the fire, and the handler segment picks which handler threw. Two fires of one event share an `origin`, so that string on its own can point at the wrong throw.
 
 <Callout type="warning">
 

--- a/apps/guide/content/docs/events/telemetry.mdx
+++ b/apps/guide/content/docs/events/telemetry.mdx
@@ -122,6 +122,49 @@ export class WriteAudit extends Subscriber<'responseAttempted'> {
 
 A `reply` or an `update` can come back from Discord without the message it should carry. seedcord throws `ReplyCallbackMissingMessage` there, and that write publishes nothing, since the call itself succeeded and named no message.
 
+## What one event fire reports
+
+One event fire runs every handler you registered for it, each behind its own fault boundary. `eventDispatched` reports the fire once they settle, on the gateway transport.
+
+{/* prettier-ignore-start */}
+
+| field | type | what it holds |
+| --- | --- | --- |
+| `name` | `keyof ClientEvents` | the event, `messageCreate` shaped |
+| `outcome` | [`DispatchOutcome`](ref:core/DispatchOutcome) | how the middleware chain ended |
+| `handlers` | [`HandlerOutcome[]`](ref:core/HandlerOutcome) | one entry per handler that ran, in order |
+| `durationMs` | `number` | dispatch entry until every handler settles, monotonic |
+
+{/* prettier-ignore-end */}
+
+`outcome` describes the middleware chain alone. A chain that refuses the event reads `refused` and leaves `handlers` empty, because no handler ran. Each entry in `handlers` carries the class name and its own outcome, so one failing handler shows up without hiding the ones that succeeded.
+
+```ts twoslash title="src/subscribers/FlakyHandlers.ts"
+import { Subscribe, Subscriber } from '@seedcord/gateway';
+// ---cut---
+@Subscribe('eventDispatched')
+export class FlakyHandlers extends Subscriber<'eventDispatched'> {
+    public async execute(): Promise<void> {
+        const { name, handlers } = this.data;
+
+        for (const entry of handlers) {
+            if (entry.outcome === 'handled') continue;
+            this.logger.warn(
+                `${entry.handler} ${entry.outcome} on ${name}`
+            );
+        }
+    }
+}
+```
+
+The thrown value stays off this key. `unknownException` already carries it, under an `origin` of `event:messageCreate:AutoMod`, so joining on that string pairs a failed entry here with the throw that caused it.
+
+<Callout type="warning">
+
+An event carries no snowflake, so there is no `queuedMs` to read. A fire that runs no handler publishes nothing, and neither does `eventDispatching`, so the pair stays even.
+
+</Callout>
+
 ## Storing them yourself
 
 seedcord publishes these and keeps none of them. A subscriber is the whole surface. Anything you want to keep, you write somewhere yourself.

--- a/apps/guide/content/docs/gates/your-own.mdx
+++ b/apps/guide/content/docs/gates/your-own.mdx
@@ -94,7 +94,7 @@ Leaving the `ctx` parameter unannotated makes it a [`GateContextBase`](ref:core/
 | `memberRoleIds` | `readonly string[]` | the caller's role ids without the everyone role, empty outside a server |
 | `memberPermissions` | `bigint \| null` | the caller's permission bits, channel-scoped on an interaction and role-derived on a gateway event, null outside a server |
 | `appPermissions` | `bigint \| null` | your bot's permission bits in the invoked channel, null on gateway events |
-| `routeId` | `string \| null` | the dispatched handler as `kind:route`, such as `slash:daily`, null off a route |
+| `declaredRoute` | `string \| null` | the route this dispatch matched, such as `slash:daily`, null off a route |
 
 {/* prettier-ignore-end */}
 

--- a/apps/guide/content/docs/throwing/reporting.mdx
+++ b/apps/guide/content/docs/throwing/reporting.mdx
@@ -60,11 +60,11 @@ import type { WebhookReport } from '@seedcord/gateway';
 // ---cut-start---
 
 class MirrorCard extends BuilderComponent<'container'> {
-    constructor(uuid: string, route: string) {
+    constructor(uuid: string, origin: string) {
         super('container');
 
         this.instance.addTextDisplayComponents((text) =>
-            text.setContent(`### ${route}\n\`${uuid}\``)
+            text.setContent(`### ${origin}\n\`${uuid}\``)
         );
     }
 }
@@ -144,14 +144,14 @@ import type { WebhookReport } from '@seedcord/gateway';
 // ---cut-start---
 
 class MirrorCard extends BuilderComponent<'container'> {
-    constructor(uuid: string, route: string, suppressed: number) {
+    constructor(uuid: string, origin: string, suppressed: number) {
         super('container');
 
         const tail =
             suppressed > 0 ? `\n-# +${suppressed} more` : '';
 
         this.instance.addTextDisplayComponents((text) =>
-            text.setContent(`### ${route}\n\`${uuid}\`${tail}`)
+            text.setContent(`### ${origin}\n\`${uuid}\`${tail}`)
         );
     }
 }
@@ -177,7 +177,7 @@ export class FaultMirror extends WebhookLog<'handledException'> {
 }
 ```
 
-Both shipped reporters key on the route and the error's class name, and they end their card with the count.
+Both shipped reporters key on the origin and the error's class name, and they end their card with the count.
 
 ```txt output
 -# 12 more of these since the last report

--- a/apps/guide/content/docs/throwing/reporting.mdx
+++ b/apps/guide/content/docs/throwing/reporting.mdx
@@ -74,11 +74,11 @@ class MirrorCard extends BuilderComponent<'container'> {
 @WebhookUrl('FAULT_MIRROR_WEBHOOK_URL')
 export class FaultMirror extends WebhookLog<'handledException'> {
     public report(): WebhookReport {
-        const { uuid, routeId } = this.data;
+        const { uuid, origin } = this.data;
 
         return {
             username: 'Faults',
-            components: [new MirrorCard(uuid, routeId).component]
+            components: [new MirrorCard(uuid, origin).component]
         };
     }
 }
@@ -161,16 +161,16 @@ class MirrorCard extends BuilderComponent<'container'> {
 @WebhookUrl('FAULT_MIRROR_WEBHOOK_URL')
 export class FaultMirror extends WebhookLog<'handledException'> {
     protected override throttleKey(): string {
-        return `mirror:${this.data.routeId}`;
+        return `mirror:${this.data.origin}`;
     }
 
     public report(suppressed: number): WebhookReport {
-        const { uuid, routeId } = this.data;
+        const { uuid, origin } = this.data;
 
         return {
             username: 'Faults',
             components: [
-                new MirrorCard(uuid, routeId, suppressed).component
+                new MirrorCard(uuid, origin, suppressed).component
             ]
         };
     }

--- a/packages/core/src/dispatch/DispatchContext.ts
+++ b/packages/core/src/dispatch/DispatchContext.ts
@@ -12,6 +12,8 @@ export class DispatchContext implements DispatchBag {
     // a {} here would let a key named toString or __proto__ reach Object.prototype
     private readonly state = Object.create(null) as Partial<DispatchState>;
 
+    public readonly id = crypto.randomUUID();
+
     constructor(public readonly routeId: string) {}
 
     set<Key extends keyof DispatchState>(key: Key, value: DispatchState[Key]): void {

--- a/packages/core/src/dispatch/dispatchReport.ts
+++ b/packages/core/src/dispatch/dispatchReport.ts
@@ -29,6 +29,7 @@ export function outcomeFor(caught: unknown): Exclude<DispatchOutcome, 'handled'>
 }
 
 interface DispatchReport {
+    readonly dispatchId: string;
     readonly routeId: string;
     readonly interactionId: string;
     readonly kind: `${InteractionKind}`;
@@ -61,6 +62,7 @@ export function queuedMsFor(interactionId: string): number {
 export function reportDispatch(bus: Bus, report: DispatchReport): void {
     const durationMs = performance.now() - report.startedAt;
     bus[PublishDefault]('interactionDispatched', {
+        dispatchId: report.dispatchId,
         routeId: report.routeId,
         interactionId: report.interactionId,
         kind: report.kind,

--- a/packages/core/src/dispatch/dispatchResult.ts
+++ b/packages/core/src/dispatch/dispatchResult.ts
@@ -11,8 +11,8 @@ export type DispatchResult =
 export type HandlerResult = { readonly handler: string } & DispatchResult;
 
 /**
- * What `eventDispatched` publishes for each handler that ran. The thrown value stays off the bus, since
- * `unknownException` already carries it under the same `event:name:handler` origin.
+ * What `eventDispatched` publishes for each handler that ran. `unknownException` carries the thrown
+ * value under the same `event:name:handler` origin.
  */
 export type HandlerOutcome = Pick<HandlerResult, 'handler' | 'outcome'>;
 

--- a/packages/core/src/dispatch/dispatchResult.ts
+++ b/packages/core/src/dispatch/dispatchResult.ts
@@ -11,6 +11,12 @@ export type DispatchResult =
 export type HandlerResult = { readonly handler: string } & DispatchResult;
 
 /**
+ * What `eventDispatched` publishes for each handler that ran. The thrown value stays off the bus, since
+ * `unknownException` already carries it under the same `event:name:handler` origin.
+ */
+export type HandlerOutcome = Pick<HandlerResult, 'handler' | 'outcome'>;
+
+/**
  * An event middleware's `after()` receives this once the event finishes. `outcome` reports the
  * middleware chain alone. `handlers` holds one entry per handler that ran. A stopped chain runs none.
  */

--- a/packages/core/src/gates/Gate.ts
+++ b/packages/core/src/gates/Gate.ts
@@ -39,9 +39,9 @@ export interface GateContextBase {
      */
     readonly appPermissions: bigint | null;
     /**
-     * The route this dispatch matched, as `kind:route` (`slash:daily`, `button:confirm`). A handler
-     * registered on several routes reports the one that matched. Null off a route, which covers a plain
-     * event handler and a gate run outside a handler.
+     * The handler's own route, as `kind:route` (`slash:daily`, `button:confirm`). A handler registered
+     * on several reports the one this dispatch matched. Null when the handler declares none, which
+     * covers a plain event handler, the unhandled default, and a gate run outside a handler.
      */
     readonly declaredRoute: string | null;
     /**

--- a/packages/core/src/gates/Gate.ts
+++ b/packages/core/src/gates/Gate.ts
@@ -39,11 +39,12 @@ export interface GateContextBase {
      */
     readonly appPermissions: bigint | null;
     /**
-     * The dispatched handler as `kind:route` (`slash:daily`, `button:confirm`), or null off a route (a
-     * plain event handler, or a gate run outside a handler). `runHandlerGates` sets it from the handler's
-     * metadata. `Cooldown` uses it so its window is stable across restarts and isolates.
+     * The route this dispatch matched, as `kind:route` (`slash:daily`, `button:confirm`). A handler
+     * registered on several routes reports the one that matched. Null off a route, which covers a plain
+     * event handler and a gate run outside a handler. `Cooldown` keys on it so its window survives a
+     * restart.
      */
-    readonly routeId: string | null;
+    readonly declaredRoute: string | null;
     /**
      * The bag for this dispatch, the same instance the handler and its middleware hold. Every middleware
      * runs before the first gate. A gate therefore reads what a middleware wrote.

--- a/packages/core/src/gates/Gate.ts
+++ b/packages/core/src/gates/Gate.ts
@@ -41,8 +41,7 @@ export interface GateContextBase {
     /**
      * The route this dispatch matched, as `kind:route` (`slash:daily`, `button:confirm`). A handler
      * registered on several routes reports the one that matched. Null off a route, which covers a plain
-     * event handler and a gate run outside a handler. `Cooldown` keys on it so its window survives a
-     * restart.
+     * event handler and a gate run outside a handler.
      */
     readonly declaredRoute: string | null;
     /**

--- a/packages/core/src/gates/catalog/Cooldown.ts
+++ b/packages/core/src/gates/catalog/Cooldown.ts
@@ -130,7 +130,7 @@ export function Cooldown(
     const anonId = anonSeq++;
     // routed keys stay stable across restarts, letting a durable store rebuild the same window
     const keyOf = (ctx: GateContextBase): string =>
-        `cooldown:${ctx.routeId ?? `anon${anonId}`}:${per}:w${windowMs}:l${options?.limit ?? 1}:${scopeValue(ctx, per)}`;
+        `cooldown:${ctx.declaredRoute ?? `anon${anonId}`}:${per}:w${windowMs}:l${options?.limit ?? 1}:${scopeValue(ctx, per)}`;
 
     return defineEffectGate(
         'Cooldown',

--- a/packages/core/src/gates/runGates.ts
+++ b/packages/core/src/gates/runGates.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata';
 
-import { GatedMetadataKey, InteractionRouteKeys } from '#src/metadataKeys';
+import { GatedMetadataKey } from '#src/metadataKeys';
 
 import { discardCommits, runCheck, runCommits } from './effects';
 
@@ -8,16 +8,6 @@ import type { Gate, GateContextBase } from './Gate';
 
 // a combinator (`and`/`or`) reports once under its joined name.
 export type GateObserver = (gateName: string, elapsedMs: number) => void;
-
-// the stable id a route decorator stored, e.g. slash:daily or button:confirm. null for a plain event handler.
-export function routeIdOf(handlerCtor: object): string | null {
-    for (const [kind, key] of Object.entries(InteractionRouteKeys)) {
-        // justified: getMetadata returns any, this key only ever stores the route/prefix string array
-        const routes = Reflect.getMetadata(key, handlerCtor) as string[] | undefined;
-        if (routes?.length) return `${kind}:${routes.join(',')}`;
-    }
-    return null;
-}
 
 async function timedCheck(gate: Gate<GateContextBase>, ctx: GateContextBase, observe: GateObserver): Promise<void> {
     const start = performance.now();
@@ -46,16 +36,15 @@ export async function runGates(
     }
 }
 
-// dispatchers call this before execute, inside the boundary, so a refusal renders or drops. an explicit
-// routeId is for manifest-driven handlers, which carry no route metadata to derive one from.
+// dispatchers call this before execute, inside the boundary, so a refusal renders or drops
 export async function runHandlerGates(
     handlerCtor: object,
     ctx: GateContextBase,
-    routeId?: string,
+    declaredRoute?: string,
     observe?: GateObserver
 ): Promise<void> {
     // justified: getMetadata returns any, and this key only ever stores the @Gated gate array
     const gates = Reflect.getMetadata(GatedMetadataKey, handlerCtor) as readonly Gate<GateContextBase>[] | undefined;
     if (!gates) return;
-    await runGates(gates, { ...ctx, routeId: routeId ?? routeIdOf(handlerCtor) }, observe);
+    await runGates(gates, { ...ctx, declaredRoute: declaredRoute ?? null }, observe);
 }

--- a/packages/core/src/gates/slowGate.ts
+++ b/packages/core/src/gates/slowGate.ts
@@ -20,7 +20,7 @@ function logger(): Logger {
  */
 export interface SlowGateMonitor {
     readonly observe: GateObserver;
-    report(routeId: string | null): void;
+    report(declaredRoute: string | null): void;
 }
 
 // undefined in production, so timedCheck skips the clock there. read per call, the environment binds late
@@ -29,13 +29,13 @@ export function slowGateMonitor(): SlowGateMonitor | undefined {
     const readings: { name: string; ms: number }[] = [];
     return {
         observe: (name, ms) => readings.push({ name, ms }),
-        report(routeId) {
+        report(declaredRoute) {
             const total = readings.reduce((sum, reading) => sum + reading.ms, 0);
             if (total < SLOW_GATE_MS) return;
             const shares = readings
                 .toSorted((a, b) => b.ms - a.ms)
                 .map((reading) => `${paint.sky.bold(reading.name)} ${paint.mute(`${Math.round(reading.ms)}ms`)}`);
-            const route = routeId === null ? '' : ` for ${paint.sky.bold(routeId)}`;
+            const route = declaredRoute === null ? '' : ` for ${paint.sky.bold(declaredRoute)}`;
             const headline = `gates${route} took ${paint.amber(`${Math.round(total)}ms`)} of the 3s ack budget`;
             logger().utils.block(headline, shares, 'warn', (text) => text);
         }

--- a/packages/core/src/handlers/RepliableHandler.ts
+++ b/packages/core/src/handlers/RepliableHandler.ts
@@ -30,10 +30,10 @@ export abstract class RepliableHandler<
         super(event, core, dispatch, 'interactions');
         this.routeId = dispatch.routeId;
         // the override runs before its own field initializers
-        this.sender = sender ?? this.buildSender(event, core, this.routeId);
+        this.sender = sender ?? this.buildSender(event, core, dispatch);
     }
 
-    protected abstract buildSender(event: Event, core: TCore, routeId: string): TSender;
+    protected abstract buildSender(event: Event, core: TCore, dispatch: DispatchContext): TSender;
 
     /** Send the initial response, exactly once. */
     protected reply(response: ReplyResponse<TNative> | string, opts?: SendOpts): Promise<TMessage> {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -36,7 +36,7 @@ export { RegisterInteractionMiddleware } from '#decorators/middleware';
 export type { InteractionMiddlewareOptions } from '#decorators/middleware';
 
 export { DispatchContext } from '#src/dispatch/DispatchContext';
-export type { DispatchResult, EventDispatchResult, HandlerResult } from '#src/dispatch/dispatchResult';
+export type { DispatchResult, EventDispatchResult, HandlerOutcome, HandlerResult } from '#src/dispatch/dispatchResult';
 
 export { BaseHandler } from '#src/handlers/BaseHandler';
 export { RepliableHandler } from '#src/handlers/RepliableHandler';

--- a/packages/core/src/internal.index.ts
+++ b/packages/core/src/internal.index.ts
@@ -26,7 +26,7 @@ export {
     type RoutableConstructor
 } from '#decorators/interactionRoutes';
 
-export { routeIdOf, runGates, runHandlerGates } from '#gates/runGates';
+export { runGates, runHandlerGates } from '#gates/runGates';
 export { slowGateMonitor, type SlowGateMonitor } from '#gates/slowGate';
 export type { GateObserver } from '#gates/runGates';
 export { accessorStore, clearStore, guardedAccessor } from '#src/miscellaneous/guarded';

--- a/packages/core/src/node/processErrors.ts
+++ b/packages/core/src/node/processErrors.ts
@@ -19,7 +19,7 @@ export function registerProcessErrors(core: CoreBase, shutdown: CoordinatedShutd
         if (core.config.errors?.errorStack ?? false) logger.error(uuid, error);
         else logger.error(`${uuid} | ${error.message}`);
 
-        core.bus[PublishDefault]('unknownException', { uuid, error, origin });
+        core.bus[PublishDefault]('unknownException', { uuid, dispatchId: null, error, origin });
     }
 
     const onRejection = (reason: unknown): void => {

--- a/packages/core/src/node/processErrors.ts
+++ b/packages/core/src/node/processErrors.ts
@@ -12,14 +12,14 @@ const logger = new Logger('Faults', { channel: 'errors' });
 
 /** @internal */
 export function registerProcessErrors(core: CoreBase, shutdown: CoordinatedShutdown): () => void {
-    function report(caught: unknown, routeId: string): void {
+    function report(caught: unknown, origin: string): void {
         const error = asError(caught);
         const uuid = crypto.randomUUID();
 
         if (core.config.errors?.errorStack ?? false) logger.error(uuid, error);
         else logger.error(`${uuid} | ${error.message}`);
 
-        core.bus[PublishDefault]('unknownException', { uuid, error, routeId });
+        core.bus[PublishDefault]('unknownException', { uuid, error, origin });
     }
 
     const onRejection = (reason: unknown): void => {

--- a/packages/core/src/reply/BaseReplySender.ts
+++ b/packages/core/src/reply/BaseReplySender.ts
@@ -32,16 +32,19 @@ export abstract class BaseReplySender<TMessage extends { id: string }, TNative =
     private ackedBy?: AckTrace;
 
     protected constructor(
-        protected readonly routeId: string,
         private readonly telemetry: ReplyTelemetry,
         initialState: AckState = 'unacked'
     ) {
         this.state = initialState;
     }
 
+    protected get routeId(): string {
+        return this.telemetry.dispatch.routeId;
+    }
+
     // anything that threw already reported through attemptWrite
     private report(method: ReplyMethod, startedAt: number, messageId: string | null): void {
-        publishResponse(this.telemetry, { routeId: this.routeId, method, startedAt, outcome: 'sent', messageId });
+        publishResponse(this.telemetry, { method, startedAt, outcome: 'sent', messageId });
     }
 
     private async attempt<Result>(
@@ -49,7 +52,7 @@ export abstract class BaseReplySender<TMessage extends { id: string }, TNative =
         startedAt: number,
         write: () => Promise<Result>
     ): Promise<Result> {
-        return await attemptWrite(this.telemetry, this.routeId, method, startedAt, write);
+        return await attemptWrite(this.telemetry, method, startedAt, write);
     }
 
     public async reply(response: ReplyResponse<TNative> | string, opts?: SendOpts): Promise<TMessage> {

--- a/packages/core/src/reply/responseReport.ts
+++ b/packages/core/src/reply/responseReport.ts
@@ -6,6 +6,7 @@ import { PublishDefault } from '#subscribers/publishDefault';
 
 import type { Bus } from '#subscribers/Bus';
 import type { ReplyMethod } from './ackLegality';
+import type { DispatchContext } from '../dispatch/DispatchContext';
 
 let replyLogger: Logger | undefined;
 function logger(): Logger {
@@ -15,6 +16,7 @@ function logger(): Logger {
 
 export interface ReplyTelemetry {
     readonly bus: Bus;
+    readonly dispatch: DispatchContext;
     readonly interactionId: string;
 }
 
@@ -22,7 +24,6 @@ export interface ReplyTelemetry {
 export type WriteMethod = ReplyMethod | 'respond';
 
 interface WriteStart {
-    readonly routeId: string;
     readonly method: WriteMethod;
     // performance.now() captured before the write began
     readonly startedAt: number;
@@ -43,8 +44,10 @@ export type ResponseReport = SentReport | FailedReport;
 /** @internal */
 export function publishResponse(telemetry: ReplyTelemetry, report: ResponseReport): void {
     const durationMs = performance.now() - report.startedAt;
+    const { routeId } = telemetry.dispatch;
     const write = {
-        routeId: report.routeId,
+        dispatchId: telemetry.dispatch.id,
+        routeId,
         interactionId: telemetry.interactionId,
         method: report.method,
         durationMs
@@ -58,26 +61,24 @@ export function publishResponse(telemetry: ReplyTelemetry, report: ResponseRepor
 
     // after publish so a throwing sink doesn't reach the publish above
     logger().trace(
-        `${paint.sky.bold(report.routeId)} ${report.method} ${report.outcome} ${paint.mute('in')} ${Math.round(durationMs)}ms`
+        `${paint.sky.bold(routeId)} ${report.method} ${report.outcome} ${paint.mute('in')} ${Math.round(durationMs)}ms`
     );
 }
 
 export async function reportedWrite<Result>(
     telemetry: ReplyTelemetry,
-    routeId: string,
     method: WriteMethod,
     write: () => Promise<Result>
 ): Promise<Result> {
     const startedAt = performance.now();
-    const result = await attemptWrite(telemetry, routeId, method, startedAt, write);
-    publishResponse(telemetry, { routeId, method, startedAt, outcome: 'sent', messageId: null });
+    const result = await attemptWrite(telemetry, method, startedAt, write);
+    publishResponse(telemetry, { method, startedAt, outcome: 'sent', messageId: null });
     return result;
 }
 
 // publishes the failed arm when write() throws, since the caller's success report sits after the write and a throw skips it
 export async function attemptWrite<Result>(
     telemetry: ReplyTelemetry,
-    routeId: string,
     method: WriteMethod,
     startedAt: number,
     write: () => Promise<Result>
@@ -86,7 +87,7 @@ export async function attemptWrite<Result>(
         return await write();
     } catch (caught) {
         const error = asError(caught);
-        publishResponse(telemetry, { routeId, method, startedAt, outcome: 'failed', error });
+        publishResponse(telemetry, { method, startedAt, outcome: 'failed', error });
         // rethrown raw
         throw caught;
     }

--- a/packages/core/src/subscribers/default/HandledException.ts
+++ b/packages/core/src/subscribers/default/HandledException.ts
@@ -17,7 +17,7 @@ import type { AllSubscriptions, FaultSource } from '../types/Subscriptions';
 @WebhookUrl('HANDLED_EXCEPTION_WEBHOOK_URL')
 export class HandledException extends WebhookLog<'handledException', CoreBase> {
     protected override throttleKey(): string {
-        return `handledException:${this.data.routeId}:${this.data.denial.name}`;
+        return `handledException:${this.data.origin}:${this.data.denial.name}`;
     }
 
     report(suppressed: number): WebhookReport {

--- a/packages/core/src/subscribers/default/UnknownException.ts
+++ b/packages/core/src/subscribers/default/UnknownException.ts
@@ -17,7 +17,7 @@ import type { AllSubscriptions } from '../types/Subscriptions';
 @WebhookUrl('UNKNOWN_EXCEPTION_WEBHOOK_URL')
 export class UnknownException extends WebhookLog<'unknownException', CoreBase> {
     protected override throttleKey(): string {
-        return `unknownException:${this.data.routeId}:${nameOf(this.data.error)}`;
+        return `unknownException:${this.data.origin}:${nameOf(this.data.error)}`;
     }
 
     report(suppressed: number): WebhookReport {

--- a/packages/core/src/subscribers/types/Subscriptions.ts
+++ b/packages/core/src/subscribers/types/Subscriptions.ts
@@ -104,7 +104,7 @@ export interface DefaultSubscriptions {
         readonly uuid: UUID;
         readonly error: Error;
         /** Where the throw came from, `slash:ban` for an interaction and `event:name:handler` for an event. */
-        readonly routeId: string;
+        readonly origin: string;
         readonly guild?: { readonly id: string; readonly name: string } | undefined;
         readonly user?: { readonly id: string; readonly username: string } | undefined;
         readonly metadata?: unknown;
@@ -113,8 +113,8 @@ export interface DefaultSubscriptions {
     readonly handledException: {
         readonly denial: Notice;
         readonly uuid: UUID;
-        /** The same id `interactionDispatched` publishes. An event reads `event:name:handler`. */
-        readonly routeId: string;
+        /** Where the reported Notice came from, the same shape `unknownException.origin` carries. */
+        readonly origin: string;
         readonly source: FaultSource;
     };
     /** Triggered when an interaction dispatch throws past the fault boundary. */

--- a/packages/core/src/subscribers/types/Subscriptions.ts
+++ b/packages/core/src/subscribers/types/Subscriptions.ts
@@ -2,8 +2,8 @@ import type { WriteMethod } from '#reply/responseReport';
 import type { InteractionKind } from '#src/metadataKeys';
 import type { Notice } from '#stops/Notice';
 import type { TypedExclude } from '@seedcord/types';
+import type { UUID } from '@seedcord/types/internal';
 import type { APIApplicationCommand } from 'discord-api-types/v10';
-import type { UUID } from 'node:crypto';
 
 /**
  * How a dispatch finished. The thrown value's type sets this, wherever it was thrown. A `Silence` and a
@@ -57,6 +57,8 @@ export interface EventFaultSource {
  * The fields both `responseAttempted` arms carry.
  */
 export interface AttemptedWrite {
+    /** The dispatch this write belongs to, for joining against every other key it published. */
+    readonly dispatchId: string;
     readonly routeId: string;
     /** The interaction this write belongs to, for joining against `interactionDispatched`. */
     readonly interactionId: string;
@@ -102,6 +104,8 @@ export interface DefaultSubscriptions {
     /** Triggered when an unhandled exception (a raw non-Notice throw) occurs. */
     readonly unknownException: {
         readonly uuid: UUID;
+        /** The dispatch that raised it. Null on a process-level throw, which has no dispatch behind it. */
+        readonly dispatchId: string | null;
         readonly error: Error;
         /** Where the throw came from, `slash:ban` for an interaction and `event:name:handler` for an event. */
         readonly origin: string;
@@ -113,6 +117,8 @@ export interface DefaultSubscriptions {
     readonly handledException: {
         readonly denial: Notice;
         readonly uuid: UUID;
+        /** The dispatch that reported it. */
+        readonly dispatchId: string;
         /** Where the reported Notice came from, the same shape `unknownException.origin` carries. */
         readonly origin: string;
         readonly source: FaultSource;
@@ -123,6 +129,8 @@ export interface DefaultSubscriptions {
     };
     /** Triggered once per interaction dispatch, after the handler chain settles. */
     readonly interactionDispatched: {
+        /** This dispatch, for joining against every other key it published. */
+        readonly dispatchId: string;
         readonly routeId: string;
         /** The interaction this dispatch ran, for joining against `responseAttempted`. */
         readonly interactionId: string;

--- a/packages/core/tests/dispatch/DispatchContext.test.ts
+++ b/packages/core/tests/dispatch/DispatchContext.test.ts
@@ -65,4 +65,12 @@ describe('DispatchContext', () => {
         bag.set('__proto__', 'en');
         expect(bag.require('__proto__')).toBe('en');
     });
+
+    it('gives every dispatch its own id', () => {
+        const first = new DispatchContext('slash:test');
+        const second = new DispatchContext('slash:test');
+
+        expect(first.id).not.toBe(second.id);
+        expect(first.id).toBe(first.id);
+    });
 });

--- a/packages/core/tests/dispatch/dispatchReport.test.ts
+++ b/packages/core/tests/dispatch/dispatchReport.test.ts
@@ -28,6 +28,7 @@ class Refusal extends Notice {
 
 function reportFor(queuedMs = 0): Parameters<typeof reportDispatch>[1] {
     return {
+        dispatchId: 'd-1',
         routeId: 'slash:ping',
         interactionId: 'i1',
         kind: InteractionKind.Slash,

--- a/packages/core/tests/dispatch/dispatchResult.types-test.ts
+++ b/packages/core/tests/dispatch/dispatchResult.types-test.ts
@@ -1,6 +1,6 @@
 import { expectTypeOf } from 'vitest';
 
-import type { DispatchResult, EventDispatchResult, HandlerResult } from '#src/dispatch/dispatchResult';
+import type { DispatchResult, EventDispatchResult, HandlerOutcome, HandlerResult } from '#src/dispatch/dispatchResult';
 import type { DispatchOutcome } from '#subscribers/types/Subscriptions';
 
 // catches a fourth outcome added to DispatchOutcome and missed here
@@ -31,3 +31,9 @@ expectTypeOf(perHandler).toHaveProperty('handler').toEqualTypeOf<string>();
 if (perHandler.outcome !== 'handled') {
     expectTypeOf(perHandler).toHaveProperty('caught').toEqualTypeOf<unknown>();
 }
+
+const published = {} as HandlerOutcome;
+
+// the thrown value stays off the bus whichever way HandlerResult grows
+expectTypeOf(published).not.toHaveProperty('caught');
+expectTypeOf<HandlerOutcome['outcome']>().toEqualTypeOf<DispatchOutcome>();

--- a/packages/core/tests/gates/catalog/Cooldown.test.ts
+++ b/packages/core/tests/gates/catalog/Cooldown.test.ts
@@ -23,7 +23,7 @@ class CustomRefusal extends Notice {
 
 function cdCtx(
     rateLimiter: object,
-    ids: { userId?: string; guildId?: string; channelId?: string; routeId?: string | null } = {}
+    ids: { userId?: string; guildId?: string; channelId?: string; declaredRoute?: string | null } = {}
 ): GateContextBase {
     // the gate reads core.rateLimiter and the id scalars, so a minimal cast stands in
     const core = { rateLimiter } as unknown as CoreBase;
@@ -32,7 +32,7 @@ function cdCtx(
         userId: ids.userId ?? 'u1',
         guildId: ids.guildId ?? 'g1',
         channelId: ids.channelId ?? 'c1',
-        routeId: ids.routeId ?? null
+        declaredRoute: ids.declaredRoute ?? null
     } as unknown as GateContextBase;
 }
 
@@ -61,7 +61,7 @@ describe('Cooldown', () => {
 
     it('keys the same route and config identically across two Cooldown instances', async () => {
         const peek = vi.fn().mockReturnValue({ limited: false });
-        const ctx = cdCtx({ peek, charge: vi.fn() }, { routeId: 'slash:daily' });
+        const ctx = cdCtx({ peek, charge: vi.fn() }, { declaredRoute: 'slash:daily' });
         await Cooldown(5).check(ctx);
         await Cooldown(5).check(ctx);
         // the key derives from the route and config, so two loads of the same handler match
@@ -70,20 +70,20 @@ describe('Cooldown', () => {
 
     it('includes the route id in the key', async () => {
         const peek = vi.fn().mockReturnValue({ limited: false });
-        await Cooldown(5).check(cdCtx({ peek, charge: vi.fn() }, { routeId: 'slash:daily' }));
+        await Cooldown(5).check(cdCtx({ peek, charge: vi.fn() }, { declaredRoute: 'slash:daily' }));
         expect(String(peek.mock.calls[0]?.[0])).toContain('slash:daily');
     });
 
     it('keys two different routes to different keys', async () => {
         const peek = vi.fn().mockReturnValue({ limited: false });
-        await Cooldown(5).check(cdCtx({ peek, charge: vi.fn() }, { routeId: 'slash:daily' }));
-        await Cooldown(5).check(cdCtx({ peek, charge: vi.fn() }, { routeId: 'slash:weekly' }));
+        await Cooldown(5).check(cdCtx({ peek, charge: vi.fn() }, { declaredRoute: 'slash:daily' }));
+        await Cooldown(5).check(cdCtx({ peek, charge: vi.fn() }, { declaredRoute: 'slash:weekly' }));
         expect(peek.mock.calls[0]?.[0]).not.toBe(peek.mock.calls[1]?.[0]);
     });
 
     it('keys two durations on one route to different keys', async () => {
         const peek = vi.fn().mockReturnValue({ limited: false });
-        const ctx = cdCtx({ peek, charge: vi.fn() }, { routeId: 'slash:daily' });
+        const ctx = cdCtx({ peek, charge: vi.fn() }, { declaredRoute: 'slash:daily' });
         await Cooldown(5).check(ctx);
         await Cooldown(10).check(ctx);
         expect(peek.mock.calls[0]?.[0]).not.toBe(peek.mock.calls[1]?.[0]);
@@ -92,16 +92,16 @@ describe('Cooldown', () => {
     it('keys two off-route Cooldown instances to different keys', async () => {
         const peek = vi.fn().mockReturnValue({ limited: false });
         // no route to key on, so unrelated event handlers must not collide on one bucket
-        await Cooldown(5).check(cdCtx({ peek, charge: vi.fn() }, { routeId: null }));
-        await Cooldown(5).check(cdCtx({ peek, charge: vi.fn() }, { routeId: null }));
+        await Cooldown(5).check(cdCtx({ peek, charge: vi.fn() }, { declaredRoute: null }));
+        await Cooldown(5).check(cdCtx({ peek, charge: vi.fn() }, { declaredRoute: null }));
         expect(peek.mock.calls[0]?.[0]).not.toBe(peek.mock.calls[1]?.[0]);
     });
 
     it('keys one off-route Cooldown instance identically across contexts', async () => {
         const peek = vi.fn().mockReturnValue({ limited: false });
         const gate = Cooldown(5);
-        await gate.check(cdCtx({ peek, charge: vi.fn() }, { routeId: null }));
-        await gate.check(cdCtx({ peek, charge: vi.fn() }, { routeId: null }));
+        await gate.check(cdCtx({ peek, charge: vi.fn() }, { declaredRoute: null }));
+        await gate.check(cdCtx({ peek, charge: vi.fn() }, { declaredRoute: null }));
         // one declaration site keys one bucket, so the same off-route gate limits its scope consistently
         expect(peek.mock.calls[0]?.[0]).toBe(peek.mock.calls[1]?.[0]);
     });

--- a/packages/core/tests/gates/runGates.test.ts
+++ b/packages/core/tests/gates/runGates.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect } from 'vitest';
 import { and, or } from '#gates/combinators';
 import { defineEffectGate, defineGate } from '#gates/Gate';
 import { runGates, runHandlerGates } from '#gates/runGates';
-import { GatedMetadataKey, InteractionRouteKeys, InteractionKind } from '#src/metadataKeys';
+import { GatedMetadataKey } from '#src/metadataKeys';
 import { Notice } from '#stops/Notice';
 
 import { TestNotice } from '../utils/TestNotice';
@@ -220,39 +220,24 @@ describe('gate observer', () => {
 });
 
 describe('runHandlerGates', () => {
-    it('threads the handler route id onto the context as kind:route', async () => {
+    it('puts the route the dispatcher matched onto the context', async () => {
         let seen: string | null | undefined;
         const probe = defineGate('probe', (c: GateContextBase) => {
-            seen = c.routeId;
+            seen = c.declaredRoute;
         });
         // runHandlerGates only reads metadata off the ctor, so a plain object stands in for the handler class
         const dailyHandler = {};
-        Reflect.defineMetadata(InteractionRouteKeys[InteractionKind.Slash], ['daily'], dailyHandler);
         Reflect.defineMetadata(GatedMetadataKey, [probe], dailyHandler);
 
-        await runHandlerGates(dailyHandler, ctx);
+        await runHandlerGates(dailyHandler, ctx, 'slash:daily');
 
         expect(seen).toBe('slash:daily');
     });
 
-    it('prefers an explicit route id over the ctor metadata', async () => {
-        let seen: string | null | undefined;
-        const probe = defineGate('probe', (c: GateContextBase) => {
-            seen = c.routeId;
-        });
-        const dailyHandler = {};
-        Reflect.defineMetadata(InteractionRouteKeys[InteractionKind.Slash], ['daily'], dailyHandler);
-        Reflect.defineMetadata(GatedMetadataKey, [probe], dailyHandler);
-
-        await runHandlerGates(dailyHandler, ctx, 'slash:manifest');
-
-        expect(seen).toBe('slash:manifest');
-    });
-
-    it('leaves routeId null for a handler with no route metadata', async () => {
+    it('leaves declaredRoute null when the dispatcher matched no route', async () => {
         let seen: string | null | undefined = 'unset';
         const probe = defineGate('probe', (c: GateContextBase) => {
-            seen = c.routeId;
+            seen = c.declaredRoute;
         });
         const plain = {};
         Reflect.defineMetadata(GatedMetadataKey, [probe], plain);

--- a/packages/core/tests/node/process-errors.test.ts
+++ b/packages/core/tests/node/process-errors.test.ts
@@ -77,7 +77,7 @@ describe('process error handlers', () => {
             expect(reported).toHaveLength(1);
         });
         expect(reported[0]?.error).toBe(thrown);
-        expect(reported[0]?.routeId).toBe('process:unhandledRejection');
+        expect(reported[0]?.origin).toBe('process:unhandledRejection');
         expect(run).not.toHaveBeenCalled();
     });
 
@@ -92,7 +92,7 @@ describe('process error handlers', () => {
             expect(reported).toHaveLength(1);
         });
         expect(reported[0]?.error).toBe(thrown);
-        expect(reported[0]?.routeId).toBe('process:uncaughtException');
+        expect(reported[0]?.origin).toBe('process:uncaughtException');
         expect(run).toHaveBeenCalledWith(1);
     });
 

--- a/packages/core/tests/reply/replyTiming.test.ts
+++ b/packages/core/tests/reply/replyTiming.test.ts
@@ -2,6 +2,7 @@ import { Logger, LoggerChannelRegistry } from '@seedcord/logger';
 import { afterEach, describe, expect, it, vi, type MockInstance } from 'vitest';
 
 import { publishResponse } from '#reply/responseReport';
+import { DispatchContext } from '#src/dispatch/DispatchContext';
 import { Bus } from '#subscribers/Bus';
 
 import type { CoreBase } from '#interfaces/CoreBase';
@@ -31,8 +32,8 @@ describe('reply timing', () => {
         });
 
         publishResponse(
-            { bus: stubBus(), interactionId: 'i1' },
-            { routeId: 'slash:ban', method: 'reply', startedAt: performance.now(), outcome: 'sent', messageId: 'm1' }
+            { bus: stubBus(), dispatch: new DispatchContext('slash:ban'), interactionId: 'i1' },
+            { method: 'reply', startedAt: performance.now(), outcome: 'sent', messageId: 'm1' }
         );
         handle.dispose();
 
@@ -50,8 +51,8 @@ describe('reply timing', () => {
         clock += 88;
 
         publishResponse(
-            { bus: stubBus(), interactionId: 'i1' },
-            { routeId: 'slash:ban', method: 'reply', startedAt, outcome: 'sent', messageId: 'm1' }
+            { bus: stubBus(), dispatch: new DispatchContext('slash:ban'), interactionId: 'i1' },
+            { method: 'reply', startedAt, outcome: 'sent', messageId: 'm1' }
         );
 
         expect(trace).toHaveBeenCalledTimes(1);
@@ -66,9 +67,8 @@ describe('reply timing', () => {
         const trace = traceSpy();
 
         publishResponse(
-            { bus: stubBus(), interactionId: 'i1' },
+            { bus: stubBus(), dispatch: new DispatchContext('slash:ban'), interactionId: 'i1' },
             {
-                routeId: 'slash:ban',
                 method: 'respond',
                 startedAt: performance.now(),
                 outcome: 'failed',

--- a/packages/core/tests/reply/responseAttempted.test.ts
+++ b/packages/core/tests/reply/responseAttempted.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { BaseReplySender } from '#reply/BaseReplySender';
+import { DispatchContext } from '#src/dispatch/DispatchContext';
 import { Bus } from '#subscribers/Bus';
 
 import type { CoreBase } from '#interfaces/CoreBase';
@@ -16,7 +17,7 @@ const created: TestMessage = { id: 'm1' };
 
 class TestSender extends BaseReplySender<TestMessage> {
     public constructor(bus: Bus) {
-        super('slash:ping', { bus, interactionId: 'i1' });
+        super({ bus, dispatch: new DispatchContext('slash:ping'), interactionId: 'i1' });
     }
 
     protected writeReply(): Promise<TestMessage> {

--- a/packages/core/tests/subscribers/Bus.listener-isolation.test.ts
+++ b/packages/core/tests/subscribers/Bus.listener-isolation.test.ts
@@ -15,6 +15,7 @@ function stubBus(): Bus {
 
 const faultPayload = (): AllSubscriptions['unknownException'] => ({
     uuid: randomUUID(),
+    dispatchId: 'd-1',
     error: new Error('boom'),
     origin: 'slash:probe'
 });

--- a/packages/core/tests/subscribers/Bus.listener-isolation.test.ts
+++ b/packages/core/tests/subscribers/Bus.listener-isolation.test.ts
@@ -16,7 +16,7 @@ function stubBus(): Bus {
 const faultPayload = (): AllSubscriptions['unknownException'] => ({
     uuid: randomUUID(),
     error: new Error('boom'),
-    routeId: 'slash:probe'
+    origin: 'slash:probe'
 });
 
 describe('Bus listener isolation', () => {

--- a/packages/core/tests/subscribers/Bus.once-reentrancy.test.ts
+++ b/packages/core/tests/subscribers/Bus.once-reentrancy.test.ts
@@ -21,7 +21,7 @@ describe("Bus 'once' re-entrancy", () => {
         const payload: AllSubscriptions['unknownException'] = {
             uuid: randomUUID(),
             error: new Error('boom'),
-            routeId: 'slash:probe'
+            origin: 'slash:probe'
         };
 
         let runs = 0;

--- a/packages/core/tests/subscribers/Bus.once-reentrancy.test.ts
+++ b/packages/core/tests/subscribers/Bus.once-reentrancy.test.ts
@@ -20,6 +20,7 @@ describe("Bus 'once' re-entrancy", () => {
 
         const payload: AllSubscriptions['unknownException'] = {
             uuid: randomUUID(),
+            dispatchId: 'd-1',
             error: new Error('boom'),
             origin: 'slash:probe'
         };

--- a/packages/core/tests/subscribers/Bus.parallel.test.ts
+++ b/packages/core/tests/subscribers/Bus.parallel.test.ts
@@ -46,7 +46,7 @@ describe('Bus subscriber concurrency', () => {
         bus[PublishDefault]('unknownException', {
             uuid: crypto.randomUUID(),
             error: new Error('boom'),
-            routeId: 'slash:probe'
+            origin: 'slash:probe'
         });
         await delay(60);
 

--- a/packages/core/tests/subscribers/Bus.parallel.test.ts
+++ b/packages/core/tests/subscribers/Bus.parallel.test.ts
@@ -45,6 +45,7 @@ describe('Bus subscriber concurrency', () => {
 
         bus[PublishDefault]('unknownException', {
             uuid: crypto.randomUUID(),
+            dispatchId: 'd-1',
             error: new Error('boom'),
             origin: 'slash:probe'
         });

--- a/packages/core/tests/subscribers/Bus.publish-guard.test.ts
+++ b/packages/core/tests/subscribers/Bus.publish-guard.test.ts
@@ -29,6 +29,7 @@ describe('publish protection', () => {
 
         bus[PublishDefault]('unknownException', {
             uuid: crypto.randomUUID(),
+            dispatchId: 'd-1',
             error: new Error('boom'),
             origin: 'slash:probe'
         });

--- a/packages/core/tests/subscribers/Bus.publish-guard.test.ts
+++ b/packages/core/tests/subscribers/Bus.publish-guard.test.ts
@@ -30,7 +30,7 @@ describe('publish protection', () => {
         bus[PublishDefault]('unknownException', {
             uuid: crypto.randomUUID(),
             error: new Error('boom'),
-            routeId: 'slash:probe'
+            origin: 'slash:probe'
         });
 
         expect(seen).toBe(1);

--- a/packages/core/tests/subscribers/HandledException.test.ts
+++ b/packages/core/tests/subscribers/HandledException.test.ts
@@ -47,7 +47,7 @@ const eventSource: EventFaultSource = {
 const core = {} as unknown as CoreBase;
 
 function handledReport(denial: Notice, source: FaultSource, suppressed = 0): WebhookReport {
-    const data = { denial, uuid: randomUUID(), routeId: 'slash:probe', source };
+    const data = { denial, uuid: randomUUID(), origin: 'slash:probe', source };
     return new HandledException(data, core).report(suppressed);
 }
 

--- a/packages/core/tests/subscribers/HandledException.test.ts
+++ b/packages/core/tests/subscribers/HandledException.test.ts
@@ -47,7 +47,7 @@ const eventSource: EventFaultSource = {
 const core = {} as unknown as CoreBase;
 
 function handledReport(denial: Notice, source: FaultSource, suppressed = 0): WebhookReport {
-    const data = { denial, uuid: randomUUID(), origin: 'slash:probe', source };
+    const data = { denial, uuid: randomUUID(), dispatchId: 'd-1', origin: 'slash:probe', source };
     return new HandledException(data, core).report(suppressed);
 }
 

--- a/packages/core/tests/subscribers/UnknownException.test.ts
+++ b/packages/core/tests/subscribers/UnknownException.test.ts
@@ -16,7 +16,7 @@ const core = {} as unknown as CoreBase;
 
 // the text a text-display carries in the container, so an assertion sees the real webhook string
 function reportText(error: Error, suppressed = 0): string {
-    const report = new UnknownException({ uuid: randomUUID(), error, routeId: 'slash:probe' }, core).report(suppressed);
+    const report = new UnknownException({ uuid: randomUUID(), error, origin: 'slash:probe' }, core).report(suppressed);
     // justified: report() emits a single container component, its json shape is APIContainerComponent
     const container = report.components[0]?.toJSON() as APIContainerComponent;
     return container.components

--- a/packages/core/tests/subscribers/UnknownException.test.ts
+++ b/packages/core/tests/subscribers/UnknownException.test.ts
@@ -16,7 +16,8 @@ const core = {} as unknown as CoreBase;
 
 // the text a text-display carries in the container, so an assertion sees the real webhook string
 function reportText(error: Error, suppressed = 0): string {
-    const report = new UnknownException({ uuid: randomUUID(), error, origin: 'slash:probe' }, core).report(suppressed);
+    const data = { uuid: randomUUID(), dispatchId: 'd-1', error, origin: 'slash:probe' };
+    const report = new UnknownException(data, core).report(suppressed);
     // justified: report() emits a single container component, its json shape is APIContainerComponent
     const container = report.components[0]?.toJSON() as APIContainerComponent;
     return container.components

--- a/packages/core/tests/subscribers/bus-surface.test.ts
+++ b/packages/core/tests/subscribers/bus-surface.test.ts
@@ -25,7 +25,7 @@ describe('the Bus surface a bot author reaches', () => {
     it('throws on emit, which would skip every subscriber', () => {
         const bus = stubBus();
 
-        const payload = { uuid: randomUUID(), error: new Error('x'), routeId: 'r' };
+        const payload = { uuid: randomUUID(), error: new Error('x'), origin: 'r' };
 
         // eslint-disable-next-line @typescript-eslint/no-deprecated --  this pins the deprecation
         expect(() => bus.emit('unknownException', payload)).toThrow(

--- a/packages/core/tests/subscribers/bus-surface.test.ts
+++ b/packages/core/tests/subscribers/bus-surface.test.ts
@@ -25,7 +25,7 @@ describe('the Bus surface a bot author reaches', () => {
     it('throws on emit, which would skip every subscriber', () => {
         const bus = stubBus();
 
-        const payload = { uuid: randomUUID(), error: new Error('x'), origin: 'r' };
+        const payload = { uuid: randomUUID(), dispatchId: 'd-1', error: new Error('x'), origin: 'r' };
 
         // eslint-disable-next-line @typescript-eslint/no-deprecated --  this pins the deprecation
         expect(() => bus.emit('unknownException', payload)).toThrow(

--- a/packages/core/tests/subscribers/default-reporter-keys.test.ts
+++ b/packages/core/tests/subscribers/default-reporter-keys.test.ts
@@ -54,10 +54,10 @@ beforeEach(() => {
 
 describe('the two default reporters', () => {
     it('keep their own throttle windows on one route and one error name', async () => {
-        const routeId = 'slash:ban';
+        const origin = 'slash:ban';
 
-        await new UnknownException({ uuid: randomUUID(), error: new Boom(), routeId }, core).execute();
-        await new HandledException({ denial: new Boom(), uuid: randomUUID(), routeId, source }, core).execute();
+        await new UnknownException({ uuid: randomUUID(), error: new Boom(), origin }, core).execute();
+        await new HandledException({ denial: new Boom(), uuid: randomUUID(), origin, source }, core).execute();
 
         expect(hoisted.postMock).toHaveBeenCalledTimes(2);
     });

--- a/packages/core/tests/subscribers/default-reporter-keys.test.ts
+++ b/packages/core/tests/subscribers/default-reporter-keys.test.ts
@@ -55,9 +55,13 @@ beforeEach(() => {
 describe('the two default reporters', () => {
     it('keep their own throttle windows on one route and one error name', async () => {
         const origin = 'slash:ban';
+        const dispatchId = 'd-1';
 
-        await new UnknownException({ uuid: randomUUID(), error: new Boom(), origin }, core).execute();
-        await new HandledException({ denial: new Boom(), uuid: randomUUID(), origin, source }, core).execute();
+        await new UnknownException({ uuid: randomUUID(), dispatchId, error: new Boom(), origin }, core).execute();
+        await new HandledException(
+            { denial: new Boom(), uuid: randomUUID(), dispatchId, origin, source },
+            core
+        ).execute();
 
         expect(hoisted.postMock).toHaveBeenCalledTimes(2);
     });

--- a/packages/gateway/src/bot/ReplySender.ts
+++ b/packages/gateway/src/bot/ReplySender.ts
@@ -6,7 +6,7 @@ import { MessageFlags } from 'discord.js';
 
 import type { GatewayFile, GatewayReplyResponse } from '#interfaces/ReplyResponse';
 import type { Repliables } from '#src/handlers/interactionTypes';
-import type { Bus } from '@seedcord/core';
+import type { Bus, DispatchContext } from '@seedcord/core';
 import type { AckState } from '@seedcord/core/internal';
 import type { DeferOpts, ReplyFile, SendOpts } from '@seedcord/types';
 import type {
@@ -53,10 +53,10 @@ function seedState(interaction: Repliables): AckState {
 export class ReplySender extends BaseReplySender<SentMessage, GatewayFile> {
     public constructor(
         private readonly interaction: Repliables,
-        routeId: string,
+        dispatch: DispatchContext,
         bus: Bus
     ) {
-        super(routeId, { bus, interactionId: interaction.id }, seedState(interaction));
+        super({ bus, dispatch, interactionId: interaction.id }, seedState(interaction));
     }
 
     protected async writeReply(

--- a/packages/gateway/src/bot/controllers/EventDispatcher.ts
+++ b/packages/gateway/src/bot/controllers/EventDispatcher.ts
@@ -23,6 +23,7 @@ import { Envapter } from 'envapt';
 import { eventMiddlewareMetaOf } from '#bDecorators/Middlewares';
 import { eventGateContext } from '#bot/gates/runGates';
 import { handleEventFault } from '#bot/handleEventFault';
+import { reportEventDispatch } from '#bot/reportEventDispatch';
 import { EventHandler, EventMiddleware } from '#handlers/event';
 
 import type { RegisterEventMetadataEntry } from '#bDecorators/Events';
@@ -347,6 +348,7 @@ export class EventDispatcher implements Initializeable, HmrAware {
 
         if (handlersToExecute.length === 0) return;
 
+        const startedAt = performance.now();
         const dispatch = new DispatchContext(`event:${String(eventName)}`);
         const ran: EventMiddleware[] = [];
         const handlers: HandlerResult[] = [];
@@ -367,7 +369,9 @@ export class EventDispatcher implements Initializeable, HmrAware {
                 handlers.push(await this.processHandler(eventName, entry.ctor, args, dispatch));
             }
         } finally {
-            await runAfter(ran, eventResultFor(stopped, handlers), this.logger);
+            const result = eventResultFor(stopped, handlers);
+            reportEventDispatch(this.core, eventName, result, startedAt);
+            await runAfter(ran, result, this.logger);
         }
     }
 

--- a/packages/gateway/src/bot/controllers/EventDispatcher.ts
+++ b/packages/gateway/src/bot/controllers/EventDispatcher.ts
@@ -344,9 +344,9 @@ export class EventDispatcher implements Initializeable, HmrAware {
 
         if (handlersToExecute.length === 0) return;
 
-        reportEventDispatching(this.core, eventName, args);
-
         const dispatch = new DispatchContext(`event:${String(eventName)}`);
+        reportEventDispatching(this.core, dispatch.id, eventName, args);
+
         const ran: EventMiddleware[] = [];
         const handlers: HandlerResult[] = [];
         let stopped: { caught: unknown } | null = null;
@@ -367,7 +367,7 @@ export class EventDispatcher implements Initializeable, HmrAware {
             }
         } finally {
             const result = eventResultFor(stopped, handlers);
-            reportEventDispatched(this.core, eventName, result, startedAt);
+            reportEventDispatched(this.core, dispatch.id, eventName, result, startedAt);
             await runAfter(ran, result, this.logger);
         }
     }

--- a/packages/gateway/src/bot/controllers/EventDispatcher.ts
+++ b/packages/gateway/src/bot/controllers/EventDispatcher.ts
@@ -23,13 +23,13 @@ import { Envapter } from 'envapt';
 import { eventMiddlewareMetaOf } from '#bDecorators/Middlewares';
 import { eventGateContext } from '#bot/gates/runGates';
 import { handleEventFault } from '#bot/handleEventFault';
-import { reportEventDispatch } from '#bot/reportEventDispatch';
+import { reportEventDispatched, reportEventDispatching } from '#bot/reportEventDispatch';
 import { EventHandler, EventMiddleware } from '#handlers/event';
 
 import type { RegisterEventMetadataEntry } from '#bDecorators/Events';
 import type { EventHandlerConstructor, EventMiddlewareConstructor } from '#handlers/constructors';
 import type { Core } from '#interfaces/Core';
-import type { HandlerResult, SubscriptionData } from '@seedcord/core';
+import type { HandlerResult } from '@seedcord/core';
 import type { Initializeable, MiddlewareRegistrationOf } from '@seedcord/core/internal';
 import type { EventFrequency, HmrAware, HmrUpdateEvent } from '@seedcord/types';
 import type { ClientEvents } from 'discord.js';
@@ -312,11 +312,6 @@ export class EventDispatcher implements Initializeable, HmrAware {
 
         this.core.bot.client.on(eventName, (...args: ClientEvents[typeof eventName]) => {
             if (this.draining) return;
-            // justified: the generic key erases the per-event tuple and args matches eventName here
-            this.core.bus[PublishDefault]('eventDispatching', {
-                name: eventName,
-                args
-            } as SubscriptionData<'eventDispatching'>);
             const run = this.processEvent(eventName, args).catch((caught: unknown) => {
                 const error = asError(caught);
                 this.logger.error(`[${paint.coral.bold('UNHANDLED ERROR AT ROOT')}] ${error.name}`, error.stack);
@@ -339,6 +334,7 @@ export class EventDispatcher implements Initializeable, HmrAware {
         eventName: KeyOfEvents,
         args: ClientEvents[KeyOfEvents]
     ): Promise<void> {
+        const startedAt = performance.now();
         const handlerEntries = this.eventMap.get(eventName);
         if (!handlerEntries || handlerEntries.length === 0) return;
 
@@ -348,7 +344,8 @@ export class EventDispatcher implements Initializeable, HmrAware {
 
         if (handlersToExecute.length === 0) return;
 
-        const startedAt = performance.now();
+        reportEventDispatching(this.core, eventName, args);
+
         const dispatch = new DispatchContext(`event:${String(eventName)}`);
         const ran: EventMiddleware[] = [];
         const handlers: HandlerResult[] = [];
@@ -370,7 +367,7 @@ export class EventDispatcher implements Initializeable, HmrAware {
             }
         } finally {
             const result = eventResultFor(stopped, handlers);
-            reportEventDispatch(this.core, eventName, result, startedAt);
+            reportEventDispatched(this.core, eventName, result, startedAt);
             await runAfter(ran, result, this.logger);
         }
     }

--- a/packages/gateway/src/bot/controllers/InteractionDispatcher.ts
+++ b/packages/gateway/src/bot/controllers/InteractionDispatcher.ts
@@ -74,8 +74,7 @@ interface DispatchReportRow {
     readonly fallback: boolean;
     readonly startedAt: number;
     readonly queuedMs: number;
-    // read late, since a matched handler's own routeId replaces the map key
-    readonly routeId: () => string;
+    readonly routeId: string;
 }
 
 interface BeforeHandler {
@@ -404,7 +403,7 @@ export class InteractionDispatcher implements Initializeable, HmrAware {
             fallback: !matched,
             startedAt,
             queuedMs,
-            routeId: () => dispatch.routeId
+            routeId: dispatch.routeId
         });
 
         // outside the try so the fault boundary keeps the handler's ack state
@@ -468,7 +467,7 @@ export class InteractionDispatcher implements Initializeable, HmrAware {
             if (reported) return;
             reported = true;
             reportDispatch(this.core.bus, {
-                routeId: row.routeId(),
+                routeId: row.routeId,
                 interactionId: row.interaction.id,
                 kind: row.kind,
                 outcome,

--- a/packages/gateway/src/bot/controllers/InteractionDispatcher.ts
+++ b/packages/gateway/src/bot/controllers/InteractionDispatcher.ts
@@ -13,7 +13,6 @@ import {
     MiddlewareRegistry,
     PublishDefault,
     resultFor,
-    routeIdOf,
     runAfter,
     runHandlerGates,
     slowGateMonitor
@@ -398,7 +397,7 @@ export class InteractionDispatcher implements Initializeable, HmrAware {
 
         const HandlerCtor = matched ?? fallback;
         // an empty key means a customId seedcord never minted
-        const dispatch = new DispatchContext(routeIdOf(HandlerCtor) ?? `${kind}:${key || 'unrouted'}`);
+        const dispatch = new DispatchContext(`${kind}:${key || 'unrouted'}`);
         const report = this.reporterFor({
             interaction,
             kind,

--- a/packages/gateway/src/bot/controllers/InteractionDispatcher.ts
+++ b/packages/gateway/src/bot/controllers/InteractionDispatcher.ts
@@ -84,6 +84,7 @@ interface BeforeHandler {
     readonly dispatch: DispatchContext;
     readonly sender: ReplySender | undefined;
     readonly ran: InteractionMiddleware[];
+    readonly declaredRoute: string | undefined;
 }
 
 export class InteractionDispatcher implements Initializeable, HmrAware {
@@ -414,7 +415,15 @@ export class InteractionDispatcher implements Initializeable, HmrAware {
             const handler = this.buildHandler(HandlerCtor, interaction as Repliables, dispatch, key, !matched);
             if (handler instanceof RepliableHandler) sender = handler.sender;
 
-            const refusal = await this.refusalBeforeHandler({ HandlerCtor, kind, interaction, dispatch, sender, ran });
+            const refusal = await this.refusalBeforeHandler({
+                HandlerCtor,
+                kind,
+                interaction,
+                dispatch,
+                sender,
+                ran,
+                declaredRoute: matched ? dispatch.routeId : undefined
+            });
             if (refusal) {
                 result = resultFor(refusal.caught);
                 await this.answer(refusal.caught, interaction as ValidInteractionTypes, dispatch, sender, report);
@@ -482,7 +491,7 @@ export class InteractionDispatcher implements Initializeable, HmrAware {
 
     // a returned value is the throw that stops the dispatch before the handler runs
     private async refusalBeforeHandler(step: BeforeHandler): Promise<{ caught: unknown } | null> {
-        const { HandlerCtor, kind, interaction, dispatch, sender, ran } = step;
+        const { HandlerCtor, kind, interaction, dispatch, sender, ran, declaredRoute } = step;
 
         if (kind !== InteractionKind.Autocomplete && sender) {
             try {
@@ -494,7 +503,7 @@ export class InteractionDispatcher implements Initializeable, HmrAware {
 
         // @Gated rejects autocomplete at compile time, since it has no reply target. this is the backstop
         if (interaction.isAutocomplete()) return null;
-        return this.gateRefusal(HandlerCtor, interaction as Repliables, dispatch);
+        return this.gateRefusal(HandlerCtor, interaction as Repliables, dispatch, declaredRoute);
     }
 
     private async runMiddlewares(
@@ -517,14 +526,15 @@ export class InteractionDispatcher implements Initializeable, HmrAware {
     private async gateRefusal(
         HandlerCtor: HandlerConstructor,
         interaction: Repliables,
-        dispatch: DispatchContext
+        dispatch: DispatchContext,
+        declaredRoute: string | undefined
     ): Promise<{ caught: unknown } | null> {
         const monitor = slowGateMonitor();
         try {
             await runHandlerGates(
                 HandlerCtor,
                 interactionGateContext(interaction, this.core, dispatch),
-                dispatch.routeId,
+                declaredRoute,
                 monitor?.observe
             );
             return null;
@@ -532,7 +542,7 @@ export class InteractionDispatcher implements Initializeable, HmrAware {
             return { caught };
         } finally {
             // a refusing gate spent budget too
-            monitor?.report(dispatch.routeId);
+            monitor?.report(declaredRoute ?? null);
         }
     }
 

--- a/packages/gateway/src/bot/controllers/InteractionDispatcher.ts
+++ b/packages/gateway/src/bot/controllers/InteractionDispatcher.ts
@@ -74,6 +74,7 @@ interface DispatchReportRow {
     readonly fallback: boolean;
     readonly startedAt: number;
     readonly queuedMs: number;
+    readonly dispatchId: string;
     readonly routeId: string;
 }
 
@@ -404,6 +405,7 @@ export class InteractionDispatcher implements Initializeable, HmrAware {
             fallback: !matched,
             startedAt,
             queuedMs,
+            dispatchId: dispatch.id,
             routeId: dispatch.routeId
         });
 
@@ -476,6 +478,7 @@ export class InteractionDispatcher implements Initializeable, HmrAware {
             if (reported) return;
             reported = true;
             reportDispatch(this.core.bus, {
+                dispatchId: row.dispatchId,
                 routeId: row.routeId,
                 interactionId: row.interaction.id,
                 kind: row.kind,

--- a/packages/gateway/src/bot/gates/runGates.ts
+++ b/packages/gateway/src/bot/gates/runGates.ts
@@ -66,6 +66,6 @@ export function eventGateContext(
         appPermissions: null,
         memberGuildPermissions: actor.member?.permissions.bitfield ?? null,
         appGuildPermissions: actor.guild?.members.me?.permissions.bitfield ?? null,
-        declaredRoute: null // an event handler declares no route, so this stays null through the gates
+        declaredRoute: null // an event handler doesn't declare a route
     };
 }

--- a/packages/gateway/src/bot/gates/runGates.ts
+++ b/packages/gateway/src/bot/gates/runGates.ts
@@ -37,7 +37,7 @@ export function interactionGateContext(
         appPermissions: interaction.appPermissions.bitfield,
         memberGuildPermissions: rawMember instanceof GuildMember ? rawMember.permissions.bitfield : null,
         appGuildPermissions: interaction.guild?.members.me?.permissions.bitfield ?? null,
-        routeId: null // runHandlerGates sets routeId from the handler metadata before the gates run
+        declaredRoute: null // runHandlerGates overwrites this with the matched route
     };
 }
 
@@ -66,6 +66,6 @@ export function eventGateContext(
         appPermissions: null,
         memberGuildPermissions: actor.member?.permissions.bitfield ?? null,
         appGuildPermissions: actor.guild?.members.me?.permissions.bitfield ?? null,
-        routeId: null // runHandlerGates sets routeId from the handler metadata before the gates run
+        declaredRoute: null // an event handler declares no route, so this stays null through the gates
     };
 }

--- a/packages/gateway/src/bot/handleEventFault.ts
+++ b/packages/gateway/src/bot/handleEventFault.ts
@@ -40,7 +40,7 @@ export function handleEventFault(caught: unknown, fault: EventFault, core: Core)
     const actor = deriveEventActor(args);
     extractErrorResponse(error, core, {
         event: { name: eventName, handler: handlerName, args, channelId: actor.channelId },
-        routeId: `event:${eventName}:${handlerName}`,
+        origin: `event:${eventName}:${handlerName}`,
         dispatch,
         guild: actor.guild,
         user: actor.user

--- a/packages/gateway/src/bot/handleInteractionFault.ts
+++ b/packages/gateway/src/bot/handleInteractionFault.ts
@@ -48,7 +48,7 @@ export async function handleInteractionFault(
             metadata: interaction
         });
         // empty choices clear the client's loading spinner
-        await sendEmptyChoices(interaction, core, routeId);
+        await sendEmptyChoices(interaction, core, dispatch);
         return;
     }
 
@@ -61,14 +61,18 @@ export async function handleInteractionFault(
         metadata: interaction
     });
     // the handler's own sender carries its ack state. a middleware throw arrives without one
-    const liveSender = sender ?? new ReplySender(interaction, routeId, core.bus);
+    const liveSender = sender ?? new ReplySender(interaction, dispatch, core.bus);
     await sendGuarded(liveSender, response, error instanceof Notice ? error.ephemeral : true);
 }
 
-async function sendEmptyChoices(interaction: AutocompleteInteraction, core: Core, routeId: string): Promise<void> {
-    const telemetry = { bus: core.bus, interactionId: interaction.id };
+async function sendEmptyChoices(
+    interaction: AutocompleteInteraction,
+    core: Core,
+    dispatch: DispatchContext
+): Promise<void> {
+    const telemetry = { bus: core.bus, dispatch, interactionId: interaction.id };
     try {
-        await reportedWrite(telemetry, routeId, 'respond', () => interaction.respond([]));
+        await reportedWrite(telemetry, 'respond', () => interaction.respond([]));
     } catch (error) {
         logger.debug(`autocomplete empty-choices send failed: ${String(error)}`);
     }

--- a/packages/gateway/src/bot/handleInteractionFault.ts
+++ b/packages/gateway/src/bot/handleInteractionFault.ts
@@ -41,7 +41,7 @@ export async function handleInteractionFault(
     // discord does not accept a message on an autocomplete. the fault is only reported.
     if (interaction.isAutocomplete()) {
         extractErrorResponse(error, core, {
-            routeId,
+            origin: routeId,
             dispatch,
             guild: interaction.guild,
             user: interaction.user,
@@ -54,7 +54,7 @@ export async function handleInteractionFault(
 
     const { response } = extractErrorResponse(error, core, {
         interaction,
-        routeId,
+        origin: routeId,
         dispatch,
         guild: interaction.guild,
         user: interaction.user,

--- a/packages/gateway/src/bot/reportEventDispatch.ts
+++ b/packages/gateway/src/bot/reportEventDispatch.ts
@@ -1,11 +1,20 @@
 import { PublishDefault } from '@seedcord/core/internal';
 
 import type { Core } from '#interfaces/Core';
-import type { EventDispatchResult } from '@seedcord/core';
+import type { EventDispatchResult, SubscriptionData } from '@seedcord/core';
 import type { ClientEvents } from 'discord.js';
 
+export function reportEventDispatching<Name extends keyof ClientEvents>(
+    core: Core,
+    name: Name,
+    args: ClientEvents[Name]
+): void {
+    // justified: the generic key erases the per-event tuple and args matches name here
+    core.bus[PublishDefault]('eventDispatching', { name, args } as SubscriptionData<'eventDispatching'>);
+}
+
 // the interaction side of this is core's reportDispatch
-export function reportEventDispatch(
+export function reportEventDispatched(
     core: Core,
     name: keyof ClientEvents,
     result: EventDispatchResult,

--- a/packages/gateway/src/bot/reportEventDispatch.ts
+++ b/packages/gateway/src/bot/reportEventDispatch.ts
@@ -1,0 +1,20 @@
+import { PublishDefault } from '@seedcord/core/internal';
+
+import type { Core } from '#interfaces/Core';
+import type { EventDispatchResult } from '@seedcord/core';
+import type { ClientEvents } from 'discord.js';
+
+// the event twin of core's reportDispatch, which publishes interactionDispatched
+export function reportEventDispatch(
+    core: Core,
+    name: keyof ClientEvents,
+    result: EventDispatchResult,
+    startedAt: number
+): void {
+    core.bus[PublishDefault]('eventDispatched', {
+        name,
+        outcome: result.outcome,
+        handlers: result.handlers.map(({ handler, outcome }) => ({ handler, outcome })),
+        durationMs: performance.now() - startedAt
+    });
+}

--- a/packages/gateway/src/bot/reportEventDispatch.ts
+++ b/packages/gateway/src/bot/reportEventDispatch.ts
@@ -6,21 +6,24 @@ import type { ClientEvents } from 'discord.js';
 
 export function reportEventDispatching<Name extends keyof ClientEvents>(
     core: Core,
+    dispatchId: string,
     name: Name,
     args: ClientEvents[Name]
 ): void {
     // justified: the generic key erases the per-event tuple and args matches name here
-    core.bus[PublishDefault]('eventDispatching', { name, args } as SubscriptionData<'eventDispatching'>);
+    core.bus[PublishDefault]('eventDispatching', { dispatchId, name, args } as SubscriptionData<'eventDispatching'>);
 }
 
 // the interaction side of this is core's reportDispatch
 export function reportEventDispatched(
     core: Core,
+    dispatchId: string,
     name: keyof ClientEvents,
     result: EventDispatchResult,
     startedAt: number
 ): void {
     core.bus[PublishDefault]('eventDispatched', {
+        dispatchId,
         name,
         outcome: result.outcome,
         handlers: result.handlers.map(({ handler, outcome }) => ({ handler, outcome })),

--- a/packages/gateway/src/bot/reportEventDispatch.ts
+++ b/packages/gateway/src/bot/reportEventDispatch.ts
@@ -4,7 +4,7 @@ import type { Core } from '#interfaces/Core';
 import type { EventDispatchResult } from '@seedcord/core';
 import type { ClientEvents } from 'discord.js';
 
-// the event twin of core's reportDispatch, which publishes interactionDispatched
+// the interaction side of this is core's reportDispatch
 export function reportEventDispatch(
     core: Core,
     name: keyof ClientEvents,

--- a/packages/gateway/src/handlers/RepliableHandler.ts
+++ b/packages/gateway/src/handlers/RepliableHandler.ts
@@ -6,6 +6,7 @@ import type { SentMessage } from '#bot/ReplySender';
 import type { Core } from '#interfaces/Core';
 import type { GatewayFile } from '#interfaces/ReplyResponse';
 import type { Repliables } from './interactionTypes';
+import type { DispatchContext } from '@seedcord/core';
 
 /**
  * Shared base the repliable interaction handlers extend.
@@ -29,7 +30,7 @@ export abstract class RepliableHandler<Event extends Repliables> extends CoreRep
         return this.event;
     }
 
-    protected buildSender(event: Event, core: Core, routeId: string): ReplySender {
-        return new ReplySender(event, routeId, core.bus);
+    protected buildSender(event: Event, core: Core, dispatch: DispatchContext): ReplySender {
+        return new ReplySender(event, dispatch, core.bus);
     }
 }

--- a/packages/gateway/src/handlers/interaction/AutocompleteHandler.ts
+++ b/packages/gateway/src/handlers/interaction/AutocompleteHandler.ts
@@ -112,8 +112,7 @@ export abstract class AutocompleteHandler<
     /** Send autocomplete suggestions, callback type 8. Prefer {@link match}, which restricts each field's choices to its declared type. */
     protected async respond(choices: readonly ApplicationCommandOptionChoiceData[]): Promise<void> {
         await reportedWrite(
-            { bus: this.core.bus, interactionId: this.event.id },
-            this.dispatch.routeId,
+            { bus: this.core.bus, dispatch: this.dispatch, interactionId: this.event.id },
             'respond',
             () =>
                 // eslint-disable-next-line @seedcord/no-raw-interaction-acks -- this is the base respond and calls djs directly

--- a/packages/gateway/src/miscellaneous/extractErrorResponse.ts
+++ b/packages/gateway/src/miscellaneous/extractErrorResponse.ts
@@ -28,7 +28,7 @@ interface EventOrigin {
 export interface ErrorOrigin {
     interaction?: Repliables;
     event?: EventOrigin;
-    routeId: string;
+    origin: string;
     dispatch: DispatchContext;
     guild: Nullable<Guild>;
     user: Nullable<User>;
@@ -40,19 +40,19 @@ export interface ExtractedErrorResponse {
     response: ReplyResponse;
 }
 
-export function extractErrorResponse(error: Error, core: Core, origin: ErrorOrigin): ExtractedErrorResponse {
+export function extractErrorResponse(error: Error, core: Core, fault: ErrorOrigin): ExtractedErrorResponse {
     const uuid = crypto.randomUUID();
-    const { dispatch } = origin;
+    const { dispatch } = fault;
     const developerUsername = core.config.notifications?.developerUsername;
     const ctx: RenderContext =
         developerUsername === undefined ? { uuid, dispatch } : { uuid, developerUsername, dispatch };
 
     if (error instanceof Notice) {
-        if (error.report) reportFault(error, core, origin, uuid);
+        if (error.report) reportFault(error, core, fault, uuid);
         return { uuid, response: error.render(ctx) };
     }
 
-    reportRawFault(error, core, origin, uuid);
+    reportRawFault(error, core, fault, uuid);
 
     const Override = core.config.errors?.defaultError;
     const response = Override ? new Override(uuid).render(ctx) : new Fault().render(ctx);
@@ -60,31 +60,31 @@ export function extractErrorResponse(error: Error, core: Core, origin: ErrorOrig
     return { uuid, response };
 }
 
-function reportFault(denial: Notice, core: Core, origin: ErrorOrigin, uuid: UUID): void {
+function reportFault(denial: Notice, core: Core, fault: ErrorOrigin, uuid: UUID): void {
     logger.error(`${denial.name}: ${uuid}`, denial);
 
-    if (origin.interaction) {
+    if (fault.interaction) {
         core.bus[PublishDefault]('handledException', {
             denial,
             uuid,
-            routeId: origin.routeId,
-            source: buildInteractionSource(origin.interaction)
+            origin: fault.origin,
+            source: buildInteractionSource(fault.interaction)
         });
-    } else if (origin.event) {
+    } else if (fault.event) {
         core.bus[PublishDefault]('handledException', {
             denial,
             uuid,
-            routeId: origin.routeId,
-            source: buildEventSource(origin.event, origin)
+            origin: fault.origin,
+            source: buildEventSource(fault.event, fault)
         });
     } else {
         // an autocomplete throw has no typed source. unknownException is the only channel left
         core.bus[PublishDefault]('unknownException', {
             uuid,
             error: denial,
-            routeId: origin.routeId,
-            ...scalarActors(origin),
-            metadata: metadataFor(origin)
+            origin: fault.origin,
+            ...scalarActors(fault),
+            metadata: metadataFor(fault)
         });
     }
 }
@@ -96,7 +96,7 @@ function causeLine(error: Error): string {
     return `\ncaused by ${cause.name}: ${first ?? cause.message}`;
 }
 
-function reportRawFault(error: Error, core: Core, origin: ErrorOrigin, uuid: UUID): void {
+function reportRawFault(error: Error, core: Core, fault: ErrorOrigin, uuid: UUID): void {
     const showStack = core.config.errors?.errorStack ?? false;
     if (showStack) logger.error(uuid, error);
     else logger.error(`${uuid} | ${error.message}${causeLine(error)}`);
@@ -104,32 +104,32 @@ function reportRawFault(error: Error, core: Core, origin: ErrorOrigin, uuid: UUI
     core.bus[PublishDefault]('unknownException', {
         uuid,
         error,
-        routeId: origin.routeId,
-        ...scalarActors(origin),
-        metadata: metadataFor(origin)
+        origin: fault.origin,
+        ...scalarActors(fault),
+        metadata: metadataFor(fault)
     });
 }
 
 // the bus payload must stay djs-free
-function scalarActors(origin: ErrorOrigin): Pick<SubscriptionData<'unknownException'>, 'guild' | 'user'> {
+function scalarActors(fault: ErrorOrigin): Pick<SubscriptionData<'unknownException'>, 'guild' | 'user'> {
     return {
-        guild: origin.guild ? { id: origin.guild.id, name: origin.guild.name } : undefined,
-        user: origin.user ? { id: origin.user.id, username: origin.user.username } : undefined
+        guild: fault.guild ? { id: fault.guild.id, name: fault.guild.name } : undefined,
+        user: fault.user ? { id: fault.user.id, username: fault.user.username } : undefined
     };
 }
 
-function metadataFor(origin: ErrorOrigin): unknown {
-    if (origin.event) return { eventName: origin.event.name, handler: origin.event.handler, args: origin.event.args };
-    return origin.metadata;
+function metadataFor(fault: ErrorOrigin): unknown {
+    if (fault.event) return { eventName: fault.event.name, handler: fault.event.handler, args: fault.event.args };
+    return fault.metadata;
 }
 
-function buildEventSource(event: EventOrigin, origin: ErrorOrigin): EventFaultSource {
+function buildEventSource(event: EventOrigin, fault: ErrorOrigin): EventFaultSource {
     return {
         kind: 'event',
         eventName: event.name,
         handler: event.handler,
-        userId: origin.user?.id ?? null,
-        guildId: origin.guild?.id ?? null,
+        userId: fault.user?.id ?? null,
+        guildId: fault.guild?.id ?? null,
         channelId: event.channelId,
         raw: event.args
     };

--- a/packages/gateway/src/miscellaneous/extractErrorResponse.ts
+++ b/packages/gateway/src/miscellaneous/extractErrorResponse.ts
@@ -67,6 +67,7 @@ function reportFault(denial: Notice, core: Core, fault: ErrorOrigin, uuid: UUID)
         core.bus[PublishDefault]('handledException', {
             denial,
             uuid,
+            dispatchId: fault.dispatch.id,
             origin: fault.origin,
             source: buildInteractionSource(fault.interaction)
         });
@@ -74,6 +75,7 @@ function reportFault(denial: Notice, core: Core, fault: ErrorOrigin, uuid: UUID)
         core.bus[PublishDefault]('handledException', {
             denial,
             uuid,
+            dispatchId: fault.dispatch.id,
             origin: fault.origin,
             source: buildEventSource(fault.event, fault)
         });
@@ -81,6 +83,7 @@ function reportFault(denial: Notice, core: Core, fault: ErrorOrigin, uuid: UUID)
         // an autocomplete throw has no typed source. unknownException is the only channel left
         core.bus[PublishDefault]('unknownException', {
             uuid,
+            dispatchId: fault.dispatch.id,
             error: denial,
             origin: fault.origin,
             ...scalarActors(fault),
@@ -103,6 +106,7 @@ function reportRawFault(error: Error, core: Core, fault: ErrorOrigin, uuid: UUID
 
     core.bus[PublishDefault]('unknownException', {
         uuid,
+        dispatchId: fault.dispatch.id,
         error,
         origin: fault.origin,
         ...scalarActors(fault),

--- a/packages/gateway/src/subscriptions.ts
+++ b/packages/gateway/src/subscriptions.ts
@@ -1,3 +1,4 @@
+import type { DispatchOutcome, HandlerOutcome } from '@seedcord/core';
 import type { ClientEvents, Interaction } from 'discord.js';
 
 declare module '@seedcord/core/internal' {
@@ -10,6 +11,19 @@ declare module '@seedcord/core/internal' {
         eventDispatching: {
             [Name in keyof ClientEvents]: { name: Name; args: ClientEvents[Name] };
         }[keyof ClientEvents];
+        /**
+         * Triggered once an event's handlers settle, pairing with `eventDispatching`. A fire that runs no
+         * handler triggers neither.
+         */
+        eventDispatched: {
+            name: keyof ClientEvents;
+            /** How the middleware chain ended. A chain that refused the event leaves `handlers` empty. */
+            outcome: DispatchOutcome;
+            /** One entry per handler that ran, in the order they ran. */
+            handlers: readonly HandlerOutcome[];
+            /** Dispatch entry until every handler settles. A clock change never affects it. */
+            durationMs: number;
+        };
         /** Triggered for every interaction the bot receives, before routing. */
         anyInteraction: {
             interaction: Interaction;

--- a/packages/gateway/src/subscriptions.ts
+++ b/packages/gateway/src/subscriptions.ts
@@ -9,13 +9,15 @@ declare module '@seedcord/core/internal' {
         };
         /** Triggered before an event's handlers run. An event that no handler registered never triggers it. */
         eventDispatching: {
-            [Name in keyof ClientEvents]: { name: Name; args: ClientEvents[Name] };
+            [Name in keyof ClientEvents]: { dispatchId: string; name: Name; args: ClientEvents[Name] };
         }[keyof ClientEvents];
         /**
          * Triggered once an event's handlers settle, pairing with `eventDispatching`. A fire that runs no
          * handler triggers neither.
          */
         eventDispatched: {
+            /** The same id `eventDispatching` published for this fire. */
+            dispatchId: string;
             name: keyof ClientEvents;
             /** How the middleware chain ended. A chain that refused the event leaves `handlers` empty. */
             outcome: DispatchOutcome;

--- a/packages/gateway/tests/bot/gates/multi-route-gates.test.ts
+++ b/packages/gateway/tests/bot/gates/multi-route-gates.test.ts
@@ -1,0 +1,125 @@
+import { CustomId, InteractionKind } from '@seedcord/core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { interactionsOf } from '#bot/Bot';
+import { Seedcord } from '#src/Seedcord';
+
+import { seedcordPath } from '../../utils/source-path';
+import { testConfig } from '../../utils/test-config';
+import { TestEnvironment } from '../../utils/test-env';
+
+import type { SubscriptionData } from '@seedcord/core';
+
+import '../../utils/mock-env';
+
+interface PrivateInteractionDispatcher {
+    maps: Record<InteractionKind, Map<string, unknown>>;
+    init(): Promise<void>;
+    handleButton(interaction: unknown): Promise<void>;
+}
+
+// justified: the route maps and the button entry point are private on the dispatcher
+function controllerOf(instance: Seedcord): PrivateInteractionDispatcher {
+    return interactionsOf(instance.bot) as unknown as PrivateInteractionDispatcher;
+}
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type -- the type is the literal below
+function fakeButton(customId: string) {
+    return {
+        customId,
+        reply: vi.fn().mockResolvedValue({ resource: { message: { id: 'm-1' } } }),
+        deferReply: vi.fn().mockResolvedValue(undefined),
+        editReply: vi.fn().mockResolvedValue({ id: 'm-1' }),
+        followUp: vi.fn().mockResolvedValue(undefined),
+        isAutocomplete: () => false,
+        isChatInputCommand: () => false,
+        isContextMenuCommand: () => false,
+        isButton: () => true,
+        isAnySelectMenu: () => false,
+        isModalSubmit: () => false,
+        user: { id: 'u1' },
+        member: null,
+        guild: null,
+        guildId: 'g1',
+        channelId: 'c1',
+        memberPermissions: null,
+        appPermissions: { bitfield: 0n },
+        id: 'i1',
+        deferred: false,
+        replied: false
+    };
+}
+
+const Confirm = new CustomId('confirm');
+const Cancel = new CustomId('cancel');
+
+const HANDLER_SOURCE = `
+import { ButtonHandler, ButtonRoute, Cooldown, CustomId, Gated } from '${seedcordPath}';
+
+const Confirm = new CustomId('confirm');
+const Cancel = new CustomId('cancel');
+
+@ButtonRoute(Confirm, Cancel)
+@Gated(Cooldown('10s'))
+export class Vote extends ButtonHandler<[typeof Confirm, typeof Cancel]> {
+    public async execute() {
+        await this.reply('counted');
+    }
+}
+`;
+
+describe('a handler registered on two routes', () => {
+    let testEnv: TestEnvironment;
+    let seedcord: Seedcord;
+
+    async function bootWithVote(): Promise<{
+        controller: PrivateInteractionDispatcher;
+        published: SubscriptionData<'interactionDispatched'>[];
+    }> {
+        await testEnv.createFile('interactions/Vote.ts', HANDLER_SOURCE);
+        seedcord = new Seedcord(testConfig({ interactions: testEnv.resolvePath('interactions') }));
+        const controller = controllerOf(seedcord);
+        await controller.init();
+
+        const published: SubscriptionData<'interactionDispatched'>[] = [];
+        seedcord.bus.on('interactionDispatched', (payload) => published.push(payload));
+        return { controller, published };
+    }
+
+    beforeEach(async () => {
+        // @ts-expect-error the reset hook is private
+        Seedcord.reset();
+        testEnv = new TestEnvironment('multi-route-gates-');
+        await testEnv.setup();
+    });
+
+    afterEach(async () => {
+        await testEnv.teardown();
+        vi.restoreAllMocks();
+    });
+
+    it('registers the handler under each of its routes', async () => {
+        const { controller } = await bootWithVote();
+
+        expect(controller.maps[InteractionKind.Button].has(Confirm.prefix)).toBe(true);
+        expect(controller.maps[InteractionKind.Button].has(Cancel.prefix)).toBe(true);
+    });
+
+    it('cools down each route on its own', async () => {
+        const { controller, published } = await bootWithVote();
+
+        await controller.handleButton(fakeButton(Confirm.encode({})));
+        await controller.handleButton(fakeButton(Cancel.encode({})));
+
+        expect(published.map((entry) => entry.outcome)).toEqual(['handled', 'handled']);
+    });
+
+    it('still refuses a second click on the route that was already used', async () => {
+        const { controller, published } = await bootWithVote();
+
+        await controller.handleButton(fakeButton(Confirm.encode({})));
+        await controller.handleButton(fakeButton(Confirm.encode({})));
+
+        expect(published.map((entry) => entry.outcome)).toEqual(['handled', 'refused']);
+    });
+});

--- a/packages/gateway/tests/bot/gates/multi-route-gates.test.ts
+++ b/packages/gateway/tests/bot/gates/multi-route-gates.test.ts
@@ -23,7 +23,7 @@ function controllerOf(instance: Seedcord): PrivateInteractionDispatcher {
     return interactionsOf(instance.bot) as unknown as PrivateInteractionDispatcher;
 }
 
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type -- the type is the literal below
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type -- an explicit return type would repeat the literal below
 function fakeButton(customId: string) {
     return {
         customId,

--- a/packages/gateway/tests/bot/gates/multi-route-gates.test.ts
+++ b/packages/gateway/tests/bot/gates/multi-route-gates.test.ts
@@ -105,6 +105,15 @@ describe('a handler registered on two routes', () => {
         expect(controller.maps[InteractionKind.Button].has(Cancel.prefix)).toBe(true);
     });
 
+    it('reports the clicked route as the dispatch id', async () => {
+        const { controller, published } = await bootWithVote();
+
+        await controller.handleButton(fakeButton(Confirm.encode({})));
+        await controller.handleButton(fakeButton(Cancel.encode({})));
+
+        expect(published.map((entry) => entry.routeId)).toEqual(['button:confirm', 'button:cancel']);
+    });
+
     it('cools down each route on its own', async () => {
         const { controller, published } = await bootWithVote();
 

--- a/packages/gateway/tests/bot/getConfirmation.test.ts
+++ b/packages/gateway/tests/bot/getConfirmation.test.ts
@@ -1,4 +1,5 @@
 import { ContainerBuilder } from '@discordjs/builders';
+import { DispatchContext } from '@seedcord/core';
 import { PublishDefault } from '@seedcord/core/internal';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -78,7 +79,7 @@ describe('getConfirmation', () => {
         bus: Bus = stubBus()
     ): RepliableHandler<NonModalInteraction> {
         const interaction = source as NonModalInteraction;
-        const sender = new ReplySender(interaction, routeId, bus);
+        const sender = new ReplySender(interaction, new DispatchContext(routeId), bus);
         return {
             getEvent: () => interaction,
             sender

--- a/packages/gateway/tests/events/EventBoundary.test.ts
+++ b/packages/gateway/tests/events/EventBoundary.test.ts
@@ -179,10 +179,10 @@ describe('handleEventFault', () => {
         expect(publish).toHaveBeenCalledTimes(2);
     });
 
-    it('publishes the event route as routeId', () => {
+    it('names the event and the handler that threw as the origin', () => {
         handleEventFault(new Error('boom'), 'messageCreate', 'Starboard', [{}], mockCore(publish));
 
         const [, payload] = publish.mock.calls[0] as [string, SubscriptionData<'unknownException'>];
-        expect(payload.routeId).toBe('event:messageCreate:Starboard');
+        expect(payload.origin).toBe('event:messageCreate:Starboard');
     });
 });

--- a/packages/gateway/tests/events/event-dispatched.test.ts
+++ b/packages/gateway/tests/events/event-dispatched.test.ts
@@ -146,8 +146,7 @@ describe('eventDispatched', () => {
         seedcord.bus.on('eventDispatched', (payload) => ends.push(payload));
 
         const fire = onSpy.mock.calls.find(([event]) => event === 'messageCreate')?.[1] as
-            | ((...args: unknown[]) => void)
-            | undefined;
+            ((...args: unknown[]) => void) | undefined;
         expect(fire).toBeDefined();
 
         fire?.({ reply: vi.fn() });
@@ -158,6 +157,24 @@ describe('eventDispatched', () => {
 
         expect(ends).toHaveLength(1);
         expect(starts).toHaveLength(1);
+    });
+
+    it('stamps the same dispatchId on both keys for one fire', async () => {
+        await testEnv.createFile(`${EVENTS_DIR}/Ok.ts`, OK);
+
+        seedcord = new Seedcord(testConfig({ events: testEnv.resolvePath(EVENTS_DIR) }));
+        const events = dispatcherOf(seedcord);
+        await events.init();
+
+        const starts: SubscriptionData<'eventDispatching'>[] = [];
+        const ends: SubscriptionData<'eventDispatched'>[] = [];
+        seedcord.bus.on('eventDispatching', (payload) => starts.push(payload));
+        seedcord.bus.on('eventDispatched', (payload) => ends.push(payload));
+
+        await events.processEvent('messageCreate', [{ reply: vi.fn() }]);
+
+        expect(starts[0]?.dispatchId).toEqual(expect.any(String));
+        expect(ends[0]?.dispatchId).toBe(starts[0]?.dispatchId);
     });
 
     it('stays quiet for an event no handler registered', async () => {

--- a/packages/gateway/tests/events/event-dispatched.test.ts
+++ b/packages/gateway/tests/events/event-dispatched.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { eventsOf } from '#bot/Bot';
+import { Seedcord } from '#src/Seedcord';
+
+import { seedcordPath } from '../utils/source-path';
+import { testConfig } from '../utils/test-config';
+import { TestEnvironment } from '../utils/test-env';
+
+import type { SubscriptionData } from '@seedcord/core';
+
+import '../utils/mock-env';
+
+interface PrivateEventDispatcher {
+    init(): Promise<void>;
+    processEvent(eventName: string, args: unknown[]): Promise<void>;
+}
+
+// justified: processEvent is private on the dispatcher
+function dispatcherOf(instance: Seedcord): PrivateEventDispatcher {
+    return eventsOf(instance.bot) as unknown as PrivateEventDispatcher;
+}
+
+const EVENTS_DIR = 'events';
+const MIDDLEWARES_DIR = 'event-mw';
+
+const OK = `
+    import { EventHandler, RegisterEvent } from '${seedcordPath}';
+    import { Events } from 'discord.js';
+
+    @RegisterEvent(['messageCreate'])
+    export class Ok extends EventHandler<Events.MessageCreate> {
+        public async execute() {
+            await Promise.resolve();
+        }
+    }
+`;
+
+const BOOM = `
+    import { EventHandler, RegisterEvent } from '${seedcordPath}';
+    import { Events } from 'discord.js';
+
+    @RegisterEvent(['messageCreate'])
+    export class Boom extends EventHandler<Events.MessageCreate> {
+        public async execute() {
+            await Promise.resolve();
+            throw new Error('handler exploded');
+        }
+    }
+`;
+
+const STOPS = `
+    import { RegisterEventMiddleware, EventMiddleware, Silence } from '${seedcordPath}';
+
+    @RegisterEventMiddleware()
+    export class Stops extends EventMiddleware {
+        public async execute() {
+            await Promise.resolve();
+            throw new Silence('dropped');
+        }
+    }
+`;
+
+describe('eventDispatched', () => {
+    let testEnv: TestEnvironment;
+    let seedcord: Seedcord;
+
+    async function fireMessageCreate(middlewares?: string): Promise<SubscriptionData<'eventDispatched'>[]> {
+        seedcord = new Seedcord(
+            testConfig({
+                events: testEnv.resolvePath(EVENTS_DIR),
+                ...(middlewares && { eventMiddlewares: testEnv.resolvePath(middlewares) })
+            })
+        );
+        const events = dispatcherOf(seedcord);
+        await events.init();
+
+        const published: SubscriptionData<'eventDispatched'>[] = [];
+        seedcord.bus.on('eventDispatched', (payload) => published.push(payload));
+
+        await events.processEvent('messageCreate', [{ reply: vi.fn() }]);
+        return published;
+    }
+
+    beforeEach(async () => {
+        // @ts-expect-error the reset hook is private
+        Seedcord.reset();
+        testEnv = new TestEnvironment('event-dispatched-');
+        await testEnv.setup();
+    });
+
+    afterEach(async () => {
+        await testEnv.teardown();
+        vi.restoreAllMocks();
+    });
+
+    it('publishes once per fire, naming every handler that ran and how it ended', async () => {
+        await testEnv.createFile(`${EVENTS_DIR}/Ok.ts`, OK);
+        await testEnv.createFile(`${EVENTS_DIR}/Boom.ts`, BOOM);
+
+        const published = await fireMessageCreate();
+
+        expect(published).toHaveLength(1);
+        expect(published[0]?.name).toBe('messageCreate');
+        expect(published[0]?.outcome).toBe('handled');
+        expect(published[0]?.handlers.map((entry) => `${entry.handler}:${entry.outcome}`).toSorted()).toEqual([
+            'Boom:failed',
+            'Ok:handled'
+        ]);
+    });
+
+    it('reports a refusal from the middleware chain with no handlers', async () => {
+        await testEnv.createFile(`${EVENTS_DIR}/Ok.ts`, OK);
+        await testEnv.createFile(`${MIDDLEWARES_DIR}/Stops.ts`, STOPS);
+
+        const published = await fireMessageCreate(MIDDLEWARES_DIR);
+
+        expect(published).toHaveLength(1);
+        expect(published[0]?.outcome).toBe('refused');
+        expect(published[0]?.handlers).toEqual([]);
+    });
+
+    it('stays quiet for an event no handler registered', async () => {
+        await testEnv.createFile(`${EVENTS_DIR}/Ok.ts`, OK);
+
+        seedcord = new Seedcord(testConfig({ events: testEnv.resolvePath(EVENTS_DIR) }));
+        const events = dispatcherOf(seedcord);
+        await events.init();
+
+        const published: SubscriptionData<'eventDispatched'>[] = [];
+        seedcord.bus.on('eventDispatched', (payload) => published.push(payload));
+
+        await events.processEvent('guildCreate', [{}]);
+
+        expect(published).toEqual([]);
+    });
+});

--- a/packages/gateway/tests/events/event-dispatched.test.ts
+++ b/packages/gateway/tests/events/event-dispatched.test.ts
@@ -49,6 +49,18 @@ const BOOM = `
     }
 `;
 
+const ONCE = `
+    import { EventHandler, RegisterEvent } from '${seedcordPath}';
+    import { Events } from 'discord.js';
+
+    @RegisterEvent(['messageCreate', { frequency: 'once' }])
+    export class Spent extends EventHandler<Events.MessageCreate> {
+        public async execute() {
+            await Promise.resolve();
+        }
+    }
+`;
+
 const STOPS = `
     import { RegisterEventMiddleware, EventMiddleware, Silence } from '${seedcordPath}';
 
@@ -118,6 +130,34 @@ describe('eventDispatched', () => {
         expect(published).toHaveLength(1);
         expect(published[0]?.outcome).toBe('refused');
         expect(published[0]?.handlers).toEqual([]);
+    });
+
+    it('pairs with eventDispatching once a spent once-handler leaves nothing to run', async () => {
+        await testEnv.createFile(`${EVENTS_DIR}/Once.ts`, ONCE);
+
+        seedcord = new Seedcord(testConfig({ events: testEnv.resolvePath(EVENTS_DIR) }));
+        const events = dispatcherOf(seedcord);
+        const onSpy = vi.spyOn(seedcord.bot.client, 'on');
+        await events.init();
+
+        const starts: unknown[] = [];
+        const ends: unknown[] = [];
+        seedcord.bus.on('eventDispatching', (payload) => starts.push(payload));
+        seedcord.bus.on('eventDispatched', (payload) => ends.push(payload));
+
+        const fire = onSpy.mock.calls.find(([event]) => event === 'messageCreate')?.[1] as
+            | ((...args: unknown[]) => void)
+            | undefined;
+        expect(fire).toBeDefined();
+
+        fire?.({ reply: vi.fn() });
+        await vi.waitFor(() => expect(ends).toHaveLength(1));
+
+        fire?.({ reply: vi.fn() });
+        await vi.waitFor(() => expect(starts.length).toBeGreaterThan(0));
+
+        expect(ends).toHaveLength(1);
+        expect(starts).toHaveLength(1);
     });
 
     it('stays quiet for an event no handler registered', async () => {

--- a/packages/gateway/tests/interactions/InteractionBoundary.test.ts
+++ b/packages/gateway/tests/interactions/InteractionBoundary.test.ts
@@ -71,7 +71,7 @@ function handleInteractionFault(
 
 function senderFor(mock: ReturnType<typeof mockInteraction>, routeId: string): ReplySender {
     // justified: the fixture implements only the Repliables surface the sender reads.
-    return new ReplySender(mock as unknown as Repliables, routeId, stubBus());
+    return new ReplySender(mock as unknown as Repliables, new DispatchContext(routeId), stubBus());
 }
 
 describe('handleInteractionFault', () => {

--- a/packages/gateway/tests/interactions/InteractionDispatcher.test.ts
+++ b/packages/gateway/tests/interactions/InteractionDispatcher.test.ts
@@ -1637,6 +1637,68 @@ describe('InteractionDispatcher Integration', () => {
             });
         });
 
+        it('stamps one dispatchId on the dispatch and on the write it made', async () => {
+            await testEnv.createFile(
+                'interactions/Route.ts',
+                `
+                import { SlashHandler, SlashRoute } from '${seedcordPath}';
+
+                @SlashRoute('joined')
+                export class JoinedHandler extends SlashHandler<'joined'> {
+                    public async execute() {
+                        await this.reply('done');
+                    }
+                }
+                `
+            );
+            const config = testConfig({ interactions: testEnv.resolvePath('interactions') });
+
+            seedcord = new Seedcord(config);
+            const controller = controllerOf(seedcord);
+            await controller.init();
+
+            const dispatched: SubscriptionData<'interactionDispatched'>[] = [];
+            const sent: SubscriptionData<'responseAttempted'>[] = [];
+            seedcord.bus.on('interactionDispatched', (payload) => dispatched.push(payload));
+            seedcord.bus.on('responseAttempted', (payload) => sent.push(payload));
+
+            await controller.handleSlashCommand(fakeSlash('joined'));
+
+            const id = dispatched[0]?.dispatchId;
+            expect(id).toEqual(expect.any(String));
+            expect(sent[0]?.dispatchId).toBe(id);
+        });
+
+        it('gives two runs of the same route different dispatchIds', async () => {
+            await testEnv.createFile(
+                'interactions/Route.ts',
+                `
+                import { SlashHandler, SlashRoute } from '${seedcordPath}';
+
+                @SlashRoute('again')
+                export class AgainHandler extends SlashHandler<'again'> {
+                    public async execute() {
+                        await this.reply('done');
+                    }
+                }
+                `
+            );
+            const config = testConfig({ interactions: testEnv.resolvePath('interactions') });
+
+            seedcord = new Seedcord(config);
+            const controller = controllerOf(seedcord);
+            await controller.init();
+
+            const dispatched: SubscriptionData<'interactionDispatched'>[] = [];
+            seedcord.bus.on('interactionDispatched', (payload) => dispatched.push(payload));
+
+            await controller.handleSlashCommand(fakeSlash('again'));
+            await controller.handleSlashCommand(fakeSlash('again'));
+
+            expect(dispatched).toHaveLength(2);
+            expect(dispatched[0]?.dispatchId).not.toBe(dispatched[1]?.dispatchId);
+        });
+
         // the type-based rule is the same on both transports, so a constructor Silence matches http
         it('reports refused when the handler constructor throws a Silence', async () => {
             const published = await dispatchedFor(

--- a/packages/gateway/tests/miscellaneous/extractErrorResponse.test.ts
+++ b/packages/gateway/tests/miscellaneous/extractErrorResponse.test.ts
@@ -42,7 +42,7 @@ describe('extractErrorResponse', () => {
         const denial = new Fault({ cause: new Error('write failed') });
         const result = extractErrorResponse(denial, mockCore(publish), {
             interaction: slashInteraction(),
-            routeId: 'slash:ban',
+            origin: 'slash:ban',
             dispatch,
             guild: null,
             user: null
@@ -62,7 +62,7 @@ describe('extractErrorResponse', () => {
     it('publishes unknownException for a raw, non-denial throw', () => {
         const publish = vi.fn();
         const result = extractErrorResponse(new Error('a bug'), mockCore(publish), {
-            routeId: 'autocomplete:raw-probe',
+            origin: 'autocomplete:raw-probe',
             dispatch,
             guild: null,
             user: null
@@ -71,17 +71,17 @@ describe('extractErrorResponse', () => {
         expect(publish).toHaveBeenCalledWith('unknownException', expect.objectContaining({ uuid: result.uuid }));
     });
 
-    it('publishes the routeId it was given, so a subscriber can group faults by route', () => {
+    it('publishes the origin it was given, so a subscriber can group faults by route', () => {
         const publish = vi.fn();
         extractErrorResponse(new Error('a bug'), mockCore(publish), {
-            routeId: 'slash:route-probe',
+            origin: 'slash:route-probe',
             dispatch,
             guild: null,
             user: null
         });
 
         const [, payload] = publish.mock.calls[0] as [string, SubscriptionData<'unknownException'>];
-        expect(payload.routeId).toBe('slash:route-probe');
+        expect(payload.origin).toBe('slash:route-probe');
     });
 
     it('publishes both bugs when one route throws two different errors', () => {
@@ -89,7 +89,7 @@ describe('extractErrorResponse', () => {
         const core = mockCore(publish);
         const origin = {
             interaction: slashInteraction('profile'),
-            routeId: 'slash:profile',
+            origin: 'slash:profile',
             dispatch,
             guild: null,
             user: null
@@ -111,7 +111,7 @@ describe('extractErrorResponse', () => {
         const user = { id: 'u1', username: 'uname', client: {} } as unknown as User;
 
         extractErrorResponse(new Error('a bug'), mockCore(publish), {
-            routeId: 'slash:scalar-probe',
+            origin: 'slash:scalar-probe',
             dispatch,
             guild,
             user
@@ -126,7 +126,7 @@ describe('extractErrorResponse', () => {
         const publish = vi.fn();
         extractErrorResponse(new TestNotice(), mockCore(publish), {
             interaction: slashInteraction(),
-            routeId: 'slash:quiet-probe',
+            origin: 'slash:quiet-probe',
             dispatch,
             guild: null,
             user: null
@@ -140,7 +140,7 @@ describe('extractErrorResponse', () => {
         const denial = new Fault({ cause: new Error('write failed') });
         extractErrorResponse(denial, mockCore(publish), {
             event: { name: 'messageCreate', handler: 'Starboard', args: [{}], channelId: 'ch1' },
-            routeId: 'event:messageCreate:Starboard',
+            origin: 'event:messageCreate:Starboard',
             dispatch,
             guild: null,
             user: null

--- a/packages/gateway/tests/pagination/paginator.test.ts
+++ b/packages/gateway/tests/pagination/paginator.test.ts
@@ -134,7 +134,7 @@ function stubCore(): Core {
 function stubHandler(event: ReturnType<typeof startEvent>): RepliableHandler<Repliables> {
     const interaction = asRepliable(event);
     const core = stubCore();
-    const sender = new ReplySender(interaction, 'slash:page', core.bus);
+    const sender = new ReplySender(interaction, new DispatchContext('slash:page'), core.bus);
     // justified: start reads only these three members off the handler
     return { core, getEvent: () => interaction, sender } as unknown as RepliableHandler<Repliables>;
 }

--- a/packages/gateway/tests/utils/senderMock.ts
+++ b/packages/gateway/tests/utils/senderMock.ts
@@ -1,3 +1,4 @@
+import { DispatchContext } from '@seedcord/core';
 import { vi } from 'vitest';
 
 import { ReplySender } from '#bot/ReplySender';
@@ -54,5 +55,5 @@ export function mockInteraction(overrides: FlagOverrides = {}) {
 
 export function senderFor(mock: ReturnType<typeof mockInteraction>): ReplySender {
     // eslint-disable-next-line no-restricted-syntax -- fixture cast, the mock implements only the Repliables surface the sender reads
-    return new ReplySender(mock as unknown as Repliables, ROUTE, stubBus());
+    return new ReplySender(mock as unknown as Repliables, new DispatchContext(ROUTE), stubBus());
 }

--- a/packages/http/src/dispatch/dispatchInteraction.ts
+++ b/packages/http/src/dispatch/dispatchInteraction.ts
@@ -370,7 +370,7 @@ async function gateRefusal(step: BeforeHandler): Promise<{ caught: unknown } | n
     try {
         await runHandlerGates(
             Handler,
-            interactionGateContext(payload, core, dispatch, match.routeId),
+            interactionGateContext(payload, core, dispatch),
             match.routeId ?? undefined,
             monitor?.observe
         );

--- a/packages/http/src/dispatch/dispatchInteraction.ts
+++ b/packages/http/src/dispatch/dispatchInteraction.ts
@@ -102,8 +102,8 @@ async function sendGuarded(routeId: string, send: () => Promise<unknown>): Promi
 
 // a message reply is illegal on autocomplete, so empty choices are the only way to clear the pending state
 async function respondEmptyChoices(scope: FaultScope): Promise<void> {
-    const telemetry = { bus: scope.core.bus, interactionId: scope.payload.id };
-    await reportedWrite(telemetry, scope.routeId, 'respond', () =>
+    const telemetry = { bus: scope.core.bus, dispatch: scope.dispatch, interactionId: scope.payload.id };
+    await reportedWrite(telemetry, 'respond', () =>
         scope.core.rest.post(Routes.interactionCallback(scope.payload.id, scope.payload.token), {
             body: { type: InteractionResponseType.ApplicationCommandAutocompleteResult, data: { choices: [] } }
         })
@@ -119,7 +119,7 @@ function renderContext(scope: FaultScope, uuid: RenderContext['uuid']): RenderCo
 async function handleNotice(notice: Notice, uuid: RenderContext['uuid'], scope: FaultScope): Promise<void> {
     if (notice.report) {
         logger().error(`${notice.name}: ${paint.mute(uuid)}`, notice);
-        reportFault(notice, uuid, scope.routeId, scope.payload, scope.core);
+        reportFault(notice, uuid, scope.dispatch, scope.payload, scope.core);
     }
     const { sender } = scope;
     if (!sender) {
@@ -136,7 +136,7 @@ async function handleRawFault(error: Error, uuid: RenderContext['uuid'], scope: 
     if (core.config.errors?.errorStack ?? false) logger().error(paint.mute(uuid), error);
     else logger().error(`${paint.mute(uuid)} | ${error.message}`);
 
-    reportFault(error, uuid, scope.routeId, scope.payload, core);
+    reportFault(error, uuid, scope.dispatch, scope.payload, core);
 
     if (!sender) {
         await sendGuarded(scope.routeId, () => respondEmptyChoices(scope));
@@ -202,19 +202,21 @@ function freshScope(
         payload,
         routeId,
         dispatch,
-        sender: match.kind === InteractionKind.Autocomplete ? null : new ReplySender(ref, core.rest, routeId, core.bus)
+        sender: match.kind === InteractionKind.Autocomplete ? null : new ReplySender(ref, core.rest, dispatch, core.bus)
     };
 }
 
 function dispatchReporter(
     match: ResolvedRoute,
     payload: ValidInteractionTypes,
-    core: Core
+    core: Core,
+    dispatchId: string
 ): (outcome: DispatchOutcome) => void {
     const startedAt = performance.now();
     const queuedMs = queuedMsFor(payload.id);
     return (outcome) => {
         reportDispatch(core.bus, {
+            dispatchId,
             routeId: unhandledRouteId(match),
             interactionId: payload.id,
             kind: match.kind,
@@ -306,11 +308,10 @@ async function refusalBeforeHandler(step: BeforeHandler): Promise<{ caught: unkn
 // a null return means the refusal is already sent
 export async function dispatchInteraction(args: DispatchArgs): Promise<(() => Promise<void>) | null> {
     const { match, payload, core } = args;
-    const report = dispatchReporter(match, payload, core);
-
     const routeId = unhandledRouteId(match);
     // allocated before the load so every fault path below can render against the same bag
     const dispatch = new DispatchContext(routeId);
+    const report = dispatchReporter(match, payload, core, dispatch.id);
 
     const Handler = await loadHandlerCtor(match, payload, core, dispatch, report);
     if (!Handler) return null;

--- a/packages/http/src/dispatch/reportFault.ts
+++ b/packages/http/src/dispatch/reportFault.ts
@@ -6,7 +6,7 @@ import { slashRouteOf } from './slashRouteOf';
 
 import type { ValidInteractionTypes } from '#handlers/interactionTypes';
 import type { Core } from '#interfaces/Core';
-import type { FaultSource, SubscriptionData } from '@seedcord/core';
+import type { DispatchContext, FaultSource, SubscriptionData } from '@seedcord/core';
 import type { RenderContext } from '@seedcord/types';
 
 type InteractionFaultSource = Extract<FaultSource, { kind: 'interaction' }>;
@@ -15,14 +15,15 @@ type InteractionFaultSource = Extract<FaultSource, { kind: 'interaction' }>;
 export function reportFault(
     error: Error,
     uuid: RenderContext['uuid'],
-    origin: string,
+    dispatch: DispatchContext,
     payload: ValidInteractionTypes,
     core: Core
 ): void {
     const source = interactionSource(payload);
+    const from = { uuid, dispatchId: dispatch.id, origin: dispatch.routeId };
     if (error instanceof Notice && source)
-        core.bus[PublishDefault]('handledException', { denial: error, uuid, origin, source });
-    else core.bus[PublishDefault]('unknownException', { uuid, error, origin, ...actors(payload), metadata: payload });
+        core.bus[PublishDefault]('handledException', { denial: error, ...from, source });
+    else core.bus[PublishDefault]('unknownException', { ...from, error, ...actors(payload), metadata: payload });
 }
 
 // the raw payload has guild_id and no guild name

--- a/packages/http/src/dispatch/reportFault.ts
+++ b/packages/http/src/dispatch/reportFault.ts
@@ -15,14 +15,14 @@ type InteractionFaultSource = Extract<FaultSource, { kind: 'interaction' }>;
 export function reportFault(
     error: Error,
     uuid: RenderContext['uuid'],
-    routeId: string,
+    origin: string,
     payload: ValidInteractionTypes,
     core: Core
 ): void {
     const source = interactionSource(payload);
     if (error instanceof Notice && source)
-        core.bus[PublishDefault]('handledException', { denial: error, uuid, routeId, source });
-    else core.bus[PublishDefault]('unknownException', { uuid, error, routeId, ...actors(payload), metadata: payload });
+        core.bus[PublishDefault]('handledException', { denial: error, uuid, origin, source });
+    else core.bus[PublishDefault]('unknownException', { uuid, error, origin, ...actors(payload), metadata: payload });
 }
 
 // the raw payload has guild_id and no guild name

--- a/packages/http/src/dispatch/resolve.ts
+++ b/packages/http/src/dispatch/resolve.ts
@@ -16,8 +16,7 @@ import type { APIInteraction } from 'discord-api-types/v10';
 export interface ResolvedRoute {
     readonly kind: InteractionKind;
     /**
-     * The stable dispatch id, `kind:key` (`slash:ban`), the shape core's `routeIdOf` builds. Null for the
-     * unhandled default, which matches no row.
+     * The stable dispatch id, `kind:key` (`slash:ban`). Null for the unhandled default, which matches no row.
      */
     readonly routeId: string | null;
     readonly attemptedKey?: string;

--- a/packages/http/src/gates/context.ts
+++ b/packages/http/src/gates/context.ts
@@ -8,8 +8,7 @@ import type { APIUser } from 'discord-api-types/v10';
 export function interactionGateContext(
     payload: Repliables,
     core: Core,
-    dispatch: DispatchContext,
-    routeId: string | null
+    dispatch: DispatchContext
 ): InteractionGateContext {
     const member = payload.member ?? null;
     // discord sends member.user in a guild and the top-level user in a dm
@@ -29,6 +28,6 @@ export function interactionGateContext(
         memberPermissions: member ? BigInt(member.permissions) : null,
         // app_permissions is present on every interaction Discord delivers, including DMs
         appPermissions: BigInt(payload.app_permissions),
-        routeId
+        declaredRoute: null // runHandlerGates overwrites this with the matched route
     };
 }

--- a/packages/http/src/handlers/RepliableHandler.ts
+++ b/packages/http/src/handlers/RepliableHandler.ts
@@ -7,6 +7,7 @@ import type { Core } from '#interfaces/Core';
 import type { SentMessage } from '#reply/ReplySender';
 import type { Repliables } from './interactionTypes';
 import type { API } from '@discordjs/core/http-only';
+import type { DispatchContext } from '@seedcord/core';
 
 /**
  * Shared base the repliable HTTP interaction handlers extend.
@@ -30,9 +31,9 @@ export abstract class RepliableHandler<Event extends Repliables> extends CoreRep
         return this.event;
     }
 
-    protected buildSender(event: Event, core: Core, routeId: string): ReplySender {
+    protected buildSender(event: Event, core: Core, dispatch: DispatchContext): ReplySender {
         const ref = { application_id: event.application_id, id: event.id, token: event.token };
-        return new ReplySender(ref, core.rest, routeId, core.bus);
+        return new ReplySender(ref, core.rest, dispatch, core.bus);
     }
 
     /**

--- a/packages/http/src/handlers/interaction/AutocompleteHandler.ts
+++ b/packages/http/src/handlers/interaction/AutocompleteHandler.ts
@@ -102,8 +102,7 @@ export abstract class AutocompleteHandler<Route extends keyof SlashRegistry> ext
     /** Send autocomplete suggestions, callback type 8. Prefer {@link match}, which restricts each field's choices to its declared type. */
     protected async respond(choices: readonly APIApplicationCommandOptionChoice[]): Promise<void> {
         await reportedWrite(
-            { bus: this.core.bus, interactionId: this.event.id },
-            this.dispatch.routeId,
+            { bus: this.core.bus, dispatch: this.dispatch, interactionId: this.event.id },
             'respond',
             () =>
                 this.core.rest.post(Routes.interactionCallback(this.event.id, this.event.token), {

--- a/packages/http/src/reply/ReplySender.ts
+++ b/packages/http/src/reply/ReplySender.ts
@@ -3,7 +3,7 @@ import { deferFlags, sendFlags } from '@seedcord/core/internal';
 import { InteractionResponseType, MessageFlags, Routes } from 'discord-api-types/v10';
 
 import type { REST, RawFile } from '@discordjs/rest';
-import type { Bus } from '@seedcord/core';
+import type { Bus, DispatchContext } from '@seedcord/core';
 import type { SerializedReply } from '@seedcord/core/internal';
 import type { DeferOpts, ReplyResponse, SendOpts, TypedOmit } from '@seedcord/types';
 import type { APIMessage, APIModalInteractionResponseCallbackData } from 'discord-api-types/v10';
@@ -71,10 +71,10 @@ export class ReplySender extends BaseReplySender<SentMessage> {
     public constructor(
         private readonly ref: InteractionRef,
         private readonly rest: REST,
-        routeId: string,
+        dispatch: DispatchContext,
         bus: Bus
     ) {
-        super(routeId, { bus, interactionId: ref.id });
+        super({ bus, dispatch, interactionId: ref.id });
     }
 
     protected async writeReply(response: ReplyResponse | string, opts?: SendOpts): Promise<SentMessage | undefined> {

--- a/packages/http/tests/node/dispatch/fault-publish.test.ts
+++ b/packages/http/tests/node/dispatch/fault-publish.test.ts
@@ -134,10 +134,10 @@ describe('http fault publishing', () => {
         expect(unknown[0]?.error.message).toBe('handler exploded');
     });
 
-    it('publishes the dispatch routeId, so a subscriber can group faults by route', async () => {
+    it('names the dispatch route as the fault origin, so a subscriber can group faults', async () => {
         const { unknown } = await faultsFor(BoomHandler);
 
-        expect(unknown[0]?.routeId).toBe('slash:ok');
+        expect(unknown[0]?.origin).toBe('slash:ok');
     });
 
     it('publishes both bugs when one route throws two different errors', async () => {

--- a/packages/http/tests/node/dispatch/gates.test.ts
+++ b/packages/http/tests/node/dispatch/gates.test.ts
@@ -169,7 +169,7 @@ describe('handler gates', () => {
             channelId: 'c-1',
             memberRoleIds: ['r-1', 'r-2'],
             memberPermissions: 2048n,
-            routeId: 'slash:guarded'
+            declaredRoute: 'slash:guarded'
         });
     });
 

--- a/packages/http/tests/node/dispatch/multi-route-gates.test.ts
+++ b/packages/http/tests/node/dispatch/multi-route-gates.test.ts
@@ -1,0 +1,74 @@
+import 'reflect-metadata';
+
+import { Cooldown, InteractionKind } from '@seedcord/core';
+import { GatedMetadataKey, interactionMiddleware, MiddlewareRegistry } from '@seedcord/core/internal';
+import { Envapter, PortableSource } from 'envapt';
+import { describe, expect, it, vi } from 'vitest';
+
+import { SlashHandler } from '#handlers/interaction/SlashHandler';
+import { createCore, dispatchInteraction } from '#src/dispatch/dispatchInteraction';
+
+import { slashPayload } from './harness';
+import { nullPathConfig, VALID_TOKEN } from '../../helpers/fixtures';
+
+import type { InteractionMiddlewareConstructor } from '#handlers/constructors';
+import type { ValidInteractionTypes } from '#handlers/interactionTypes';
+import type { Core } from '#interfaces/Core';
+import type { SubscriptionData } from '@seedcord/core';
+
+vi.mock('@discordjs/rest', async (importOriginal) => {
+    class FakeRest {
+        public post = vi.fn().mockResolvedValue({ resource: { message: { id: 'm-1' } } });
+        public patch = vi.fn().mockResolvedValue({ id: 'm-1' });
+
+        public setToken(): this {
+            return this;
+        }
+    }
+    return { ...(await importOriginal<object>()), REST: FakeRest };
+});
+
+class Vote extends SlashHandler<never> {
+    public async execute(): Promise<void> {
+        await this.reply('counted');
+    }
+}
+Reflect.defineMetadata(GatedMetadataKey, [Cooldown('10s')], Vote);
+
+function freshCore(): { core: Core; published: SubscriptionData<'interactionDispatched'>[] } {
+    Envapter.useSource(new PortableSource({}));
+    const core = createCore(nullPathConfig, VALID_TOKEN);
+    const published: SubscriptionData<'interactionDispatched'>[] = [];
+    core.bus.on('interactionDispatched', (payload) => published.push(payload));
+    return { core, published };
+}
+
+async function dispatchRoute(core: Core, routeId: string): Promise<void> {
+    const execute = await dispatchInteraction({
+        match: { kind: InteractionKind.Slash, routeId, load: () => Promise.resolve(Vote) },
+        payload: slashPayload('vote') as ValidInteractionTypes,
+        core,
+        middlewares: new MiddlewareRegistry<InteractionMiddlewareConstructor>(interactionMiddleware)
+    });
+    await execute?.();
+}
+
+describe('one handler class reached through two routes', () => {
+    it('cools down each route on its own', async () => {
+        const { core, published } = freshCore();
+
+        await dispatchRoute(core, 'slash:confirm');
+        await dispatchRoute(core, 'slash:cancel');
+
+        expect(published.map((entry) => entry.outcome)).toEqual(['handled', 'handled']);
+    });
+
+    it('still refuses a second run of the route that was already used', async () => {
+        const { core, published } = freshCore();
+
+        await dispatchRoute(core, 'slash:confirm');
+        await dispatchRoute(core, 'slash:confirm');
+
+        expect(published.map((entry) => entry.outcome)).toEqual(['handled', 'refused']);
+    });
+});

--- a/packages/http/tests/node/dispatch/multi-route-gates.test.ts
+++ b/packages/http/tests/node/dispatch/multi-route-gates.test.ts
@@ -53,7 +53,7 @@ async function dispatchRoute(core: Core, routeId: string): Promise<void> {
     await execute?.();
 }
 
-describe('one handler class reached through two routes', () => {
+describe('a gate keyed on the route the router matched', () => {
     it('cools down each route on its own', async () => {
         const { core, published } = freshCore();
 

--- a/packages/http/tests/node/dispatch/register-subscribers.test.ts
+++ b/packages/http/tests/node/dispatch/register-subscribers.test.ts
@@ -26,6 +26,7 @@ function manifestWith(load: () => Promise<Record<string, unknown>>): RouteManife
 
 const payload = (): SubscriptionData<'unknownException'> => ({
     uuid: crypto.randomUUID(),
+    dispatchId: 'd-1',
     error: new Error('boom'),
     origin: 'slash:probe'
 });

--- a/packages/http/tests/node/dispatch/register-subscribers.test.ts
+++ b/packages/http/tests/node/dispatch/register-subscribers.test.ts
@@ -27,7 +27,7 @@ function manifestWith(load: () => Promise<Record<string, unknown>>): RouteManife
 const payload = (): SubscriptionData<'unknownException'> => ({
     uuid: crypto.randomUUID(),
     error: new Error('boom'),
-    routeId: 'slash:probe'
+    origin: 'slash:probe'
 });
 
 // the Bus logs the subscriber failure with the thrown error as the last argument

--- a/packages/http/tests/node/pagination/paginator.test.ts
+++ b/packages/http/tests/node/pagination/paginator.test.ts
@@ -55,7 +55,7 @@ function dmPayload(): Repliables {
 function stubHandler(post: ReturnType<typeof vi.fn>, interaction = guildPayload()): RepliableHandler<Repliables> {
     const core = { bus: stubBus() } as Core;
     // justified: the fixture implements only the REST surface ReplySender reads
-    const sender = new ReplySender(ref, { post } as unknown as REST, 'slash:page', core.bus);
+    const sender = new ReplySender(ref, { post } as unknown as REST, new DispatchContext('slash:page'), core.bus);
     // justified: start reads only these three members off the handler
     return {
         core,

--- a/packages/http/tests/node/reply/ReplySender.files.test.ts
+++ b/packages/http/tests/node/reply/ReplySender.files.test.ts
@@ -1,6 +1,7 @@
 import { Readable } from 'node:stream';
 
 import { TextDisplayBuilder } from '@discordjs/builders';
+import { DispatchContext } from '@seedcord/core';
 import { describe, expect, it, vi } from 'vitest';
 
 import { ReplySender } from '#reply/ReplySender';
@@ -29,7 +30,7 @@ function restMock(): RestMock {
 
 // justified: the fixture implements only the REST surface ReplySender reads
 function senderFor(rest: RestMock): ReplySender {
-    return new ReplySender(ref, rest as unknown as REST, 'slash:ban', stubBus());
+    return new ReplySender(ref, rest as unknown as REST, new DispatchContext('slash:ban'), stubBus());
 }
 
 function sentFiles(rest: RestMock): RawFile[] | undefined {

--- a/packages/http/tests/node/reply/ReplySender.test.ts
+++ b/packages/http/tests/node/reply/ReplySender.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable max-lines -- one suite per sender, splitting fragments the shared rest mock and body fixtures */
 import { TextDisplayBuilder } from '@discordjs/builders';
+import { DispatchContext } from '@seedcord/core';
 import { AckTrace } from '@seedcord/core/internal';
 import { isSeedcordError, SeedcordErrorCode } from '@seedcord/errors';
 import { MessageFlags } from 'discord-api-types/v10';
@@ -46,7 +47,7 @@ const ref: InteractionRef = { application_id: APP_ID, id: INTERACTION_ID, token:
 
 // justified: the fixture implements only the REST surface ReplySender reads.
 function senderFor(rest: RestMock): ReplySender {
-    return new ReplySender(ref, rest as unknown as REST, ROUTE, stubBus());
+    return new ReplySender(ref, rest as unknown as REST, new DispatchContext(ROUTE), stubBus());
 }
 
 const reply: ReplyResponse = { components: [new TextDisplayBuilder().setContent('hi')] };

--- a/packages/http/tests/receiver/subscribers.test.ts
+++ b/packages/http/tests/receiver/subscribers.test.ts
@@ -43,7 +43,7 @@ function rowFor(exportName: string, load: () => Promise<Record<string, unknown>>
 const payload = (): SubscriptionData<'unknownException'> => ({
     uuid: crypto.randomUUID(),
     error: new Error('boom'),
-    routeId: 'slash:probe'
+    origin: 'slash:probe'
 });
 
 describe('manifest subscribers on workerd', () => {

--- a/packages/http/tests/receiver/subscribers.test.ts
+++ b/packages/http/tests/receiver/subscribers.test.ts
@@ -42,6 +42,7 @@ function rowFor(exportName: string, load: () => Promise<Record<string, unknown>>
 
 const payload = (): SubscriptionData<'unknownException'> => ({
     uuid: crypto.randomUUID(),
+    dispatchId: 'd-1',
     error: new Error('boom'),
     origin: 'slash:probe'
 });

--- a/packages/types/src/Interfaces/Dispatch.ts
+++ b/packages/types/src/Interfaces/Dispatch.ts
@@ -9,6 +9,12 @@ export interface DispatchState {}
  * it. Declared here so {@link RenderContext} can carry one without importing the concrete class.
  */
 export interface DispatchBag {
+    /**
+     * Unique to this one dispatch, and unique again the next time the same route runs. Every bus key
+     * this dispatch publishes carries it as `dispatchId`, so a store keyed on it lines up the dispatch,
+     * its writes, and any fault it raised.
+     */
+    readonly id: string;
     /** The dispatched handler as `kind:route`, for example `slash:daily` or `button:confirm`. */
     readonly routeId: string;
     /** Write a key for the rest of this dispatch to read. */

--- a/packages/types/src/Interfaces/Errors.ts
+++ b/packages/types/src/Interfaces/Errors.ts
@@ -1,5 +1,5 @@
+import type { UUID } from '../uuid';
 import type { RenderContext, ReplyResponse } from './ReplyResponse';
-import type { UUID } from 'node:crypto';
 
 /**
  * Structural shape of a renderable denial. A framework `Notice` subclass satisfies it. Used to type

--- a/packages/types/src/Interfaces/ReplyResponse.ts
+++ b/packages/types/src/Interfaces/ReplyResponse.ts
@@ -1,6 +1,6 @@
+import type { UUID } from '../uuid';
 import type { DispatchBag } from './Dispatch';
 import type { APIMessageTopLevelComponent } from 'discord-api-types/v10';
-import type { UUID } from 'node:crypto';
 
 /** A ComponentsV2 top-level component, as discord.js accepts it in a message's `components` field. */
 export interface V2Component {

--- a/packages/types/src/internal.index.ts
+++ b/packages/types/src/internal.index.ts
@@ -1,4 +1,5 @@
 export * from './brand';
+export type * from './uuid';
 export type * from './Hmr';
 export type * from './Interfaces/SeedcordInstance';
 export type * from './Interfaces/Store';

--- a/packages/types/src/uuid.ts
+++ b/packages/types/src/uuid.ts
@@ -1,0 +1,2 @@
+// copied from node:crypto so a consumer of this package does not need @types/node for it
+export type UUID = `${string}-${string}-${string}-${string}-${string}`;


### PR DESCRIPTION
## Checklist

- [x] Tests cover the change
- [x] `pnpm prePush` is green
- [x] Changeset added with `pnpm cs`, for any change to a published package


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added unique dispatch IDs across interaction, response, event, and fault telemetry.
  * Added `eventDispatched`, reporting handler outcomes and dispatch duration after event processing.
  * Multi-route handlers now track cooldowns independently per matched route.

* **Bug Fixes**
  * Fixed unmatched event lifecycle reports after one-time handlers run.

* **Breaking Changes**
  * Renamed fault `routeId` to `origin` and gate context `routeId` to `declaredRoute`.

* **Documentation**
  * Updated telemetry, event, gate, and fault-reporting guidance for the new fields and event.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->